### PR TITLE
fix: treat stalled await jobs as errors

### DIFF
--- a/puppetmaster/cli.py
+++ b/puppetmaster/cli.py
@@ -3730,7 +3730,7 @@ def _run_await_command(args, store) -> int:
             print(f"timed out after {args.timeout_seconds}s; job {args.job_id} is {state['status']}")
         else:
             print(summary or f"job {args.job_id} finished: {state['status']}")
-    return 0 if state["status"] != "failed" else 1
+    return 0 if state["status"] not in {"failed", "stalled"} else 1
 
 
 def _run_preflight_command(args) -> int:

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -2200,7 +2200,7 @@ def run_await_job(args: JsonObject) -> JsonObject:
         body["effective_timeout_seconds"] = timeout_seconds
     return {
         "content": [{"type": "text", "text": json.dumps(body, indent=2, default=str)}],
-        "isError": state["status"] == "failed",
+        "isError": state["status"] in {"failed", "stalled"},
     }
 
 

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -10622,6 +10622,35 @@ class PuppetmasterFrictionFixTests(unittest.TestCase):
             self.assertTrue(state["terminal"])
             self.assertEqual(state["status"], "stalled")
 
+    def test_await_returns_nonzero_for_stalled(self) -> None:
+        with TemporaryDirectory() as tmp:
+            store = self._store(tmp)
+            job = store.create_job("goal")
+            store.update_job_status(job.id, JobStatus.STALLED)
+            rc = cli_main(
+                ["--state-dir", str(store.root), "--backend", "sqlite", "await", job.id]
+            )
+            self.assertEqual(rc, 1)
+
+    def test_mcp_await_marks_stalled_as_error(self) -> None:
+        with TemporaryDirectory() as tmp:
+            store = self._store(tmp)
+            job = store.create_job("goal")
+            store.update_job_status(job.id, JobStatus.STALLED)
+            result = call_tool(
+                "puppetmaster_await_job",
+                {
+                    "cwd": tmp,
+                    "state_dir": str(store.root),
+                    "backend": "sqlite",
+                    "job_id": job.id,
+                    "timeout_seconds": 1,
+                },
+            )
+            payload = json.loads(result["content"][0]["text"])
+            self.assertTrue(result["isError"])
+            self.assertEqual(payload["status"], "stalled")
+
 
 class PuppetmasterLoudFailureTests(unittest.TestCase):
     """Tier-1 reliability: a run that did zero work must never look like success.


### PR DESCRIPTION
## Summary
- make CLI `await` return nonzero when a job ends `stalled`
- make MCP `puppetmaster_await_job` return `isError: true` for stalled jobs
- add regression coverage for stalled await behavior in both entrypoints

## Why
`stalled` is already a terminal job state, but it is not a successful outcome. Treating it as success lets automation and MCP callers miss a degraded run after waiting for completion.

## Tests
- `/Users/bferguson/.local/share/puppetmaster-venv/bin/python -m pytest tests/test_puppetmaster.py::PuppetmasterFrictionFixTests::test_wait_returns_nonzero_for_stalled tests/test_puppetmaster.py::PuppetmasterFrictionFixTests::test_await_treats_stalled_as_terminal tests/test_puppetmaster.py::PuppetmasterFrictionFixTests::test_await_returns_nonzero_for_stalled tests/test_puppetmaster.py::PuppetmasterFrictionFixTests::test_mcp_await_marks_stalled_as_error -q`
- `git diff --check`