### PR TITLE
fix: show parent process in MCP registry

### DIFF
--- a/puppetmaster/cli.py
+++ b/puppetmaster/cli.py
@@ -4284,7 +4284,8 @@ def _run_mcp_list(args) -> int:
         f"{snapshot['dead']} dead)"
     )
     print(
-        f"  {'PID':>7}  {'STATE':<6}  {'AGE':>8}  {'HBEAT':>8}  WORKSPACE"
+        f"  {'PID':>7}  {'STATE':<6}  {'AGE':>8}  {'HBEAT':>8}  "
+        f"{'PPID':>7}  {'PARENT':<12}  WORKSPACE"
     )
     for row in snapshot["servers"]:
         if not row["alive"]:
@@ -4294,10 +4295,14 @@ def _run_mcp_list(args) -> int:
         else:
             state = "ok"
         workspace = row.get("workspace") or "-"
+        parent_pid = row.get("parent_pid") or "-"
+        parent_process = row.get("parent_process") or "-"
         print(
             f"  {row['pid']:>7}  {state:<6}  "
             f"{row['age_seconds']:>8.0f}s  "
             f"{row['heartbeat_age_seconds']:>8.0f}s  "
+            f"{parent_pid:>7}  "
+            f"{parent_process:<12}  "
             f"{workspace}"
         )
     return 0
@@ -4494,4 +4499,3 @@ def cursor_prompt(
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/puppetmaster/mcp_registry.py
+++ b/puppetmaster/mcp_registry.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import subprocess
 import sys
 import threading
 import time
@@ -66,6 +67,8 @@ class McpServerEntry:
     last_heartbeat: float
     transport: str = "stdio"
     version: Optional[str] = None
+    parent_pid: Optional[int] = None
+    parent_process: Optional[str] = None
     path: Optional[str] = None  # absolute path to the tracking file
 
     def is_alive(self) -> bool:
@@ -84,6 +87,8 @@ class McpServerEntry:
             "last_heartbeat": self.last_heartbeat,
             "age_seconds": round(current - self.started_at, 3),
             "heartbeat_age_seconds": round(current - self.last_heartbeat, 3),
+            "parent_pid": self.parent_pid,
+            "parent_process": self.parent_process,
             "transport": self.transport,
             "version": self.version,
             "alive": self.is_alive(),
@@ -125,6 +130,8 @@ def register(
     workspace: Optional[str] = None,
     version: Optional[str] = None,
     transport: str = "stdio",
+    parent_pid: Optional[int] = None,
+    parent_process: Optional[str] = None,
 ) -> Path:
     """Write this server's tracking file and return its path.
 
@@ -132,6 +139,12 @@ def register(
     re-registration after a heartbeat thread restart) we overwrite it.
     """
     actual_pid = pid if pid is not None else os.getpid()
+    actual_parent_pid = parent_pid if parent_pid is not None else _parent_pid()
+    actual_parent_process = (
+        parent_process
+        if parent_process is not None
+        else _process_name(actual_parent_pid)
+    )
     now = time.time()
     payload = {
         "pid": actual_pid,
@@ -140,6 +153,8 @@ def register(
         "last_heartbeat": now,
         "transport": transport,
         "version": version,
+        "parent_pid": actual_parent_pid,
+        "parent_process": actual_parent_process,
     }
     path = registry_dir() / f"{actual_pid}.json"
     _atomic_write(path, payload)
@@ -207,6 +222,8 @@ def list_entries(*, include_stale: bool = True) -> list[McpServerEntry]:
                 last_heartbeat=float(data.get("last_heartbeat") or now),
                 transport=str(data.get("transport") or "stdio"),
                 version=data.get("version"),
+                parent_pid=_coerce_optional_int(data.get("parent_pid")),
+                parent_process=_coerce_optional_str(data.get("parent_process")),
                 path=str(child),
             )
         except (KeyError, TypeError, ValueError):
@@ -304,6 +321,7 @@ class HeartbeatThread(threading.Thread):
         self._path = registration_path
         self._interval = max(0.5, float(interval_seconds))
         self._stop_event = threading.Event()
+        self._registration_payload = self._registration_payload_from_path(registration_path)
 
     def stop(self) -> None:
         self._stop_event.set()
@@ -314,9 +332,27 @@ class HeartbeatThread(threading.Thread):
                 # File got cleaned up under us — write a fresh one so we
                 # remain visible. This is unusual but cheap to handle.
                 try:
-                    register(pid=os.getpid(), workspace=_workspace_hint())
+                    self._reregister()
                 except OSError:
                     return
+
+    def _reregister(self) -> None:
+        self._path = register(
+            pid=os.getpid(),
+            workspace=self._registration_payload.get("workspace") or _workspace_hint(),
+            version=_coerce_optional_str(self._registration_payload.get("version")),
+            transport=str(self._registration_payload.get("transport") or "stdio"),
+            parent_pid=_coerce_optional_int(self._registration_payload.get("parent_pid")),
+            parent_process=_coerce_optional_str(self._registration_payload.get("parent_process")),
+        )
+
+    @staticmethod
+    def _registration_payload_from_path(path: Path) -> dict:
+        try:
+            data = _read_entry(path)
+        except (OSError, ValueError):
+            return {}
+        return data or {}
 
 
 def _workspace_hint() -> Optional[str]:
@@ -325,6 +361,56 @@ def _workspace_hint() -> Optional[str]:
         return str(Path.cwd())
     except OSError:
         return None
+
+
+def _parent_pid() -> Optional[int]:
+    """Best-effort parent PID for the current process."""
+    try:
+        value = os.getppid()
+    except (AttributeError, OSError):
+        return None
+    return value if value > 0 else None
+
+
+def _process_name(pid: Optional[int]) -> Optional[str]:
+    """Best-effort short process label for ``pid``.
+
+    Used only for diagnostics, so failures intentionally collapse to ``None``.
+    """
+    if pid is None or pid <= 0 or os.name == "nt":
+        return None
+    try:
+        completed = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "comm="],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=1.0,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    raw = completed.stdout.strip()
+    if not raw:
+        return None
+    return Path(raw).name or raw
+
+
+def _coerce_optional_int(value: object) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_optional_str(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
 
 
 def _pid_alive(pid: int) -> bool:

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -2546,6 +2546,8 @@ class PuppetmasterTests(unittest.TestCase):
                     pid=os.getpid(),
                     workspace="/tmp/test-workspace",
                     version="0.5.2-test",
+                    parent_pid=12345,
+                    parent_process="datagrip",
                 )
                 self.assertTrue(path.exists())
 
@@ -2553,8 +2555,14 @@ class PuppetmasterTests(unittest.TestCase):
                 self.assertEqual(len(entries), 1)
                 self.assertEqual(entries[0].pid, os.getpid())
                 self.assertEqual(entries[0].workspace, "/tmp/test-workspace")
+                self.assertEqual(entries[0].parent_pid, 12345)
+                self.assertEqual(entries[0].parent_process, "datagrip")
                 self.assertTrue(entries[0].is_alive())
                 self.assertFalse(entries[0].is_stale())
+
+                payload = mcp_registry.summarize(entries)["servers"][0]
+                self.assertEqual(payload["parent_pid"], 12345)
+                self.assertEqual(payload["parent_process"], "datagrip")
 
                 before = entries[0].last_heartbeat
                 time.sleep(0.01)
@@ -2565,6 +2573,86 @@ class PuppetmasterTests(unittest.TestCase):
                 mcp_registry.deregister(path)
                 self.assertFalse(path.exists())
                 self.assertEqual(mcp_registry.list_entries(), [])
+            finally:
+                del os.environ["PUPPETMASTER_MCP_REGISTRY_DIR"]
+
+    def test_mcp_registry_detects_parent_process_identity(self) -> None:
+        from puppetmaster import mcp_registry
+
+        completed = subprocess.CompletedProcess(
+            ["ps", "-p", "4242", "-o", "comm="],
+            0,
+            "/Applications/DataGrip.app/Contents/MacOS/datagrip\n",
+            "",
+        )
+        with TemporaryDirectory() as tmp:
+            os.environ["PUPPETMASTER_MCP_REGISTRY_DIR"] = tmp
+            try:
+                with patch.object(mcp_registry.os, "getppid", return_value=4242), patch.object(
+                    mcp_registry.subprocess, "run", return_value=completed
+                ) as run:
+                    mcp_registry.register(pid=os.getpid(), workspace="/auto-parent")
+
+                entry = mcp_registry.list_entries()[0]
+                self.assertEqual(entry.parent_pid, 4242)
+                self.assertEqual(entry.parent_process, "datagrip")
+                run.assert_called_once()
+            finally:
+                del os.environ["PUPPETMASTER_MCP_REGISTRY_DIR"]
+
+    def test_mcp_registry_keeps_old_entries_without_parent_identity(self) -> None:
+        from puppetmaster import mcp_registry
+
+        with TemporaryDirectory() as tmp:
+            os.environ["PUPPETMASTER_MCP_REGISTRY_DIR"] = tmp
+            try:
+                path = Path(tmp) / f"{os.getpid()}.json"
+                path.write_text(
+                    json.dumps(
+                        {
+                            "pid": os.getpid(),
+                            "workspace": "/old",
+                            "started_at": time.time(),
+                            "last_heartbeat": time.time(),
+                            "transport": "stdio",
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+
+                entry = mcp_registry.list_entries()[0]
+                self.assertIsNone(entry.parent_pid)
+                self.assertIsNone(entry.parent_process)
+                payload = mcp_registry.summarize([entry])["servers"][0]
+                self.assertIsNone(payload["parent_pid"])
+                self.assertIsNone(payload["parent_process"])
+            finally:
+                del os.environ["PUPPETMASTER_MCP_REGISTRY_DIR"]
+
+    def test_mcp_registry_heartbeat_reregister_preserves_parent_identity(self) -> None:
+        from puppetmaster import mcp_registry
+
+        with TemporaryDirectory() as tmp:
+            os.environ["PUPPETMASTER_MCP_REGISTRY_DIR"] = tmp
+            try:
+                path = mcp_registry.register(
+                    pid=os.getpid(),
+                    workspace="/self-heal",
+                    version="test-version",
+                    parent_pid=12345,
+                    parent_process="datagrip",
+                )
+                thread = mcp_registry.HeartbeatThread(path, interval_seconds=0.5)
+                path.unlink()
+
+                with patch.object(mcp_registry.os, "getppid", return_value=99999):
+                    thread._reregister()
+
+                entry = mcp_registry.list_entries()[0]
+                self.assertEqual(entry.workspace, "/self-heal")
+                self.assertEqual(entry.version, "test-version")
+                self.assertEqual(entry.parent_pid, 12345)
+                self.assertEqual(entry.parent_process, "datagrip")
             finally:
                 del os.environ["PUPPETMASTER_MCP_REGISTRY_DIR"]
 
@@ -2731,7 +2819,12 @@ class PuppetmasterTests(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             os.environ["PUPPETMASTER_MCP_REGISTRY_DIR"] = tmp
             try:
-                mcp_registry.register(pid=os.getpid(), workspace="/listed")
+                mcp_registry.register(
+                    pid=os.getpid(),
+                    workspace="/listed",
+                    parent_pid=12345,
+                    parent_process="datagrip",
+                )
                 buf = io.StringIO()
                 with patch("sys.stdout", buf):
                     rc = cli_module.main(["mcp", "list", "--json"])
@@ -2741,6 +2834,36 @@ class PuppetmasterTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         snapshot = json.loads(buf.getvalue())
         self.assertGreaterEqual(snapshot["count"], 1)
+        server = next(row for row in snapshot["servers"] if row["pid"] == os.getpid())
+        self.assertEqual(server["parent_pid"], 12345)
+        self.assertEqual(server["parent_process"], "datagrip")
+
+    def test_cli_mcp_list_outputs_parent_process_columns(self) -> None:
+        import io
+        from puppetmaster import cli as cli_module
+        from puppetmaster import mcp_registry
+
+        with TemporaryDirectory() as tmp:
+            os.environ["PUPPETMASTER_MCP_REGISTRY_DIR"] = tmp
+            try:
+                mcp_registry.register(
+                    pid=os.getpid(),
+                    workspace="/listed",
+                    parent_pid=12345,
+                    parent_process="datagrip",
+                )
+                buf = io.StringIO()
+                with patch("sys.stdout", buf):
+                    rc = cli_module.main(["mcp", "list"])
+            finally:
+                del os.environ["PUPPETMASTER_MCP_REGISTRY_DIR"]
+
+        self.assertEqual(rc, 0)
+        output = buf.getvalue()
+        self.assertIn("PPID", output)
+        self.assertIn("PARENT", output)
+        self.assertIn("12345", output)
+        self.assertIn("datagrip", output)
 
     def test_tool_call_keepalive_skips_fast_handlers(self) -> None:
         """Handlers that finish before the start_after grace period emit no notifications.
@@ -11845,4 +11968,3 @@ class UninstallTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Summary
- record parent PID and parent process name in MCP registry entries
- show parent process identity in `puppetmaster mcp list`
- preserve compatibility with existing registry JSON that lacks parent metadata

## Why
`puppetmaster mcp list` currently shows whether tracked MCP servers are alive, stale, or dead, but not which parent app/session launched them. Adding parent process identity makes stale-server diagnosis clearer without changing cleanup behavior.

## Tests
- `python -m py_compile puppetmaster/mcp_registry.py puppetmaster/cli.py tests/test_puppetmaster.py`
- `python -m pytest tests/test_puppetmaster.py -q -k 'mcp_registry or mcp_list or mcp_cleanup or mcp_status'`
- `PUPPETMASTER_ONLY_ADAPTERS=cursor,claude-code,codex,openai python -m pytest tests/test_puppetmaster.py::ReviewEscalationTests -q`
- `PUPPETMASTER_ONLY_ADAPTERS=cursor,claude-code,codex,openai python -m pytest tests/test_puppetmaster.py -q`
  - known existing failure: `ReviewEscalationTests.test_reroute_escalates_rejected_diff`