### PR TITLE
fix: honor disable-memory for single adapter runs

### DIFF
--- a/puppetmaster/cli.py
+++ b/puppetmaster/cli.py
@@ -791,6 +791,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Allow Claude Code to run in a dirty working tree.",
     )
+    claude.add_argument(
+        "--disable-memory",
+        action="store_true",
+        help="Skip promoted shared-memory injection for a fresh perspective.",
+    )
     _add_routing_flags(claude)
 
     openai = subcommands.add_parser(
@@ -851,6 +856,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Skip CodeGraph context injection (e.g. for non-repo prompts).",
     )
+    openai.add_argument(
+        "--disable-memory",
+        action="store_true",
+        help="Skip promoted shared-memory injection for a fresh perspective.",
+    )
     _add_routing_flags(openai)
 
     codex = subcommands.add_parser(
@@ -897,6 +907,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--disable-codegraph",
         action="store_true",
         help="Skip CodeGraph context injection (e.g. for non-repo prompts).",
+    )
+    codex.add_argument(
+        "--disable-memory",
+        action="store_true",
+        help="Skip promoted shared-memory injection for a fresh perspective.",
     )
     _add_routing_flags(codex)
 
@@ -1587,6 +1602,8 @@ def _main(argv: Optional[list[str]] = None) -> int:
             "timeout_seconds": args.timeout_seconds,
             "allow_dirty": args.allow_dirty,
         }
+        if args.disable_memory:
+            payload["disable_memory"] = True
         payload.update(routing_payload_from_args(args, adapter="claude-code"))
         result = Orchestrator(store).run(
             args.prompt,
@@ -1625,6 +1642,8 @@ def _main(argv: Optional[list[str]] = None) -> int:
             payload["reasoning_effort"] = args.reasoning_effort
         if args.disable_codegraph:
             payload["disable_codegraph"] = True
+        if args.disable_memory:
+            payload["disable_memory"] = True
         payload.update(routing_payload_from_args(args, adapter="openai"))
         result = Orchestrator(store).run(
             args.prompt,
@@ -1657,6 +1676,8 @@ def _main(argv: Optional[list[str]] = None) -> int:
             payload["executable"] = args.executable
         if args.disable_codegraph:
             payload["disable_codegraph"] = True
+        if args.disable_memory:
+            payload["disable_memory"] = True
         payload.update(routing_payload_from_args(args, adapter="codex"))
         result = Orchestrator(store).run(
             args.prompt,

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -1632,6 +1632,8 @@ def codex_command(args: JsonObject) -> list[str]:
         command.append("--dangerously-bypass-approvals-and-sandbox")
     if args.get("disable_codegraph"):
         command.append("--disable-codegraph")
+    if args.get("disable_memory"):
+        command.append("--disable-memory")
     return command
 
 
@@ -1704,6 +1706,8 @@ def claude_command(args: JsonObject) -> list[str]:
         command.extend(["--timeout-seconds", str(args["timeout_seconds"])])
     if args.get("allow_dirty"):
         command.append("--allow-dirty")
+    if args.get("disable_memory"):
+        command.append("--disable-memory")
     return command
 
 
@@ -1736,6 +1740,8 @@ def openai_command(args: JsonObject) -> list[str]:
         command.extend(["--reasoning-effort", str(args["reasoning_effort"])])
     if args.get("disable_codegraph"):
         command.append("--disable-codegraph")
+    if args.get("disable_memory"):
+        command.append("--disable-memory")
     return command
 
 

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -5935,6 +5935,7 @@ class ModelRouterTests(unittest.TestCase):
                     "timeout_seconds": 120,
                     "allow_dirty": True,
                     "executable": "/opt/codex",
+                    "disable_memory": True,
                 }
             )
 
@@ -5952,6 +5953,47 @@ class ModelRouterTests(unittest.TestCase):
         self.assertIn("--allow-dirty", command)
         self.assertIn("--executable", command)
         self.assertIn("/opt/codex", command)
+        self.assertIn("--disable-memory", command)
+
+    def test_single_adapter_mcp_commands_forward_disable_memory(self) -> None:
+        from puppetmaster import mcp_server
+
+        claude = mcp_server.claude_command({"goal": "fresh claude", "cwd": ".", "disable_memory": True})
+        openai = mcp_server.openai_command({"goal": "fresh openai", "cwd": ".", "disable_memory": True})
+        codex = mcp_server.codex_command({"goal": "fresh codex", "cwd": ".", "disable_memory": True})
+
+        self.assertIn("--disable-memory", claude)
+        self.assertIn("--disable-memory", openai)
+        self.assertIn("--disable-memory", codex)
+
+    def test_single_adapter_mcp_commands_do_not_disable_memory_by_default(self) -> None:
+        from puppetmaster import mcp_server
+
+        claude = mcp_server.claude_command({"goal": "default claude", "cwd": "."})
+        openai = mcp_server.openai_command({"goal": "default openai", "cwd": "."})
+        codex = mcp_server.codex_command({"goal": "default codex", "cwd": "."})
+
+        self.assertNotIn("--disable-memory", claude)
+        self.assertNotIn("--disable-memory", openai)
+        self.assertNotIn("--disable-memory", codex)
+
+    def test_single_adapter_mcp_run_functions_forward_disable_memory(self) -> None:
+        from puppetmaster import mcp_server
+
+        captured = []
+
+        def fake_run_cli(command, args):
+            captured.append(command)
+            return {"ok": True}
+
+        with patch.object(mcp_server, "run_cli", side_effect=fake_run_cli):
+            mcp_server.run_claude({"goal": "fresh claude", "cwd": ".", "disable_memory": True})
+            mcp_server.run_openai({"goal": "fresh openai", "cwd": ".", "disable_memory": True})
+            mcp_server.run_codex({"goal": "fresh codex", "cwd": ".", "disable_memory": True})
+
+        self.assertEqual([command[0] for command in captured], ["claude", "openai", "codex"])
+        for command in captured:
+            self.assertIn("--disable-memory", command)
 
     def test_start_codex_builds_codex_cli_command(self) -> None:
         from puppetmaster import mcp_server
@@ -9962,6 +10004,39 @@ class PuppetmasterFrictionFixTests(unittest.TestCase):
         self.assertEqual(payload["routing_policy"], "cheap")
         self.assertEqual(payload["max_cost_usd"], 0.5)
         self.assertEqual(payload["min_capability"], 70)
+
+    def test_direct_single_adapter_cli_sets_disable_memory_payload(self) -> None:
+        captured = []
+
+        def fake_run(self, goal, **kwargs):  # noqa: ANN001
+            captured.append((goal, kwargs["specs"]))
+            return object()
+
+        with TemporaryDirectory() as tmp, patch(
+            "puppetmaster.cli.Orchestrator.run", autospec=True, side_effect=fake_run
+        ), patch("puppetmaster.cli.finalize_cli_run", return_value=0):
+            state_dir = str(Path(tmp) / "state")
+            cases = [
+                ("claude-code", ["claude", "fresh claude", "--cwd", tmp, "--disable-memory"]),
+                (
+                    "openai",
+                    ["openai", "fresh openai", "--cwd", tmp, "--disable-codegraph", "--disable-memory"],
+                ),
+                (
+                    "codex",
+                    ["codex", "fresh codex", "--cwd", tmp, "--disable-codegraph", "--disable-memory"],
+                ),
+            ]
+            for adapter, command in cases:
+                with self.subTest(adapter=adapter):
+                    rc = cli_main(["--state-dir", state_dir, *command])
+                    self.assertEqual(rc, 0)
+
+        self.assertEqual([specs[0].adapter for _, specs in captured], ["claude-code", "openai", "codex"])
+        self.assertEqual(
+            [specs[0].payload.get("disable_memory") for _, specs in captured],
+            [True, True, True],
+        )
 
     # --- #10: wait exit codes ------------------------------------------
     def test_wait_returns_nonzero_for_stalled(self) -> None:


### PR DESCRIPTION
## Summary
- add `--disable-memory` to direct `claude`, `openai`, and `codex` CLI commands
- forward `disable_memory` through MCP single-adapter command builders
- preserve existing swarm memory defaults and explicit `--enable-memory` behavior

## Why
Single-adapter runs already honor `disable_memory` once it reaches the `WorkerSpec` payload, but the direct CLI/MCP entrypoints did not consistently expose or forward that flag. This makes fresh-context runs available outside swarm mode.

## Tests
- `python -m py_compile puppetmaster/cli.py puppetmaster/mcp_server.py tests/test_puppetmaster.py`
- `python -m pytest tests/test_puppetmaster.py -q -k 'disable_memory or direct_single_adapter or single_adapter_mcp or run_codex_builds_codex_cli_command or routing_payload_from_args'`
- `PUPPETMASTER_ONLY_ADAPTERS=cursor,claude-code,codex,openai python -m pytest tests/test_puppetmaster.py -q`
  - known existing failure: `ReviewEscalationTests.test_reroute_escalates_rejected_diff`
- `PUPPETMASTER_ONLY_ADAPTERS=cursor,claude-code,codex,openai python -m pytest tests/test_puppetmaster.py::ReviewEscalationTests -q`