### PR TITLE
ci: bump actions to Node 24 majors (deprecation), runtime Node 20→22 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,13 @@ jobs:
         # heredoc-based steps below run identically across all three OSes.
         shell: bash
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
       - name: Install optional Node dependencies
         run: npm install --package-lock=false --no-audit
       - name: Smoke check Cursor runner syntax


### PR DESCRIPTION
## Summary
- GitHub is **forcing JavaScript actions to Node 24 by June 16, 2026** and already emits a deprecation warning on every CI job. Bump the three pinned actions to their current Node 24 majors:
  - `actions/checkout` v4 → **v6** (v6.0.3)
  - `actions/setup-python` v5 → **v6** (v6.2.0)
  - `actions/setup-node` v4 → **v6** (v6.4.0)
- Also move the **project runtime** `node-version` from the now-EOL **Node 20** to the active **22 LTS** (used only by the `npm install` + cursor-runner syntax smoke checks).

## Why
- Silences the per-job deprecation warning before the June 16 hard cutover, so CI doesn't break when Node 20 actions stop running.
- Node 20 reached end-of-life (April 2026); the smoke checks should run on a supported LTS.

## Scope / risk
- **CI-only.** No package, dependency, or API change — nothing to recut on PyPI.
- All majors verified to exist (`gh api .../releases/latest`) so no broken tag pin.
- The matrix (ubuntu/macos/windows × 3.9/3.12) is unchanged; this PR's own CI run is the verification that the new action majors + Node 22 stay green on all legs.

## Test plan
- [ ] CI green on all matrix jobs (ubuntu-latest, macos-latest, windows-latest)
- [ ] No "Node.js 20 actions are deprecated" annotation in the run