### PR TITLE
fix: classify explicit no-edit worker payloads as analysis

### DIFF
--- a/puppetmaster/adapters.py
+++ b/puppetmaster/adapters.py
@@ -1214,12 +1214,13 @@ class CodexAdapter:
         # and worktree-boundary checks are unnecessary. For write-capable
         # sandboxes we mirror Claude Code: require a git work tree and a clean
         # tree by default so resulting diffs are attributable to this task.
-        if sandbox != "read-only":
+        write_capable = sandbox != "read-only" or bypass
+        if write_capable:
             blocked = worktree_guard(task, worker_id, "codex", cwd, before)
             if blocked is not None:
                 return blocked
         if (
-            sandbox != "read-only"
+            write_capable
             and not task.payload.get("allow_dirty", False)
             and (before["changed_files"] or before["untracked_files"])
         ):

--- a/puppetmaster/cli.py
+++ b/puppetmaster/cli.py
@@ -1657,6 +1657,11 @@ def _main(argv: Optional[list[str]] = None) -> int:
             payload["executable"] = args.executable
         if args.disable_codegraph:
             payload["disable_codegraph"] = True
+        if (
+            args.sandbox == "read-only"
+            and not args.dangerously_bypass_approvals_and_sandbox
+        ):
+            payload["read_only"] = True
         payload.update(routing_payload_from_args(args, adapter="codex"))
         result = Orchestrator(store).run(
             args.prompt,

--- a/puppetmaster/workers.py
+++ b/puppetmaster/workers.py
@@ -184,9 +184,21 @@ class LocalWorker:
 _EDIT_CAPABLE_ADAPTERS = frozenset({"claude-code", "codex"})
 
 
+def spec_explicitly_no_edit(spec: WorkerSpec) -> bool:
+    """True when a worker payload declares an adapter-independent no-edit run."""
+    payload = spec.payload or {}
+    return bool(
+        payload.get("read_only")
+        or payload.get("no_edit")
+        or payload.get("dry_run")
+    )
+
+
 def spec_edits_files(spec: WorkerSpec) -> bool:
     """True when ``spec`` can leave file changes behind (vs. emit-only)."""
     payload = spec.payload or {}
+    if spec_explicitly_no_edit(spec):
+        return False
     if payload.get("mode") == "implement" or payload.get("implement"):
         return True
     return spec.adapter in _EDIT_CAPABLE_ADAPTERS

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -4328,6 +4328,48 @@ print(json.dumps({"result": "ok", "usage": {"input_tokens": 321, "output_tokens"
         self.assertEqual(verification.payload["failure"], "timeout")
         self.assertEqual(verification.payload["live_log"], "/tmp/codex_exec_live.log")
 
+    def test_codex_adapter_bypassed_read_only_uses_worktree_guard(self) -> None:
+        from puppetmaster.adapters import verification_artifact
+
+        task = Task(
+            id="t-codex-bypass",
+            job_id="job-codex-bypass",
+            role="codex-review",
+            adapter="codex",
+            instruction="Review the repo.",
+            payload={
+                "cwd": str(Path.cwd()),
+                "sandbox": "read-only",
+                "dangerously_bypass_approvals_and_sandbox": True,
+                "disable_codegraph": True,
+            },
+        )
+        clean = {"sha": "s", "changed_files": [], "untracked_files": [], "diff": ""}
+        blocked = [
+            verification_artifact(
+                task=task,
+                worker_id="worker",
+                adapter="codex",
+                check="guard",
+                result="blocked",
+                confidence=0.9,
+                evidence=["guarded"],
+                payload={"failure": "guarded"},
+            )
+        ]
+        with patch("puppetmaster.adapters.resolve_command", return_value="/usr/bin/codex"), patch(
+            "puppetmaster.adapters.git_snapshot", return_value=clean
+        ), patch(
+            "puppetmaster.adapters.worktree_guard", return_value=blocked
+        ) as guard, patch(
+            "puppetmaster.adapters.run_streamed_subprocess"
+        ) as streamed:
+            artifacts = CodexAdapter().run(task, "goal", "worker")
+
+        guard.assert_called_once()
+        streamed.assert_not_called()
+        self.assertIs(artifacts, blocked)
+
     def test_run_streamed_subprocess_closes_stdin_so_readers_see_eof(self) -> None:
         """The streamed runner must close the child's stdin (DEVNULL). A CLI
         that reads stdin would otherwise block forever on a non-interactive
@@ -9947,6 +9989,56 @@ class PuppetmasterFrictionFixTests(unittest.TestCase):
         self.assertTrue(
             spec_edits_files(WorkerSpec(role="c", instruction="x", adapter="claude-code"))
         )
+        self.assertFalse(
+            spec_edits_files(
+                WorkerSpec(
+                    role="audit",
+                    instruction="x",
+                    adapter="claude-code",
+                    payload={"read_only": True},
+                )
+            )
+        )
+        self.assertFalse(
+            spec_edits_files(
+                WorkerSpec(
+                    role="audit",
+                    instruction="x",
+                    adapter="codex",
+                    payload={"no_edit": True},
+                )
+            )
+        )
+        self.assertFalse(
+            spec_edits_files(
+                WorkerSpec(
+                    role="dry-run",
+                    instruction="x",
+                    adapter="codex",
+                    payload={"dry_run": True},
+                )
+            )
+        )
+        self.assertFalse(
+            spec_edits_files(
+                WorkerSpec(
+                    role="dry-run-implement",
+                    instruction="x",
+                    adapter="codex",
+                    payload={"mode": "implement", "dry_run": True},
+                )
+            )
+        )
+        self.assertTrue(
+            spec_edits_files(
+                WorkerSpec(
+                    role="impl",
+                    instruction="x",
+                    adapter="cursor",
+                    payload={"mode": "implement", "review": True},
+                )
+            )
+        )
 
     # --- #2 / #4: stalled-job reaper -----------------------------------
     def test_reaper_marks_dead_orchestrator_job_stalled(self) -> None:
@@ -10083,6 +10175,43 @@ class PuppetmasterFrictionFixTests(unittest.TestCase):
         self.assertEqual(payload["routing_policy"], "cheap")
         self.assertEqual(payload["max_cost_usd"], 0.5)
         self.assertEqual(payload["min_capability"], 70)
+
+    def test_direct_codex_read_only_sandbox_sets_generic_no_edit_payload(self) -> None:
+        captured = []
+
+        def fake_run(self, goal, **kwargs):  # noqa: ANN001
+            captured.append((goal, kwargs["specs"]))
+            return object()
+
+        with TemporaryDirectory() as tmp, patch(
+            "puppetmaster.cli.Orchestrator.run", autospec=True, side_effect=fake_run
+        ), patch("puppetmaster.cli.finalize_cli_run", return_value=0):
+            cases = [
+                ("read-only", False, True),
+                ("workspace-write", False, False),
+                ("read-only", True, False),
+            ]
+            for sandbox, bypass, expected_read_only in cases:
+                with self.subTest(sandbox=sandbox, bypass=bypass):
+                    command = [
+                        "--state-dir",
+                        str(Path(tmp) / "state"),
+                        "codex",
+                        f"{sandbox} review",
+                        "--cwd",
+                        tmp,
+                        "--disable-codegraph",
+                        "--sandbox",
+                        sandbox,
+                    ]
+                    if bypass:
+                        command.append("--dangerously-bypass-approvals-and-sandbox")
+                    rc = cli_main(command)
+                    self.assertEqual(rc, 0)
+
+        for (_, specs), (_, _, expected_read_only) in zip(captured, cases):
+            payload = specs[0].payload
+            self.assertEqual(payload.get("read_only", False), expected_read_only)
 
     # --- #10: wait exit codes ------------------------------------------
     def test_wait_returns_nonzero_for_stalled(self) -> None:


### PR DESCRIPTION
## Summary
- classify explicit no-edit worker payloads as analysis
- mark direct Codex `--sandbox read-only` runs as no-edit when sandboxing is not bypassed
- keep dangerous Codex bypass runs write-capable and route them through the worktree guard

## Why
Codex and Claude Code are generally edit-capable, but some runs explicitly declare that they cannot or should not edit files. Puppetmaster should classify those as analysis runs instead of edit runs, while still treating dangerous sandbox bypass as write-capable.

## Tests
- `python -m py_compile puppetmaster/adapters.py puppetmaster/cli.py puppetmaster/workers.py tests/test_puppetmaster.py`
- `python -m pytest tests/test_puppetmaster.py -q -k 'swarm_mode or direct_codex_read_only or codex_adapter_bypassed_read_only or run_codex_builds_codex_cli_command or start_codex_builds_codex_cli_command or build_codex_exec_command_with_danger_bypass'`
- `PUPPETMASTER_ONLY_ADAPTERS=cursor,claude-code,codex,openai python -m pytest tests/test_puppetmaster.py::ReviewEscalationTests -q`
- `PUPPETMASTER_ONLY_ADAPTERS=cursor,claude-code,codex,openai python -m pytest tests/test_puppetmaster.py -q`
  - known existing failure: `ReviewEscalationTests.test_reroute_escalates_rejected_diff`