### PR TITLE
test: isolate platform env during pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,12 @@ tests start invoking the real ``claude-code`` / ``cursor`` adapters
 during ``pytest`` — tests must be hermetic.
 
 This conftest forces the registry path to a nonexistent temp file
-for the duration of the suite. ``load_registry`` returns ``[]`` for a
-missing file, and ``_apply_auto_routing`` is a clean no-op when the
-registry is empty (one ``router.registry_empty`` event, then the
-original spec passes through unchanged). Net effect: tests run
-identically on every machine regardless of the developer's home
-directory state.
+and enables every platform for the duration of the suite. ``load_registry``
+returns ``[]`` for a missing file, and ``_apply_auto_routing`` is a clean
+no-op when the registry is empty (one ``router.registry_empty`` event, then
+the original spec passes through unchanged). Net effect: tests run
+identically on every machine regardless of the developer's home directory
+state or personal platform lock.
 
 Individual tests that exercise the router directly (e.g. the cost +
 auto-route end-to-end test) still write their own registry into a
@@ -25,23 +25,33 @@ so this fixture does not interfere with them.
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 from pathlib import Path
 
-import pytest
+from puppetmaster.platform_lock import KNOWN_ADAPTERS, ONLY_ENV
 
 
-@pytest.fixture(autouse=True, scope="session")
-def _isolate_puppetmaster_models_registry():
-    """Force the router to see an empty registry during pytest runs."""
-    tmp = tempfile.mkdtemp(prefix="pm-test-empty-")
-    sentinel = Path(tmp) / "models-does-not-exist.json"
-    previous = os.environ.get("PUPPETMASTER_MODELS_PATH")
+_ENV_BEFORE: dict[str, str | None] = {}
+_ISOLATION_TMP: str | None = None
+
+
+def pytest_configure(config):
+    """Force routing/platform tests away from the developer's real config."""
+    global _ISOLATION_TMP
+    _ISOLATION_TMP = tempfile.mkdtemp(prefix="pm-test-empty-")
+    sentinel = Path(_ISOLATION_TMP) / "models-does-not-exist.json"
+    _ENV_BEFORE["PUPPETMASTER_MODELS_PATH"] = os.environ.get("PUPPETMASTER_MODELS_PATH")
+    _ENV_BEFORE[ONLY_ENV] = os.environ.get(ONLY_ENV)
     os.environ["PUPPETMASTER_MODELS_PATH"] = str(sentinel)
-    try:
-        yield
-    finally:
-        if previous is None:
-            os.environ.pop("PUPPETMASTER_MODELS_PATH", None)
+    os.environ[ONLY_ENV] = ",".join(KNOWN_ADAPTERS)
+
+
+def pytest_unconfigure(config):
+    for key, value in _ENV_BEFORE.items():
+        if value is None:
+            os.environ.pop(key, None)
         else:
-            os.environ["PUPPETMASTER_MODELS_PATH"] = previous
+            os.environ[key] = value
+    if _ISOLATION_TMP is not None:
+        shutil.rmtree(_ISOLATION_TMP, ignore_errors=True)

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -9591,6 +9591,15 @@ class ReadsLogTests(unittest.TestCase):
 class SetupPlatformStepTests(unittest.TestCase):
     """The `setup` wizard's platform-lock step (non-interactive paths)."""
 
+    def setUp(self) -> None:
+        import os
+        from puppetmaster import platform_lock as pl
+
+        self._env_before = {
+            "PUPPETMASTER_MODELS_PATH": os.environ.get("PUPPETMASTER_MODELS_PATH"),
+            pl.ONLY_ENV: os.environ.get(pl.ONLY_ENV),
+        }
+
     def _args(self, **kw):
         from types import SimpleNamespace
         base = {"platforms": None, "skip_platforms": False}
@@ -9605,7 +9614,12 @@ class SetupPlatformStepTests(unittest.TestCase):
 
     def tearDown(self) -> None:
         import os
-        os.environ.pop("PUPPETMASTER_MODELS_PATH", None)
+
+        for key, value in self._env_before.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
     def test_explicit_platforms_sets_lock(self) -> None:
         from puppetmaster.cli import _setup_platform_step


### PR DESCRIPTION
## Summary
- isolate `PUPPETMASTER_MODELS_PATH` and `PUPPETMASTER_ONLY_ADAPTERS` during pytest runs
- restore setup-platform test environment mutations after each test
- prevent developer-local platform locks from changing router/escalation test results

## Why
The suite could fail on machines with a personal platform lock, such as `PUPPETMASTER_ONLY_ADAPTERS=codex` or a user-level platform config that disables `cursor`. That leaked into router and escalation tests, causing order-dependent failures even though the same tests passed in isolation.

## Tests
- `python -m py_compile tests/conftest.py tests/test_puppetmaster.py`
- `python -m pytest tests/test_puppetmaster.py::SetupPlatformStepTests tests/test_puppetmaster.py::ReviewEscalationTests -q`
- `python -m pytest tests/test_puppetmaster.py -q`