### PR TITLE
fix: emit truthful patch artifacts from dirty worktrees

### DIFF
--- a/puppetmaster/adapters.py
+++ b/puppetmaster/adapters.py
@@ -7,6 +7,7 @@ import shutil
 import socket
 import subprocess
 import sys
+import tempfile
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -291,20 +292,26 @@ def build_patch_payload(
     - **Untracked visibility**: untracked files are surfaced alongside changed
       files so a run that only creates new files is still attributable.
     """
-    raw_diff = str(after.get("diff") or "")
+    raw_diff = str(
+        after.get("worker_diff")
+        if after.get("worker_diff") is not None
+        else after.get("diff") or ""
+    )
     redacted = redact_secrets(raw_diff) or ""
     total = len(redacted)
     truncated = total > _PATCH_INLINE_CHARS
     inline = redacted[-_PATCH_INLINE_CHARS:] if truncated else redacted
     payload: dict[str, Any] = {
         "change": change,
-        "files": after.get("changed_files", []),
-        "untracked_files": after.get("untracked_files", []),
+        "files": after.get("worker_changed_files", after.get("changed_files", [])),
+        "untracked_files": after.get("worker_untracked_files", after.get("untracked_files", [])),
         "unified_diff": inline,
         "diff_total_chars": total,
         "diff_truncated": truncated,
         "base_sha": before.get("sha"),
         "head_sha": after.get("sha"),
+        "base_tree": before.get("tree"),
+        "head_tree": after.get("tree"),
         "status": status,
         "revert": (
             "Review the diff, then use git restore / git checkout or your VCS "
@@ -618,7 +625,7 @@ class CursorAdapter:
             timeout_seconds=timeout_seconds,
         )
         if completed.timed_out:
-            after = git_snapshot(cwd)
+            after = git_snapshot(cwd, base_tree=str(before.get("tree") or "") or None)
             artifacts: list[Artifact] = [
                 verification_artifact(
                     task=task,
@@ -644,13 +651,13 @@ class CursorAdapter:
             ]
             # A timed-out implement run may still have edited files; surface the
             # partial diff so the work isn't silently lost.
-            if after["diff"].strip():
+            if _should_emit_patch_artifact(before, after):
                 artifacts.append(
                     self._patch_artifact(task, worker_id, before, after, status="failed")
                 )
             return artifacts
 
-        after = git_snapshot(cwd)
+        after = git_snapshot(cwd, base_tree=str(before.get("tree") or "") or None)
         failure = classify_cursor_failure(completed.stderr + completed.stdout)
         usage = token_usage(
             sdk_usage=sdk_usage_from_stdout(completed.stdout),
@@ -693,7 +700,7 @@ class CursorAdapter:
                 },
             )
         ]
-        if after["diff"].strip():
+        if _should_emit_patch_artifact(before, after):
             artifacts.append(
                 self._patch_artifact(
                     task,
@@ -994,7 +1001,7 @@ class ClaudeCodeAdapter:
         if completed.timed_out:
             stdout = completed.stdout
             stderr = completed.stderr
-            after = git_snapshot(cwd)
+            after = git_snapshot(cwd, base_tree=str(before.get("tree") or "") or None)
             stdout_capture = capture_subprocess_stdout(
                 text=stdout,
                 task=task,
@@ -1032,7 +1039,7 @@ class ClaudeCodeAdapter:
             ]
             # A timed-out run may have already edited files; surface the partial
             # diff so the work isn't silently stranded in the tree.
-            if str(after.get("diff") or "").strip():
+            if _should_emit_patch_artifact(before, after):
                 artifacts.append(
                     Artifact(
                         job_id=task.job_id,
@@ -1053,7 +1060,7 @@ class ClaudeCodeAdapter:
                 )
             return artifacts
 
-        after = git_snapshot(cwd)
+        after = git_snapshot(cwd, base_tree=str(before.get("tree") or "") or None)
         # Claude Code stdout often carries long edit transcripts. Give the
         # head/tail more room than Cursor (12k tail vs 8k) but still spool the
         # full transcript so middle bytes survive.
@@ -1105,7 +1112,7 @@ class ClaudeCodeAdapter:
             },
         )
         artifacts = [verification]
-        if str(after.get("diff") or "").strip():
+        if _should_emit_patch_artifact(before, after):
             artifacts.append(
                 Artifact(
                     job_id=task.job_id,
@@ -1125,6 +1132,17 @@ class ClaudeCodeAdapter:
                 )
             )
         return artifacts
+
+
+def _should_emit_patch_artifact(before: dict, after: dict) -> bool:
+    """True when a PATCH can be attributed to the worker run."""
+    worker_diff = after.get("worker_diff")
+    if worker_diff is not None:
+        return bool(str(worker_diff).strip())
+    before_diff = str(before.get("diff") or "")
+    if before_diff.strip() or before.get("changed_files") or before.get("untracked_files"):
+        return False
+    return bool(str(after.get("diff") or "").strip())
 
 
 DEFAULT_CODEX_MODEL = "gpt-5.4-mini"
@@ -1261,7 +1279,7 @@ class CodexAdapter:
         if completed.timed_out:
             stdout = completed.stdout
             stderr = completed.stderr
-            after = git_snapshot(cwd)
+            after = git_snapshot(cwd, base_tree=str(before.get("tree") or "") or None)
             stdout_capture = capture_subprocess_stdout(
                 text=stdout,
                 task=task,
@@ -1301,7 +1319,7 @@ class CodexAdapter:
                     },
                 )
             ]
-            if str(after.get("diff") or "").strip():
+            if _should_emit_patch_artifact(before, after):
                 artifacts.append(
                     Artifact(
                         job_id=task.job_id,
@@ -1322,7 +1340,7 @@ class CodexAdapter:
                 )
             return artifacts
 
-        after = git_snapshot(cwd)
+        after = git_snapshot(cwd, base_tree=str(before.get("tree") or "") or None)
 
         events = parse_codex_events(completed.stdout)
         usage = next(
@@ -1460,7 +1478,7 @@ class CodexAdapter:
                 )
             )
         artifacts.extend(parsed_artifacts)
-        if str(after.get("diff") or "").strip():
+        if _should_emit_patch_artifact(before, after):
             artifacts.append(
                 Artifact(
                     job_id=task.job_id,
@@ -1766,43 +1784,122 @@ def tool_list(value: object) -> str:
     return str(value)
 
 
-def git_snapshot(cwd: Path) -> dict[str, object]:
+def git_snapshot(cwd: Path, *, base_tree: Optional[str] = None) -> dict[str, object]:
     """Capture a diff-attributable snapshot of the working tree.
 
     Captures changes **against HEAD** (not just working-tree-vs-index) so that
-    *staged* edits are seen by dirty-tree gating and included in PATCH diffs,
-    and synthesizes no-index patches for *untracked* files so a run that only
-    creates new files still produces an applyable diff. Also reports whether
-    ``cwd`` is inside a git work tree so full-edit adapters can refuse to run
-    outside a repo (where diffs are unattributable)."""
+    *staged* edits are seen by dirty-tree gating and included in dirty-state
+    checks, and synthesizes no-index patches for *untracked* files. When
+    ``base_tree`` is provided, also records a PM-attributable diff from that
+    pre-worker tree to the current worktree. Also reports whether ``cwd`` is
+    inside a git work tree so full-edit adapters can refuse to run outside a
+    repo (where diffs are unattributable)."""
     inside = git_output(cwd, ["rev-parse", "--is-inside-work-tree"]) == "true"
-    sha = git_output(cwd, ["rev-parse", "HEAD"])
-    untracked = git_untracked_files(cwd)
+    root = git_worktree_root(cwd) if inside else cwd
+    sha = git_output(root, ["rev-parse", "HEAD"])
+    untracked = git_untracked_files(root)
     if sha:
         # HEAD exists: `git diff HEAD` covers both staged and unstaged tracked
         # changes; plain `git diff` would silently drop staged edits.
-        changed = git_lines(cwd, ["diff", "HEAD", "--name-only"])
-        diff = git_diff_output(cwd, ["diff", "HEAD", "--binary"])
+        changed = git_lines(root, ["diff", "HEAD", "--name-only"])
+        diff = git_diff_output(root, ["diff", "HEAD", "--binary"])
     else:
         # No commit yet (or detached/empty): union the staged and unstaged
         # diffs so nothing tracked is missed.
         changed = sorted(
-            set(git_lines(cwd, ["diff", "--name-only"]))
-            | set(git_lines(cwd, ["diff", "--cached", "--name-only"]))
+            set(git_lines(root, ["diff", "--name-only"]))
+            | set(git_lines(root, ["diff", "--cached", "--name-only"]))
         )
-        diff = git_diff_output(cwd, ["diff", "--binary"]) + git_diff_output(
-            cwd, ["diff", "--cached", "--binary"]
+        diff = git_diff_output(root, ["diff", "--binary"]) + git_diff_output(
+            root, ["diff", "--cached", "--binary"]
         )
-    untracked_diff = git_untracked_diff(cwd, untracked)
+    untracked_diff = git_untracked_diff(root, untracked)
     if untracked_diff:
         diff = (diff.rstrip("\n") + "\n" + untracked_diff) if diff.strip() else untracked_diff
-    return {
+    tree = git_worktree_tree(root) if inside else ""
+    worker_diff = ""
+    worker_changed: list[str] = []
+    if base_tree and tree:
+        worker_changed = git_lines(root, ["diff", "--name-only", base_tree, tree, "--"])
+        worker_diff = git_diff_output(root, ["diff", "--binary", base_tree, tree, "--"])
+    snapshot = {
         "sha": sha or "uncommitted",
         "is_worktree": inside,
         "changed_files": changed,
         "untracked_files": untracked,
         "diff": diff,
     }
+    if tree:
+        snapshot["tree"] = tree
+    if base_tree:
+        worker_changed_set = set(worker_changed)
+        snapshot["worker_changed_files"] = worker_changed
+        snapshot["worker_untracked_files"] = [path for path in untracked if path in worker_changed_set]
+        snapshot["worker_diff"] = worker_diff
+    return snapshot
+
+
+def git_worktree_root(cwd: Path) -> Path:
+    root = git_output(cwd, ["rev-parse", "--show-toplevel"])
+    return Path(root) if root else cwd
+
+
+def git_worktree_tree(cwd: Path) -> str:
+    """Write the current worktree state to a temporary Git tree.
+
+    Uses a throwaway index so staged/user index state is never modified. The tree
+    includes tracked changes and untracked, non-ignored files, matching the files
+    Puppetmaster can later report in a PATCH artifact.
+    """
+    sha = git_output(cwd, ["rev-parse", "HEAD"])
+    fd, index_path = tempfile.mkstemp(prefix="puppetmaster-index-")
+    os.close(fd)
+    env = {**os.environ, "GIT_INDEX_FILE": index_path}
+    try:
+        if sha:
+            read = subprocess.run(
+                ["git", "read-tree", sha],
+                cwd=cwd,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        else:
+            read = subprocess.run(
+                ["git", "read-tree", "--empty"],
+                cwd=cwd,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        if read.returncode != 0:
+            return ""
+        add = subprocess.run(
+            ["git", "add", "-A", "--", "."],
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if add.returncode != 0:
+            return ""
+        written = subprocess.run(
+            ["git", "write-tree"],
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return written.stdout.strip() if written.returncode == 0 else ""
+    finally:
+        try:
+            os.unlink(index_path)
+        except OSError:
+            pass
 
 
 def git_output(cwd: Path, args: list[str]) -> str:
@@ -2581,4 +2678,3 @@ def classify_claude_code_failure(output: str) -> str:
     if "timeout" in lowered or "timed out" in lowered:
         return "timeout"
     return "unknown"
-

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -1416,14 +1416,107 @@ class PuppetmasterTests(unittest.TestCase):
             timed_out=False,
             live_log_path=None,
         )
-        dirty = {"sha": "s", "changed_files": ["pre.py"], "untracked_files": [], "diff": ""}
-        with patch("puppetmaster.adapters.git_snapshot", side_effect=[dirty, dirty]), patch(
+        before_dirty = {
+            "sha": "s",
+            "changed_files": ["pre.py"],
+            "untracked_files": [],
+            "diff": "diff --git a/pre.py b/pre.py\n+already dirty\n",
+        }
+        after_dirty = {
+            "sha": "s",
+            "changed_files": ["pre.py", "helper.py"],
+            "untracked_files": [],
+            "worker_changed_files": ["helper.py"],
+            "worker_untracked_files": [],
+            "worker_diff": "diff --git a/helper.py b/helper.py\n+def helper():\n+    return 1\n",
+            "diff": (
+                "diff --git a/pre.py b/pre.py\n+already dirty\n"
+                "diff --git a/helper.py b/helper.py\n+def helper():\n+    return 1\n"
+            ),
+        }
+        with patch("puppetmaster.adapters.git_snapshot", side_effect=[before_dirty, after_dirty]), patch(
             "puppetmaster.adapters.run_streamed_subprocess", return_value=completed
         ) as run:
             artifacts = CursorAdapter().run(task, "goal", "worker-cursor")
 
         run.assert_called_once()  # dirty guard bypassed
         self.assertEqual(artifacts[0].payload["result"], "passed")
+        patch_artifact = next(a for a in artifacts if a.type == ArtifactType.PATCH)
+        self.assertEqual(patch_artifact.payload["files"], ["helper.py"])
+        self.assertIn("helper.py", patch_artifact.payload["unified_diff"])
+        self.assertNotIn("pre.py", patch_artifact.payload["unified_diff"])
+
+    def test_dirty_baseline_without_worker_diff_emits_no_patch(self) -> None:
+        from puppetmaster.adapters import _should_emit_patch_artifact
+
+        before_dirty = {
+            "sha": "s",
+            "changed_files": ["pre.py"],
+            "untracked_files": [],
+            "diff": "diff --git a/pre.py b/pre.py\n+already dirty\n",
+        }
+        after_unattributed = {
+            "sha": "s",
+            "changed_files": ["pre.py", "helper.py"],
+            "untracked_files": [],
+            "worker_diff": "",
+            "diff": (
+                "diff --git a/pre.py b/pre.py\n+already dirty\n"
+                "diff --git a/helper.py b/helper.py\n+def helper():\n+    return 1\n"
+            ),
+        }
+
+        self.assertFalse(_should_emit_patch_artifact(before_dirty, after_unattributed))
+
+    def test_cursor_implement_dirty_tree_snapshot_failure_emits_no_patch(self) -> None:
+        from puppetmaster import adapters
+
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+            (repo / "pre.py").write_text("clean\n", encoding="utf-8")
+            subprocess.run(["git", "add", "pre.py"], cwd=repo, check=True, capture_output=True)
+            subprocess.run(
+                ["git", "-c", "user.name=T", "-c", "user.email=t@e.com", "commit", "-m", "seed"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+            )
+            (repo / "pre.py").write_text("user dirty\n", encoding="utf-8")
+            before_tree = adapters.git_worktree_tree(repo)
+            task = Task(
+                job_id="job",
+                role="cursor",
+                instruction="add a helper",
+                adapter="cursor",
+                payload={
+                    "prompt": "Add a helper",
+                    "cwd": str(repo),
+                    "mode": "implement",
+                    "allow_dirty": True,
+                    "disable_codegraph": True,
+                },
+            )
+            completed = StreamedProcess(
+                returncode=0,
+                stdout=json.dumps({"status": "finished", "result": "ok"}),
+                stderr="",
+                timed_out=False,
+                live_log_path=None,
+            )
+
+            def fake_run(*args: object, **kwargs: object) -> StreamedProcess:
+                (repo / "helper.py").write_text("pm change\n", encoding="utf-8")
+                return completed
+
+            with patch(
+                "puppetmaster.adapters.git_worktree_tree",
+                side_effect=[before_tree, ""],
+            ), patch("puppetmaster.adapters.run_streamed_subprocess", side_effect=fake_run):
+                artifacts = CursorAdapter().run(task, "goal", "worker-cursor")
+
+            self.assertEqual(artifacts[0].payload["result"], "passed")
+            self.assertNotIn(ArtifactType.PATCH, [artifact.type for artifact in artifacts])
 
     def test_codegraph_helper_returns_none_when_cli_missing(self) -> None:
         with TemporaryDirectory() as tmp:
@@ -4114,6 +4207,140 @@ print(json.dumps({"result": "ok", "usage": {"input_tokens": 321, "output_tokens"
             self.assertIn("two", snap["diff"])
             self.assertIn("new_file.txt", snap["diff"])
             self.assertIn("+hello", snap["diff"])
+
+    def test_git_snapshot_worker_diff_excludes_preexisting_dirty_files(self) -> None:
+        from puppetmaster.adapters import git_snapshot
+
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+            (repo / "pre.py").write_text("clean\n", encoding="utf-8")
+            subprocess.run(["git", "add", "pre.py"], cwd=repo, check=True, capture_output=True)
+            subprocess.run(
+                ["git", "-c", "user.name=T", "-c", "user.email=t@e.com", "commit", "-m", "seed"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+            )
+
+            (repo / "pre.py").write_text("user dirty\n", encoding="utf-8")
+            before = git_snapshot(repo)
+            (repo / "helper.py").write_text("pm change\n", encoding="utf-8")
+
+            after = git_snapshot(repo, base_tree=before["tree"])
+
+            self.assertIn("pre.py", after["diff"])
+            self.assertIn("helper.py", after["worker_changed_files"])
+            self.assertIn("helper.py", after["worker_untracked_files"])
+            self.assertIn("helper.py", after["worker_diff"])
+            self.assertNotIn("pre.py", after["worker_diff"])
+
+    def test_git_snapshot_worker_diff_fails_closed_without_after_tree(self) -> None:
+        from puppetmaster.adapters import _should_emit_patch_artifact, git_snapshot
+
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+            (repo / "pre.py").write_text("clean\n", encoding="utf-8")
+            subprocess.run(["git", "add", "pre.py"], cwd=repo, check=True, capture_output=True)
+            subprocess.run(
+                ["git", "-c", "user.name=T", "-c", "user.email=t@e.com", "commit", "-m", "seed"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+            )
+
+            (repo / "pre.py").write_text("user dirty\n", encoding="utf-8")
+            before = git_snapshot(repo)
+            (repo / "helper.py").write_text("pm change\n", encoding="utf-8")
+
+            with patch("puppetmaster.adapters.git_worktree_tree", return_value=""):
+                after = git_snapshot(repo, base_tree=before["tree"])
+
+            self.assertEqual(after["worker_changed_files"], [])
+            self.assertEqual(after["worker_diff"], "")
+            self.assertFalse(_should_emit_patch_artifact(before, after))
+
+    def test_git_snapshot_worker_tree_preserves_real_index(self) -> None:
+        from puppetmaster.adapters import git_snapshot
+
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+            target = repo / "tracked.py"
+            target.write_text("base\n", encoding="utf-8")
+            subprocess.run(["git", "add", "tracked.py"], cwd=repo, check=True, capture_output=True)
+            subprocess.run(
+                ["git", "-c", "user.name=T", "-c", "user.email=t@e.com", "commit", "-m", "seed"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+            )
+
+            target.write_text("staged\n", encoding="utf-8")
+            subprocess.run(["git", "add", "tracked.py"], cwd=repo, check=True, capture_output=True)
+            target.write_text("worktree\n", encoding="utf-8")
+            (repo / "new.py").write_text("untracked\n", encoding="utf-8")
+
+            cached_before = subprocess.run(
+                ["git", "diff", "--cached", "--binary"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            worktree_before = subprocess.run(
+                ["git", "diff", "--binary"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+
+            git_snapshot(repo)
+
+            cached_after = subprocess.run(
+                ["git", "diff", "--cached", "--binary"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            worktree_after = subprocess.run(
+                ["git", "diff", "--binary"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            self.assertEqual(cached_after, cached_before)
+            self.assertEqual(worktree_after, worktree_before)
+
+    def test_git_snapshot_worker_diff_covers_whole_repo_from_subdir(self) -> None:
+        from puppetmaster.adapters import git_snapshot
+
+        with TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+            (repo / "pkg").mkdir()
+            (repo / "pkg" / "seed.py").write_text("seed\n", encoding="utf-8")
+            subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+            subprocess.run(
+                ["git", "-c", "user.name=T", "-c", "user.email=t@e.com", "commit", "-m", "seed"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+            )
+
+            subdir = repo / "pkg"
+            before = git_snapshot(subdir)
+            (repo / "outside.py").write_text("pm change\n", encoding="utf-8")
+
+            after = git_snapshot(subdir, base_tree=before["tree"])
+
+            self.assertIn("outside.py", after["worker_changed_files"])
+            self.assertIn("outside.py", after["worker_untracked_files"])
+            self.assertIn("outside.py", after["worker_diff"])
 
     def test_git_snapshot_flags_non_worktree(self) -> None:
         from puppetmaster.adapters import git_snapshot
@@ -11845,4 +12072,3 @@ class UninstallTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Summary
- capture pre/post worker Git trees with a temporary index
- emit PATCH artifacts from the worker-attributed diff instead of the whole dirty tree
- fail closed when worker attribution is unavailable
- preserve existing dirty-tree blocking behavior unless `allow_dirty` is set

## Tests
- `git diff --check`
- `python -m py_compile puppetmaster/adapters.py tests/test_puppetmaster.py`
- `python -m pytest tests/test_puppetmaster.py -q -k 'patch or git_snapshot or dirty_baseline or allow_dirty or dirty_tree_snapshot_failure'`
- `PUPPETMASTER_ONLY_ADAPTERS=cursor,claude-code,codex,openai python -m pytest tests/test_puppetmaster.py -q`
  - known existing failure: `ReviewEscalationTests.test_reroute_escalates_rejected_diff`
- `PUPPETMASTER_ONLY_ADAPTERS=cursor,claude-code,codex,openai python -m pytest tests/test_puppetmaster.py::ReviewEscalationTests -q`