### PR TITLE
fix: make Codex MCP credential inheritance explicit

### DIFF
--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -131,6 +131,15 @@ Requirements:
 - Codex CLI authenticated locally. The simplest path is `printenv OPENAI_API_KEY | codex login --with-api-key` (or `codex login` for ChatGPT-account auth).
 - A reviewed workflow config, because this adapter can modify files in the configured `cwd` under the default `workspace-write` sandbox.
 
+For Puppetmaster MCP inside Codex, install selected credential env explicitly:
+
+```bash
+python -m puppetmaster install-codex-mcp --inherit-env OPENAI_API_KEY,CODEX_HOME
+python -m puppetmaster install-codex-mcp --env-file ~/.config/puppetmaster/env.zsh
+```
+
+Keep secrets in a private env file (`chmod 600`) instead of inline MCP config. `puppetmaster doctor` reports whether `OPENAI_API_KEY` and `CODEX_HOME` are visible to the MCP server without printing their values, and Codex billing detection reads `$CODEX_HOME/auth.json` before falling back to `~/.codex/auth.json`.
+
 Defaults are tuned for non-interactive automation: `approval_policy="never"`, `--sandbox workspace-write`, `--ephemeral`, `--skip-git-repo-check`. Use `payload.sandbox="read-only"` for explore / plan tasks that should never touch the worktree. Opt in to `payload.dangerously_bypass_approvals_and_sandbox=true` only when the surrounding environment is already externally sandboxed.
 
 If the adapter returns `failure=not_authenticated`, run `printenv OPENAI_API_KEY | codex login --with-api-key` once.
@@ -162,4 +171,3 @@ Like Claude Code, when Codex edits tracked files, Puppetmaster records a `patch`
 4. Add tests that prove provider failures become artifacts.
 
 Provider adapters should avoid raw transcript dumps. Return claims, decisions, patches, risks, or verification results with evidence.
-

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -135,10 +135,11 @@ For Puppetmaster MCP inside Codex, install selected credential env explicitly:
 
 ```bash
 python -m puppetmaster install-codex-mcp --inherit-env OPENAI_API_KEY,CODEX_HOME
+python -m puppetmaster install-codex-mcp --map-env CODEX_HOME=MY_CODEX_API_HOME
 python -m puppetmaster install-codex-mcp --env-file ~/.config/puppetmaster/env.zsh
 ```
 
-Keep secrets in a private env file (`chmod 600`) instead of inline MCP config. `puppetmaster doctor` reports whether `OPENAI_API_KEY` and `CODEX_HOME` are visible to the MCP server without printing their values, and Codex billing detection reads `$CODEX_HOME/auth.json` before falling back to `~/.codex/auth.json`.
+Keep secrets in a private env file (`chmod 600`) instead of inline MCP config. `CODEX_HOME` is Codex's canonical auth-home variable, not a Puppetmaster requirement; use `--map-env CODEX_HOME=YOUR_LOCAL_NAME` if your machine uses a different local variable name. `puppetmaster doctor --json` reports credential visibility and billing-source evidence without printing values, and Codex billing detection reads `$CODEX_HOME/auth.json` before falling back to `~/.codex/auth.json`.
 
 Defaults are tuned for non-interactive automation: `approval_policy="never"`, `--sandbox workspace-write`, `--ephemeral`, `--skip-git-repo-check`. Use `payload.sandbox="read-only"` for explore / plan tasks that should never touch the worktree. Opt in to `payload.dangerously_bypass_approvals_and_sandbox=true` only when the surrounding environment is already externally sandboxed.
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -22,6 +22,9 @@ python -m puppetmaster install-cursor-mcp           # workspace .cursor/mcp.json
 python -m puppetmaster install-cursor-mcp --global  # ~/.cursor/mcp.json
 python -m puppetmaster install-codex-mcp            # codex mcp add ...
 python -m puppetmaster install-claude-mcp           # claude mcp add --scope user ...
+python -m puppetmaster install-codex-mcp --inherit-env OPENAI_API_KEY,CODEX_HOME
+python -m puppetmaster install-codex-mcp --map-env CODEX_HOME=MY_CODEX_API_HOME
+python -m puppetmaster install-codex-mcp --env-file ~/.config/puppetmaster/env.zsh
 python -m puppetmaster install-rules                # write .cursor/rules/puppetmaster.mdc + AGENTS.md
 python -m puppetmaster install-rules --global       # also ~/.codex/instructions.md and ~/.claude/CLAUDE.md
 ```
@@ -29,6 +32,11 @@ python -m puppetmaster install-rules --global       # also ~/.codex/instructions
 All four installers resolve `sys.executable`, run a `tools/list`
 handshake before writing anything, are idempotent (re-run =
 `unchanged`), and preserve existing user content in the target files.
+For Codex MCP credentials, prefer a private env file (`chmod 600`) over
+inline secrets in MCP JSON/TOML; env-file and secret-like inherited values are
+loaded through a Puppetmaster-managed Python wrapper/private env file so values
+are not printed or embedded in the wrapper. If your local variable name differs
+from the provider's canonical variable, map it with `--map-env TARGET=SOURCE`.
 
 ## Running swarms
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -36,7 +36,8 @@ For Codex MCP credentials, prefer a private env file (`chmod 600`) over
 inline secrets in MCP JSON/TOML; env-file and secret-like inherited values are
 loaded through a Puppetmaster-managed Python wrapper/private env file so values
 are not printed or embedded in the wrapper. If your local variable name differs
-from the provider's canonical variable, map it with `--map-env TARGET=SOURCE`.
+from the provider's canonical variable, map it with `--map-env TARGET=SOURCE`
+instead of renaming your shell environment.
 
 ## Running swarms
 

--- a/puppetmaster/cli.py
+++ b/puppetmaster/cli.py
@@ -118,7 +118,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     subcommands.add_parser("init", help="Create the local Puppetmaster state store.")
     subcommands.add_parser("state", help="Print the resolved Puppetmaster state directory.")
-    subcommands.add_parser("doctor", help="Check local runtime dependencies.")
+    doctor_parser = subcommands.add_parser("doctor", help="Check local runtime dependencies.")
+    doctor_parser.add_argument("--json", action="store_true", help="Emit structured JSON.")
     subcommands.add_parser("adapters", help="List available worker adapters.")
 
     install_codex = subcommands.add_parser(
@@ -1565,7 +1566,24 @@ def _main(argv: Optional[list[str]] = None) -> int:
         return 0
 
     if args.command == "doctor":
-        for check in run_doctor(Path.cwd(), state_dir):
+        checks = run_doctor(Path.cwd(), state_dir)
+        if getattr(args, "json", False):
+            print(
+                json.dumps(
+                    [
+                        {
+                            "name": check.name,
+                            "status": check.status,
+                            "detail": check.detail,
+                            "evidence": check.evidence,
+                        }
+                        for check in checks
+                    ],
+                    indent=2,
+                )
+            )
+            return 0
+        for check in checks:
             print(f"{check.status:8} {check.name:16} {check.detail}")
         return 0
 

--- a/puppetmaster/cli.py
+++ b/puppetmaster/cli.py
@@ -41,6 +41,7 @@ from puppetmaster.mcp_registry import (
     prune_dead as registry_prune_dead,
     summarize as registry_summarize,
 )
+from puppetmaster.redaction import redact_secrets
 from puppetmaster.orchestrator import Orchestrator
 from puppetmaster.state import (
     find_state_dir_for_job,
@@ -123,6 +124,17 @@ def build_parser() -> argparse.ArgumentParser:
     install_codex = subcommands.add_parser(
         "install-codex-mcp",
         help="Register Puppetmaster as an MCP server in the OpenAI Codex CLI.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  puppetmaster install-codex-mcp --inherit-env OPENAI_API_KEY,CODEX_HOME\n"
+            "  puppetmaster install-codex-mcp --map-env CODEX_HOME=MY_CODEX_API_HOME\n"
+            "  puppetmaster install-codex-mcp --env-file ~/.config/puppetmaster/env.zsh\n"
+            "\n"
+            "Recommended: keep secrets in a private env file (`chmod 600`) rather "
+            "than inline MCP JSON/TOML. Use --map-env when your local variable "
+            "name differs from the provider's canonical variable."
+        ),
     )
     install_codex.add_argument(
         "--force",
@@ -143,6 +155,51 @@ def build_parser() -> argparse.ArgumentParser:
         "--codex",
         default=None,
         help="Override the `codex` CLI path (defaults to the first `codex` on PATH).",
+    )
+    install_codex.add_argument(
+        "--env",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "Set a selected MCP-server environment variable. Intended for "
+            "non-secret values; repeat for multiple keys."
+        ),
+    )
+    install_codex.add_argument(
+        "--inherit-env",
+        action="append",
+        default=[],
+        metavar="KEY[,KEY...]",
+        help=(
+            "Copy only these environment variables from the installer process "
+            "into the MCP server environment."
+        ),
+    )
+    install_codex.add_argument(
+        "--env-file",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help=(
+            "Read selected MCP-server env from a shell-style env file, for "
+            "example ~/.config/puppetmaster/env.zsh. File contents are never printed."
+        ),
+    )
+    install_codex.add_argument(
+        "--map-env",
+        action="append",
+        default=[],
+        metavar="TARGET=SOURCE",
+        help=(
+            "Map a canonical MCP-server env key from a local installer env key, "
+            "for example CODEX_HOME=MY_CODEX_API_HOME."
+        ),
+    )
+    install_codex.add_argument(
+        "--force-env",
+        action="store_true",
+        help="Allow requested env values to override existing puppetmaster MCP env keys.",
     )
 
     install_claude = subcommands.add_parser(
@@ -2398,17 +2455,17 @@ def _print_install_result(result: InstallResult, host: str) -> int:
     ``1`` for any error so a CI step can fail fast on a broken install.
     """
     print(f"[install-{host}-mcp] status: {result.status}")
-    print(f"[install-{host}-mcp] target: {result.target}")
-    print(f"[install-{host}-mcp] python: {result.python_executable}")
+    print(f"[install-{host}-mcp] target: {redact_secrets(result.target)}")
+    print(f"[install-{host}-mcp] python: {redact_secrets(result.python_executable)}")
     if result.handshake is not None:
         if result.handshake.ok:
             print(
                 f"[install-{host}-mcp] handshake: OK ({result.handshake.tool_count} tools)"
             )
         else:
-            print(f"[install-{host}-mcp] handshake: FAILED — {result.handshake.error}")
+            print(f"[install-{host}-mcp] handshake: FAILED — {redact_secrets(result.handshake.error)}")
     for line in result.messages:
-        print(f"[install-{host}-mcp] {line}")
+        print(f"[install-{host}-mcp] {redact_secrets(line)}")
     return 0 if result.status in {"installed", "unchanged", "would_install"} else 1
 
 
@@ -2577,6 +2634,11 @@ def _run_install_codex(args) -> int:
     result = install_codex_mcp(
         codex_executable=getattr(args, "codex", None),
         force=getattr(args, "force", False),
+        force_env=getattr(args, "force_env", False),
+        env=tuple(getattr(args, "env", []) or []),
+        inherit_env=tuple(getattr(args, "inherit_env", []) or []),
+        env_files=tuple(Path(p).expanduser() for p in (getattr(args, "env_file", []) or [])),
+        map_env=tuple(getattr(args, "map_env", []) or []),
         dry_run=getattr(args, "dry_run", False),
         skip_handshake=getattr(args, "skip_handshake", False),
     )

--- a/puppetmaster/diagnostics.py
+++ b/puppetmaster/diagnostics.py
@@ -6,7 +6,7 @@ import shutil
 import sqlite3
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -27,6 +27,7 @@ class Check:
     name: str
     status: str
     detail: str
+    evidence: list[str] = field(default_factory=list)
 
 
 def _guard(name: str, fn: "Callable[[], Check]") -> Check:
@@ -65,13 +66,11 @@ def run_doctor(root: Path, state_dir: Optional[Path] = None) -> list[Check]:
         _guard("mcp-servers", _mcp_servers_check),
         _guard("CURSOR_API_KEY", lambda: _env_check("CURSOR_API_KEY")),
         _guard("OPENAI_API_KEY", lambda: _env_check("OPENAI_API_KEY")),
-        _guard("CODEX_HOME", lambda: _env_check("CODEX_HOME")),
-        _guard("mcp-env:OPENAI_API_KEY", lambda: _mcp_env_check("OPENAI_API_KEY")),
-        _guard("mcp-env:CODEX_HOME", lambda: _mcp_env_check("CODEX_HOME")),
         _guard("sqlite-state", lambda: _sqlite_state_check(state_path / "state.sqlite3")),
         _guard("git-status", lambda: _git_clean_check(root)),
         _guard("agent-rules", lambda: _agent_rules_check(root)),
     ]
+    checks.extend(_guard_many(_credential_env_checks))
     checks.extend(_guard_many(_billing_checks))
     checks.append(_guard("catalog-freshness", _catalog_freshness_check))
     checks.append(_guard("platform-lock", _platform_lock_check))
@@ -156,8 +155,52 @@ def _billing_checks() -> list[Check]:
             continue
         state = "ok" if status.healthy else "warn"
         checks.append(
-            Check(f"billing:{adapter}", state, f"{status.billing} — {status.detail}")
+            Check(
+                f"billing:{adapter}",
+                state,
+                f"{status.billing} — {status.detail}",
+                evidence=list(status.evidence),
+            )
         )
+    return checks
+
+
+_PROVIDER_CREDENTIAL_ENV_KEYS: dict[str, tuple[str, ...]] = {
+    "cursor": ("CURSOR_API_KEY",),
+    "openai": ("OPENAI_API_KEY",),
+    "codex": ("CODEX_HOME", "OPENAI_API_KEY"),
+    "claude-code": (
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_USE_BEDROCK",
+        "AWS_PROFILE",
+        "AWS_BEARER_TOKEN_BEDROCK",
+    ),
+}
+
+
+def _credential_env_checks() -> list[Check]:
+    checks: list[Check] = []
+    seen: set[tuple[str, str]] = set()
+    for provider, keys in _PROVIDER_CREDENTIAL_ENV_KEYS.items():
+        for key in keys:
+            marker = (provider, key)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            status = "ok" if os.environ.get(key) else "optional"
+            detail = (
+                f"{key} visible to this process (value hidden)"
+                if status == "ok"
+                else f"{key} not visible to this process"
+            )
+            checks.append(
+                Check(
+                    f"credential-env:{provider}:{key}",
+                    status,
+                    detail,
+                    evidence=[f"provider:{provider}", f"env:{key}", f"visible:{status == 'ok'}"],
+                )
+            )
     return checks
 
 
@@ -344,6 +387,12 @@ def adapter_status(root: Path) -> list[dict[str, object]]:
     claude_installed = _claude_code_installed()
     codex_installed = _codex_cli_installed()
     openai_key = bool(os.environ.get("OPENAI_API_KEY"))
+    try:
+        from puppetmaster.platform_billing import detect_codex_billing
+
+        codex_auth = detect_codex_billing()
+    except Exception:
+        codex_auth = None
     rows = []
     for info in ADAPTER_INFO:
         configured = info.status == "built-in"
@@ -354,11 +403,7 @@ def adapter_status(root: Path) -> list[dict[str, object]]:
         elif info.name == "openai":
             configured = openai_key
         elif info.name == "codex":
-            # Codex needs BOTH: the CLI installed AND OpenAI auth. We don't
-            # introspect `codex login` state from here (the auth file is
-            # outside our purview), so OPENAI_API_KEY is a decent proxy
-            # that we don't false-positive on a never-authed Codex install.
-            configured = codex_installed and openai_key
+            configured = codex_installed and bool(codex_auth and codex_auth.healthy)
         if info.status == "stub":
             configured = False
         rows.append(
@@ -540,8 +585,8 @@ def _codex_command() -> str:
 
 def _env_check(name: str) -> Check:
     if os.environ.get(name):
-        return Check(name, "ok", "set")
-    return Check(name, "optional", "not set")
+        return Check(name, "ok", "set", evidence=[f"env:{name}", "visible:true"])
+    return Check(name, "optional", "not set", evidence=[f"env:{name}", "visible:false"])
 
 
 def _mcp_env_check(name: str) -> Check:

--- a/puppetmaster/diagnostics.py
+++ b/puppetmaster/diagnostics.py
@@ -65,6 +65,9 @@ def run_doctor(root: Path, state_dir: Optional[Path] = None) -> list[Check]:
         _guard("mcp-servers", _mcp_servers_check),
         _guard("CURSOR_API_KEY", lambda: _env_check("CURSOR_API_KEY")),
         _guard("OPENAI_API_KEY", lambda: _env_check("OPENAI_API_KEY")),
+        _guard("CODEX_HOME", lambda: _env_check("CODEX_HOME")),
+        _guard("mcp-env:OPENAI_API_KEY", lambda: _mcp_env_check("OPENAI_API_KEY")),
+        _guard("mcp-env:CODEX_HOME", lambda: _mcp_env_check("CODEX_HOME")),
         _guard("sqlite-state", lambda: _sqlite_state_check(state_path / "state.sqlite3")),
         _guard("git-status", lambda: _git_clean_check(root)),
         _guard("agent-rules", lambda: _agent_rules_check(root)),
@@ -541,6 +544,12 @@ def _env_check(name: str) -> Check:
     return Check(name, "optional", "not set")
 
 
+def _mcp_env_check(name: str) -> Check:
+    if os.environ.get(name):
+        return Check(f"mcp-env:{name}", "ok", "visible to this process (value hidden)")
+    return Check(f"mcp-env:{name}", "optional", "not visible to this process")
+
+
 def _sqlite_state_check(path: Path) -> Check:
     if not path.exists():
         return Check("sqlite-state", "optional", "no local sqlite state yet")
@@ -585,4 +594,3 @@ def _git_clean_check(root: Path) -> Check:
         return Check("git-status", "optional", "not a git repository")
     detail = completed.stdout.strip()
     return Check("git-status", "ok" if not detail else "warn", detail or "clean")
-

--- a/puppetmaster/installers.py
+++ b/puppetmaster/installers.py
@@ -34,7 +34,9 @@ import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Mapping, Optional
+
+from puppetmaster.redaction import redact_secrets, register_secret_value
 
 
 # Codex's MCP client enforces a hard per-tool timeout (`tool_timeout_sec`,
@@ -49,6 +51,10 @@ from typing import Optional
 # user override is never clobbered.
 CODEX_STARTUP_TIMEOUT_SEC = 30
 CODEX_TOOL_TIMEOUT_SEC = 300
+_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SECRET_KEY_HINTS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL")
+_CODEX_WRAPPER_PATH = Path("~/.config/puppetmaster/codex-mcp-wrapper.py").expanduser()
+_CODEX_MANAGED_ENV_PATH = Path("~/.config/puppetmaster/codex-mcp.env.json").expanduser()
 
 
 @dataclass(frozen=True)
@@ -187,6 +193,290 @@ def ensure_cursor_sdk(
     return SdkBootstrapResult(
         "installed", f"@cursor/sdk bootstrapped into {location}", str(location)
     )
+
+
+@dataclass(frozen=True)
+class McpEnvRequest:
+    """User-requested MCP environment sources.
+
+    ``direct`` comes from ``--env KEY=VALUE``. ``inherit`` comes from
+    ``--inherit-env KEY[,KEY...]`` and is copied from the installer process.
+    ``env_files`` are parsed as simple shell-style env files. ``map_env`` maps
+    a provider's canonical key from a local user key (``TARGET=SOURCE``).
+    ``force`` lets requested values override existing MCP env keys; otherwise
+    existing keys win to avoid silently clobbering user-owned credentials on
+    reinstall.
+    """
+
+    direct: tuple[str, ...] = ()
+    inherit: tuple[str, ...] = ()
+    env_files: tuple[Path, ...] = ()
+    map_env: tuple[str, ...] = ()
+    force: bool = False
+
+
+@dataclass
+class McpEnvResolution:
+    env: dict[str, str] = field(default_factory=dict)
+    messages: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    secret_keys: set[str] = field(default_factory=set)
+    requested_keys: set[str] = field(default_factory=set)
+    uses_env_file: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _is_valid_env_key(key: str) -> bool:
+    return bool(_ENV_KEY_RE.match(key))
+
+
+def _is_secret_like_key(key: str) -> bool:
+    upper = key.upper()
+    return any(hint in upper for hint in _SECRET_KEY_HINTS)
+
+
+def _register_env_secrets(env: Mapping[str, str]) -> set[str]:
+    secret_keys: set[str] = set()
+    for key, value in env.items():
+        if _is_secret_like_key(key):
+            secret_keys.add(key)
+            register_secret_value(value)
+            continue
+        if re.search(r"sk-[A-Za-z0-9_\-]{8,}", value) or re.search(
+            r"(?i)bearer\s+[A-Za-z0-9._\-]{8,}", value
+        ):
+            secret_keys.add(key)
+            register_secret_value(value)
+    return secret_keys
+
+
+def _parse_direct_env(assignments: tuple[str, ...]) -> tuple[dict[str, str], list[str]]:
+    env: dict[str, str] = {}
+    errors: list[str] = []
+    for raw in assignments:
+        if "=" not in raw:
+            errors.append("--env entries must be KEY=VALUE")
+            continue
+        key, value = raw.split("=", 1)
+        key = key.strip()
+        if not _is_valid_env_key(key):
+            errors.append(f"invalid env key {key!r}")
+            continue
+        env[key] = value
+    return env, errors
+
+
+def _parse_env_mappings(mappings: tuple[str, ...]) -> tuple[list[tuple[str, str]], list[str]]:
+    parsed: list[tuple[str, str]] = []
+    errors: list[str] = []
+    for raw in mappings:
+        if "=" not in raw:
+            errors.append("--map-env entries must be TARGET=SOURCE")
+            continue
+        target, source = (part.strip() for part in raw.split("=", 1))
+        if not _is_valid_env_key(target):
+            errors.append(f"invalid target env key {target!r}")
+            continue
+        if not _is_valid_env_key(source):
+            errors.append(f"invalid source env key {source!r}")
+            continue
+        parsed.append((target, source))
+    return parsed, errors
+
+
+def _split_inherit_keys(raw_keys: tuple[str, ...]) -> tuple[list[str], list[str]]:
+    keys: list[str] = []
+    errors: list[str] = []
+    seen: set[str] = set()
+    for raw in raw_keys:
+        for part in raw.split(","):
+            key = part.strip()
+            if not key:
+                continue
+            if not _is_valid_env_key(key):
+                errors.append(f"invalid env key {key!r}")
+                continue
+            if key not in seen:
+                keys.append(key)
+                seen.add(key)
+    return keys, errors
+
+
+def _parse_env_file(path: Path) -> tuple[dict[str, str], list[str], list[str]]:
+    """Parse a conservative shell-style env file without executing it."""
+
+    env: dict[str, str] = {}
+    warnings: list[str] = []
+    errors: list[str] = []
+    expanded = path.expanduser()
+    if not expanded.is_file():
+        return env, warnings, [f"env file not found: {expanded}"]
+    try:
+        mode = expanded.stat().st_mode
+    except OSError as exc:
+        return env, warnings, [f"could not stat env file {expanded}: {exc!r}"]
+    if mode & 0o077:
+        warnings.append(
+            f"env file {expanded} is group/world readable; recommended permissions are 0600 "
+            f"(`chmod 600 {expanded}`)"
+        )
+    try:
+        lines = expanded.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        return env, warnings, [f"could not read env file {expanded}: {exc!r}"]
+
+    for lineno, raw in enumerate(lines, start=1):
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        try:
+            parts = shlex.split(stripped, comments=True, posix=True)
+        except ValueError as exc:
+            errors.append(f"{expanded}:{lineno}: could not parse shell env line: {exc}")
+            continue
+        if not parts:
+            continue
+        if parts[0] == "export":
+            parts = parts[1:]
+        elif parts[0] in {"set", "setenv", "source", "."}:
+            warnings.append(f"{expanded}:{lineno}: ignored unsupported shell command")
+            continue
+        elif "=" not in parts[0]:
+            warnings.append(f"{expanded}:{lineno}: ignored unsupported shell command")
+            continue
+        parsed_any = False
+        for part in parts:
+            if "=" not in part:
+                warnings.append(f"{expanded}:{lineno}: ignored token without KEY=VALUE")
+                continue
+            key, value = part.split("=", 1)
+            if not _is_valid_env_key(key):
+                errors.append(f"{expanded}:{lineno}: invalid env key {key!r}")
+                continue
+            env[key] = value
+            parsed_any = True
+        if not parsed_any and parts:
+            warnings.append(f"{expanded}:{lineno}: no env assignments found")
+    return env, warnings, errors
+
+
+def resolve_mcp_env(
+    request: Optional[McpEnvRequest],
+    *,
+    existing_env: Optional[Mapping[str, str]] = None,
+    source_env: Optional[Mapping[str, str]] = None,
+) -> McpEnvResolution:
+    """Resolve requested MCP env with deterministic precedence."""
+
+    resolution = McpEnvResolution()
+    if request is None:
+        request = McpEnvRequest()
+    source_env = source_env if source_env is not None else os.environ
+    requested: dict[str, str] = {}
+
+    for env_file in request.env_files:
+        file_env, warnings, errors = _parse_env_file(env_file)
+        resolution.uses_env_file = True
+        resolution.messages.extend(warnings)
+        resolution.errors.extend(errors)
+        requested.update(file_env)
+    inherit_keys, inherit_errors = _split_inherit_keys(request.inherit)
+    resolution.errors.extend(inherit_errors)
+    for key in inherit_keys:
+        if key in source_env:
+            requested[key] = str(source_env[key])
+        else:
+            resolution.messages.append(f"requested inherited env {key} is not set in installer environment")
+    mappings, mapping_errors = _parse_env_mappings(request.map_env)
+    resolution.errors.extend(mapping_errors)
+    for target, source in mappings:
+        if source in source_env:
+            requested[target] = str(source_env[source])
+        else:
+            resolution.messages.append(
+                f"requested env mapping {target}={source} skipped because {source} is not set"
+            )
+    direct, direct_errors = _parse_direct_env(request.direct)
+    resolution.errors.extend(direct_errors)
+    requested.update(direct)
+    resolution.requested_keys = set(requested)
+
+    existing = dict(existing_env or {})
+    if request.force:
+        merged = {**existing, **requested}
+        overridden = sorted(set(existing) & set(requested))
+        if overridden:
+            resolution.messages.append(
+                f"--force-env overriding existing env key(s): {', '.join(overridden)}"
+            )
+    else:
+        merged = {**requested, **existing}
+        preserved = sorted(set(existing) & set(requested))
+        if preserved:
+            resolution.messages.append(
+                "preserved existing env key(s) "
+                f"{', '.join(preserved)}; pass --force-env to override"
+            )
+    resolution.env = merged
+    resolution.secret_keys = _register_env_secrets(merged)
+    return resolution
+
+
+def _managed_env_content(env: Mapping[str, str]) -> str:
+    """Private, machine-readable managed env content for wrapper launchers."""
+
+    return json.dumps({key: str(env[key]) for key in sorted(env)}, indent=2, sort_keys=True) + "\n"
+
+
+def _write_private_file(path: Path, content: str, mode: int) -> bool:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    current = None
+    if path.exists():
+        try:
+            current = path.read_text(encoding="utf-8")
+        except OSError:
+            current = None
+    if current == content:
+        try:
+            os.chmod(path, mode)
+        except OSError:
+            pass
+        return False
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(content, encoding="utf-8")
+    os.chmod(tmp_path, mode)
+    os.replace(tmp_path, path)
+    return True
+
+
+def _codex_wrapper_content(managed_env_path: Path) -> str:
+    # Python wrapper instead of shell/zsh keeps the env-file/secret fallback
+    # portable across Unix shells and Windows process launchers.
+    return (
+        "#!/usr/bin/env python3\n"
+        "# Managed by Puppetmaster; re-run `puppetmaster install-codex-mcp` to update.\n"
+        "import json\n"
+        "import os\n"
+        "import runpy\n"
+        "from pathlib import Path\n"
+        f"env_path = Path({str(managed_env_path)!r})\n"
+        "if env_path.is_file():\n"
+        "    with env_path.open('r', encoding='utf-8') as handle:\n"
+        "        for key, value in json.load(handle).items():\n"
+        "            os.environ[str(key)] = str(value)\n"
+        "runpy.run_module('puppetmaster.mcp_server', run_name='__main__')\n"
+    )
+
+
+def _codex_config_path(env: Optional[Mapping[str, str]] = None) -> Path:
+    env = env if env is not None else os.environ
+    codex_home = env.get("CODEX_HOME")
+    if codex_home:
+        return Path(codex_home).expanduser() / "config.toml"
+    return Path("~/.codex/config.toml").expanduser()
 
 
 def handshake_mcp_server(
@@ -465,11 +755,82 @@ def _ensure_codex_timeouts(config_path: Path) -> list[str]:
     return messages
 
 
+def _parse_toml_string(value: str) -> str:
+    stripped = value.strip()
+    if stripped.startswith('"') and stripped.endswith('"'):
+        try:
+            return json.loads(stripped)
+        except json.JSONDecodeError:
+            return stripped[1:-1]
+    if stripped.startswith("'") and stripped.endswith("'"):
+        return stripped[1:-1]
+    return stripped
+
+
+def _read_codex_puppetmaster_env(config_path: Path) -> dict[str, str]:
+    """Read the existing ``[mcp_servers.puppetmaster.env]`` table best-effort."""
+
+    try:
+        lines = config_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return {}
+    header = re.compile(r"^\s*\[\s*mcp_servers\.puppetmaster\.env\s*\]\s*$")
+    next_table = re.compile(r"^\s*\[")
+    header_idx = next((i for i, line in enumerate(lines) if header.match(line)), None)
+    if header_idx is None:
+        return {}
+    env: dict[str, str] = {}
+    for line in lines[header_idx + 1 :]:
+        if next_table.match(line):
+            break
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        key = key.strip().strip('"')
+        if _is_valid_env_key(key):
+            env[key] = _parse_toml_string(value)
+    return env
+
+
+def _codex_supports_stdio_env(codex: str) -> bool:
+    try:
+        result = subprocess.run(
+            [codex, "mcp", "add", "--help"],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    text = f"{result.stdout}\n{result.stderr}"
+    return "--env <KEY=VALUE>" in text or "--env" in text
+
+
+def _codex_needs_wrapper(
+    resolution: McpEnvResolution,
+    *,
+    codex_supports_env: bool,
+) -> bool:
+    if not resolution.env:
+        return False
+    if not codex_supports_env:
+        return True
+    return resolution.uses_env_file or bool(resolution.secret_keys)
+
+
 def install_codex_mcp(
     *,
     python_executable: Optional[str] = None,
     codex_executable: Optional[str] = None,
     force: bool = False,
+    force_env: bool = False,
+    env: tuple[str, ...] = (),
+    inherit_env: tuple[str, ...] = (),
+    env_files: tuple[Path, ...] = (),
+    map_env: tuple[str, ...] = (),
     dry_run: bool = False,
     skip_handshake: bool = False,
 ) -> InstallResult:
@@ -490,17 +851,22 @@ def install_codex_mcp(
     entry is removed and re-added so a stale Python path can be fixed
     without manual intervention.
 
-    Note: Codex stores no per-server env block on stdio MCP entries by
-    default in the same way Cursor does, so this installer does not
-    forward env vars. Users who need to pass env to the MCP subprocess
-    should re-run with ``--env KEY=VAL`` after install via
-    ``codex mcp add puppetmaster --env KEY=VAL -- <python> -m ...``
-    or hand-edit the TOML.
+    Env handling: ``env`` maps to explicit ``--env KEY=VALUE`` values,
+    ``inherit_env`` copies selected keys from this installer process,
+    ``map_env`` maps a canonical provider key from a local key, and
+    ``env_files`` parses shell-style env files. Existing Codex env table keys
+    are preserved unless ``force_env=True``. When the local Codex CLI supports
+    stdio ``--env`` and the requested values are non-secret, we register native
+    Codex env entries. For env-files, secret-like values, or Codex CLIs without
+    stdio env support, we register a deterministic Puppetmaster-owned Python
+    wrapper that loads a private 0600 JSON env file instead, keeping raw
+    credentials out of Codex TOML and wrapper code.
     """
     python = python_executable or sys.executable
     codex = codex_executable or "codex"
     resolved_codex = shutil.which(codex) or (codex if Path(codex).expanduser().exists() else None)
     messages: list[str] = []
+    target_path = _codex_config_path()
     if resolved_codex is None:
         messages.append(
             f"`codex` CLI not found on PATH (looked for {codex!r}). "
@@ -508,18 +874,60 @@ def install_codex_mcp(
         )
         return InstallResult(
             status="error",
-            target="~/.codex/config.toml",
+            target=str(target_path),
             python_executable=python,
             messages=messages,
         )
 
+    existing_env = _read_codex_puppetmaster_env(target_path)
+    env_request = McpEnvRequest(
+        direct=tuple(env),
+        inherit=tuple(inherit_env),
+        env_files=tuple(Path(p).expanduser() for p in env_files),
+        map_env=tuple(map_env),
+        force=force_env,
+    )
+    env_resolution = resolve_mcp_env(env_request, existing_env=existing_env)
+    messages.extend(env_resolution.messages)
+    if env_resolution.errors:
+        messages.extend(env_resolution.errors)
+        return InstallResult(
+            status="error",
+            target=str(target_path),
+            python_executable=python,
+            messages=[redact_secrets(m) or "" for m in messages],
+        )
+
+    codex_supports_env = _codex_supports_stdio_env(resolved_codex) if env_resolution.env else True
+    use_wrapper = bool(env_resolution.env) and _codex_needs_wrapper(
+        env_resolution, codex_supports_env=codex_supports_env
+    )
+    wrapper_path = _CODEX_WRAPPER_PATH
+    managed_env_path = _CODEX_MANAGED_ENV_PATH
     desired_command = python
-    desired_args = ["-m", "puppetmaster.mcp_server"]
+    desired_args = [str(wrapper_path)] if use_wrapper else ["-m", "puppetmaster.mcp_server"]
+    if use_wrapper:
+        desired_env = {}
+    else:
+        desired_env = env_resolution.env
+    desired_env = dict(desired_env)
     existing_command = None
     existing_args: list[str] = []
+    managed_files_current = True
+    if use_wrapper:
+        managed_env_content = _managed_env_content(env_resolution.env)
+        wrapper_content = _codex_wrapper_content(managed_env_path)
+        try:
+            managed_files_current = (
+                managed_env_path.read_text(encoding="utf-8") == managed_env_content
+                and wrapper_path.read_text(encoding="utf-8") == wrapper_content
+            )
+        except OSError:
+            managed_files_current = False
     try:
         get_result = subprocess.run(
             [resolved_codex, "mcp", "get", "puppetmaster"],
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
             timeout=10,
@@ -540,17 +948,29 @@ def install_codex_mcp(
         if (
             existing_command == desired_command
             and existing_args == desired_args
+            and existing_env == desired_env
+            and managed_files_current
             and not force
         ):
+            timeout_messages = _ensure_codex_timeouts(target_path)
+            messages.extend(timeout_messages)
+            if any(message.startswith("set Codex timeouts") for message in timeout_messages):
+                return InstallResult(
+                    status="installed",
+                    target=str(target_path),
+                    python_executable=python,
+                    handshake=None,
+                    messages=[redact_secrets(m) or "" for m in messages],
+                )
             messages.append(
                 "codex `puppetmaster` MCP entry already matches sys.executable; nothing to do"
             )
             return InstallResult(
                 status="unchanged",
-                target="~/.codex/config.toml",
+                target=str(target_path),
                 python_executable=python,
                 handshake=None,
-                messages=messages,
+                messages=[redact_secrets(m) or "" for m in messages],
             )
         if existing_command:
             messages.append(
@@ -567,34 +987,66 @@ def install_codex_mcp(
             )
             return InstallResult(
                 status="error",
-                target="~/.codex/config.toml",
+                target=str(target_path),
                 python_executable=python,
                 handshake=handshake,
-                messages=messages,
+                messages=[redact_secrets(m) or "" for m in messages],
             )
         messages.append(
             f"handshake OK ({handshake.tool_count} tools advertised by {python})"
         )
 
     if dry_run:
+        env_note = ""
+        if env_resolution.env:
+            keys = ", ".join(sorted(env_resolution.env))
+            env_note = f"; env key(s): {keys}"
+        wrapper_note = ""
+        if use_wrapper:
+            wrapper_note = (
+                f"; would register managed Python wrapper {wrapper_path} backed by private env file "
+                f"{managed_env_path}"
+            )
+        elif env_resolution.env:
+            wrapper_note = "; would use Codex native --env entries"
         messages.append(
             f"DRY RUN — would run: "
-            f"`{resolved_codex} mcp add puppetmaster -- {desired_command} {' '.join(desired_args)}`"
+            f"`{resolved_codex} mcp add puppetmaster"
+            f"{' [--env KEY=<redacted> ...]' if desired_env else ''}"
+            f" -- {desired_command} {' '.join(desired_args)}`"
             f", then set startup_timeout_sec={CODEX_STARTUP_TIMEOUT_SEC}/"
             f"tool_timeout_sec={CODEX_TOOL_TIMEOUT_SEC} on the entry if unset"
+            f"{env_note}{wrapper_note}"
         )
         return InstallResult(
             status="would_install",
-            target="~/.codex/config.toml",
+            target=str(target_path),
             python_executable=python,
             handshake=handshake,
-            messages=messages,
+            messages=[redact_secrets(m) or "" for m in messages],
+        )
+
+    if use_wrapper:
+        env_changed = _write_private_file(managed_env_path, managed_env_content, 0o600)
+        wrapper_changed = _write_private_file(wrapper_path, wrapper_content, 0o700)
+        messages.append(
+            "using managed Codex MCP Python wrapper with private env file "
+            f"({len(env_resolution.env)} key(s); values not printed)"
+        )
+        if env_changed:
+            messages.append(f"wrote private managed env file {managed_env_path} (0600)")
+        if wrapper_changed:
+            messages.append(f"wrote managed wrapper {wrapper_path} (0700)")
+    elif env_resolution.env:
+        messages.append(
+            f"using Codex native MCP env entries for key(s): {', '.join(sorted(env_resolution.env))}"
         )
 
     if get_result is not None and get_result.returncode == 0:
         try:
             subprocess.run(
                 [resolved_codex, "mcp", "remove", "puppetmaster"],
+                stdin=subprocess.DEVNULL,
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -608,13 +1060,14 @@ def install_codex_mcp(
         "mcp",
         "add",
         "puppetmaster",
-        "--",
-        desired_command,
-        *desired_args,
     ]
+    for key in sorted(desired_env):
+        add_cmd.extend(["--env", f"{key}={desired_env[key]}"])
+    add_cmd.extend(["--", desired_command, *desired_args])
     try:
         add_result = subprocess.run(
             add_cmd,
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
             timeout=15,
@@ -624,10 +1077,10 @@ def install_codex_mcp(
         messages.append(f"`codex mcp add` failed: {exc!r}")
         return InstallResult(
             status="error",
-            target="~/.codex/config.toml",
+            target=str(target_path),
             python_executable=python,
             handshake=handshake,
-            messages=messages,
+            messages=[redact_secrets(m) or "" for m in messages],
         )
     if add_result.returncode != 0:
         messages.append(
@@ -636,21 +1089,21 @@ def install_codex_mcp(
         )
         return InstallResult(
             status="error",
-            target="~/.codex/config.toml",
+            target=str(target_path),
             python_executable=python,
             handshake=handshake,
-            messages=messages,
+            messages=[redact_secrets(m) or "" for m in messages],
         )
     messages.append(
         f"registered puppetmaster MCP entry with Codex via `{resolved_codex} mcp add`"
     )
-    messages.extend(_ensure_codex_timeouts(Path("~/.codex/config.toml").expanduser()))
+    messages.extend(_ensure_codex_timeouts(target_path))
     return InstallResult(
         status="installed",
-        target="~/.codex/config.toml",
+        target=str(target_path),
         python_executable=python,
         handshake=handshake,
-        messages=messages,
+        messages=[redact_secrets(m) or "" for m in messages],
     )
 
 
@@ -722,6 +1175,28 @@ def _remove_codex_puppetmaster_table(config_path: Path) -> tuple[bool, list[str]
     return True, messages
 
 
+def _remove_codex_managed_files(*, dry_run: bool = False) -> tuple[bool, list[str]]:
+    """Remove Puppetmaster-owned Codex wrapper/env artifacts if present."""
+
+    removed_any = False
+    messages: list[str] = []
+    for path in (_CODEX_WRAPPER_PATH, _CODEX_MANAGED_ENV_PATH):
+        if not path.exists():
+            continue
+        if dry_run:
+            removed_any = True
+            messages.append(f"DRY RUN — would remove managed Codex MCP file {path}")
+            continue
+        try:
+            path.unlink()
+        except OSError as exc:
+            messages.append(f"could not remove managed Codex MCP file {path}: {exc!r}")
+            continue
+        removed_any = True
+        messages.append(f"removed managed Codex MCP file {path}")
+    return removed_any, messages
+
+
 def uninstall_cursor_mcp(
     *,
     target_path: Path,
@@ -779,7 +1254,7 @@ def uninstall_codex_mcp(
     table cannot survive a missing CLI.
     """
     codex = codex_executable or "codex"
-    config_path = Path("~/.codex/config.toml").expanduser()
+    config_path = _codex_config_path()
     target_label = str(config_path)
     messages: list[str] = []
     resolved_codex = shutil.which(codex) or (codex if Path(codex).expanduser().exists() else None)
@@ -805,7 +1280,9 @@ def uninstall_codex_mcp(
         header = re.compile(r"^\s*\[\s*mcp_servers\.puppetmaster\s*\]\s*$")
         table_present = any(header.match(line) for line in config_path.read_text(encoding="utf-8").splitlines())
 
-    if not has_entry and not table_present:
+    managed_files_present = any(path.exists() for path in (_CODEX_WRAPPER_PATH, _CODEX_MANAGED_ENV_PATH))
+
+    if not has_entry and not table_present and not managed_files_present:
         messages.append("no puppetmaster MCP entry in Codex config")
         return UninstallResult(status="unchanged", target=target_label, messages=messages)
 
@@ -818,6 +1295,8 @@ def uninstall_codex_mcp(
             messages.append(
                 f"DRY RUN — would remove [mcp_servers.puppetmaster] from {config_path}"
             )
+        _, managed_messages = _remove_codex_managed_files(dry_run=True)
+        messages.extend(managed_messages)
         return UninstallResult(status="would_remove", target=target_label, messages=messages)
 
     removed_any = False
@@ -847,6 +1326,10 @@ def uninstall_codex_mcp(
     removed_table, table_messages = _remove_codex_puppetmaster_table(config_path)
     messages.extend(table_messages)
     removed_any = removed_any or removed_table
+
+    removed_managed, managed_messages = _remove_codex_managed_files()
+    messages.extend(managed_messages)
+    removed_any = removed_any or removed_managed
 
     if not removed_any:
         if messages:

--- a/puppetmaster/installers.py
+++ b/puppetmaster/installers.py
@@ -427,7 +427,6 @@ def resolve_mcp_env(
 
 def _managed_env_content(env: Mapping[str, str]) -> str:
     """Private, machine-readable managed env content for wrapper launchers."""
-
     return json.dumps({key: str(env[key]) for key in sorted(env)}, indent=2, sort_keys=True) + "\n"
 
 
@@ -907,6 +906,9 @@ def install_codex_mcp(
     desired_command = python
     desired_args = [str(wrapper_path)] if use_wrapper else ["-m", "puppetmaster.mcp_server"]
     if use_wrapper:
+        # Wrapper mode exists specifically to keep secret-like values and
+        # env-file contents out of Codex TOML. Put the full effective env in
+        # the private managed env file and clear native Codex env entries.
         desired_env = {}
     else:
         desired_env = env_resolution.env

--- a/puppetmaster/platform_billing.py
+++ b/puppetmaster/platform_billing.py
@@ -55,6 +55,33 @@ class BillingStatus:
         return self.billing == "plan"
 
 
+@dataclass(frozen=True)
+class AuthContext:
+    """Effective credential context used to detect one adapter's billing.
+
+    This keeps provider-specific detectors honest about *which* environment
+    and home directory they inspected without making any one provider's
+    variable name (for example ``CODEX_HOME``) a Puppetmaster-wide concept.
+    """
+
+    env: Mapping[str, str]
+    home: Path
+    label: str = "process"
+
+
+def auth_context(
+    *,
+    env: Optional[Mapping[str, str]] = None,
+    home: Optional[Path] = None,
+    label: str = "process",
+) -> AuthContext:
+    return AuthContext(
+        env=env if env is not None else os.environ,
+        home=home if home is not None else Path.home(),
+        label=label,
+    )
+
+
 def _default_runner(command: list[str]) -> "tuple[int, str, str]":
     try:
         completed = subprocess.run(
@@ -335,6 +362,7 @@ def detect_codex_billing(
     codex_command: str = "codex",
     env: Optional[Mapping[str, str]] = None,
     home: Optional[Path] = None,
+    context: Optional[AuthContext] = None,
 ) -> BillingStatus:
     """Codex: API key (api) vs ChatGPT subscription (plan).
 
@@ -342,12 +370,11 @@ def detect_codex_billing(
     ``~/.codex/auth.json`` (fast, deterministic, no subprocess), and only
     falls back to parsing ``codex login status`` when the file is missing.
     """
-    env = env if env is not None else os.environ
-    home = home if home is not None else Path.home()
-    auth_path, auth_label = _codex_auth_path(env, home)
+    ctx = context or auth_context(env=env, home=home)
+    auth_path, auth_label = _codex_auth_path(ctx.env, ctx.home)
     from_file = _read_codex_auth(auth_path, auth_label)
     if from_file is not None:
-        return from_file
+        return replace(from_file, evidence=[*from_file.evidence, f"auth_context:{ctx.label}"])
     run = run or _default_runner
     returncode, stdout, stderr = run([codex_command, "login", "status"])
     text = f"{stdout}\n{stderr}".lower()
@@ -357,7 +384,7 @@ def detect_codex_billing(
             billing="unknown",
             healthy=False,
             detail="Codex CLI not found on PATH.",
-            evidence=["codex_cli:missing"],
+            evidence=["codex_cli:missing", f"auth_context:{ctx.label}"],
         )
     if "not logged in" in text or "not authenticated" in text:
         return BillingStatus(
@@ -365,7 +392,7 @@ def detect_codex_billing(
             billing="unknown",
             healthy=False,
             detail="Codex is not logged in (run `codex login`).",
-            evidence=["codex_login:none"],
+            evidence=["codex_login:none", f"auth_context:{ctx.label}"],
         )
     if "api key" in text:
         return BillingStatus(
@@ -376,7 +403,7 @@ def detect_codex_billing(
                 "Codex is logged in with an OpenAI API key — work bills "
                 "per-token to that account (out-of-pocket)."
             ),
-            evidence=["codex_login:api_key"],
+            evidence=["codex_login:api_key", f"auth_context:{ctx.label}"],
         )
     if "logged in" in text or "chatgpt" in text:
         return BillingStatus(
@@ -387,14 +414,14 @@ def detect_codex_billing(
                 "Codex is logged in via a ChatGPT subscription — work is "
                 "covered by that plan."
             ),
-            evidence=["codex_login:chatgpt"],
+            evidence=["codex_login:chatgpt", f"auth_context:{ctx.label}"],
         )
     return BillingStatus(
         adapter="codex",
         billing="unknown",
         healthy=False,
         detail="Codex is not logged in (run `codex login`).",
-        evidence=["codex_login:none"],
+        evidence=["codex_login:none", f"auth_context:{ctx.label}"],
     )
 
 
@@ -423,7 +450,7 @@ _DETECTORS: dict[str, Callable[..., BillingStatus]] = {
         env=kw.get("env"), home=kw.get("home")
     ),
     "codex": lambda **kw: detect_codex_billing(
-        run=kw.get("run"), env=kw.get("env"), home=kw.get("home")
+        run=kw.get("run"), env=kw.get("env"), home=kw.get("home"), context=kw.get("context")
     ),
     "openai": lambda **kw: detect_openai_billing(env=kw.get("env")),
 }
@@ -435,6 +462,7 @@ def detect_adapter_billing(
     env: Optional[Mapping[str, str]] = None,
     home: Optional[Path] = None,
     run: Optional[CommandRunner] = None,
+    context: Optional[AuthContext] = None,
 ) -> BillingStatus:
     """Detect the billing posture for ``adapter``.
 
@@ -451,7 +479,7 @@ def detect_adapter_billing(
             detail=f"No billing detector for adapter {adapter!r}; treating as pass-through.",
             evidence=[f"adapter:{adapter}", "detector:none"],
         )
-    return detector(env=env, home=home, run=run)
+    return detector(env=env, home=home, run=run, context=context)
 
 
 _BILLING_CACHE: dict[str, tuple[BillingStatus, float]] = {}

--- a/puppetmaster/platform_billing.py
+++ b/puppetmaster/platform_billing.py
@@ -13,9 +13,10 @@ authenticated on this machine right now:
   (not mere file existence, which survives a logout) — per-token to the console
   account when ``ANTHROPIC_API_KEY`` is set — or per-token to the AWS account
   when ``CLAUDE_CODE_USE_BEDROCK`` is enabled with usable AWS credentials.
-* **Codex** reads ``~/.codex/auth.json`` (``auth_mode``/``tokens``) directly —
-  an API key is out-of-pocket; a ChatGPT login is subscription-covered —
-  falling back to ``codex login status`` only when that file is absent.
+* **Codex** reads ``$CODEX_HOME/auth.json`` when ``CODEX_HOME`` is set, else
+  ``~/.codex/auth.json`` (``auth_mode``/``tokens``) directly — an API key is
+  out-of-pocket; a ChatGPT login is subscription-covered — falling back to
+  ``codex login status`` only when that file is absent.
 
 Every probe is a pure function with injectable ``env`` / ``home`` / ``run``
 dependencies so the test suite can exercise each branch without real
@@ -277,8 +278,15 @@ def detect_claude_billing(
     )
 
 
-def _read_codex_auth(home: Path) -> "Optional[BillingStatus]":
-    """Detect Codex billing from ``~/.codex/auth.json`` without a subprocess.
+def _codex_auth_path(env: Mapping[str, str], home: Path) -> tuple[Path, str]:
+    codex_home = env.get("CODEX_HOME")
+    if codex_home:
+        return Path(codex_home).expanduser() / "auth.json", "$CODEX_HOME/auth.json"
+    return home / ".codex" / "auth.json", "~/.codex/auth.json"
+
+
+def _read_codex_auth(path: Path, label: str) -> "Optional[BillingStatus]":
+    """Detect Codex billing from Codex auth.json without a subprocess.
 
     The file is authoritative and fast: ``auth_mode == "apikey"`` (or a present
     ``OPENAI_API_KEY``) is out-of-pocket; ``auth_mode == "chatgpt"`` (or a
@@ -286,8 +294,6 @@ def _read_codex_auth(home: Path) -> "Optional[BillingStatus]":
     absent/unreadable so the caller can fall back to ``codex login status``.
     """
     import json
-
-    path = home / ".codex" / "auth.json"
     if not path.is_file():
         return None
     try:
@@ -305,10 +311,10 @@ def _read_codex_auth(home: Path) -> "Optional[BillingStatus]":
             billing="api",
             healthy=True,
             detail=(
-                "Codex is authenticated with an OpenAI API key (~/.codex/auth.json) "
+                f"Codex is authenticated with an OpenAI API key ({label}) "
                 "— work bills per-token to that account (out-of-pocket)."
             ),
-            evidence=["codex_auth:apikey"],
+            evidence=["codex_auth:apikey", f"codex_auth_path:{label}"],
         )
     if mode == "chatgpt" or has_tokens:
         return BillingStatus(
@@ -316,10 +322,10 @@ def _read_codex_auth(home: Path) -> "Optional[BillingStatus]":
             billing="plan",
             healthy=True,
             detail=(
-                "Codex is signed in via a ChatGPT subscription (~/.codex/auth.json) "
+                f"Codex is signed in via a ChatGPT subscription ({label}) "
                 "— work is covered by that plan (no marginal API spend)."
             ),
-            evidence=["codex_auth:chatgpt"],
+            evidence=["codex_auth:chatgpt", f"codex_auth_path:{label}"],
         )
     return None
 
@@ -327,15 +333,19 @@ def _read_codex_auth(home: Path) -> "Optional[BillingStatus]":
 def detect_codex_billing(
     run: Optional[CommandRunner] = None,
     codex_command: str = "codex",
+    env: Optional[Mapping[str, str]] = None,
     home: Optional[Path] = None,
 ) -> BillingStatus:
     """Codex: API key (api) vs ChatGPT subscription (plan).
 
-    Reads ``~/.codex/auth.json`` first (fast, deterministic, no subprocess) and
-    only falls back to parsing ``codex login status`` when the file is missing.
+    Reads ``$CODEX_HOME/auth.json`` first when CODEX_HOME is set, otherwise
+    ``~/.codex/auth.json`` (fast, deterministic, no subprocess), and only
+    falls back to parsing ``codex login status`` when the file is missing.
     """
+    env = env if env is not None else os.environ
     home = home if home is not None else Path.home()
-    from_file = _read_codex_auth(home)
+    auth_path, auth_label = _codex_auth_path(env, home)
+    from_file = _read_codex_auth(auth_path, auth_label)
     if from_file is not None:
         return from_file
     run = run or _default_runner
@@ -412,7 +422,9 @@ _DETECTORS: dict[str, Callable[..., BillingStatus]] = {
     "claude-code": lambda **kw: detect_claude_billing(
         env=kw.get("env"), home=kw.get("home")
     ),
-    "codex": lambda **kw: detect_codex_billing(run=kw.get("run"), home=kw.get("home")),
+    "codex": lambda **kw: detect_codex_billing(
+        run=kw.get("run"), env=kw.get("env"), home=kw.get("home")
+    ),
     "openai": lambda **kw: detect_openai_billing(env=kw.get("env")),
 }
 

--- a/puppetmaster/redaction.py
+++ b/puppetmaster/redaction.py
@@ -27,6 +27,11 @@ _SECRET_ENV_VARS = (
     "ANTHROPIC_API_KEY",
     "CURSOR_API_KEY",
     "OPENAI_ORG_ID",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "NPM_TOKEN",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
 )
 _SECRET_SK = re.compile(r"sk-[A-Za-z0-9_\-]{8,}")
 _SECRET_BEARER = re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._\-]{8,}")

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -7335,11 +7335,11 @@ class ModelRouterTests(unittest.TestCase):
 
         captured = {}
 
-        def fake_run_cli(command, args):
+        def fake_run_worker_cli(command, args):
             captured["command"] = command
             return {"ok": True}
 
-        with patch.object(mcp_server, "run_cli", side_effect=fake_run_cli):
+        with patch.object(mcp_server, "run_worker_cli", side_effect=fake_run_worker_cli):
             mcp_server.run_codex(
                 {
                     "goal": "ship codex worker",
@@ -7396,11 +7396,11 @@ class ModelRouterTests(unittest.TestCase):
 
         captured = []
 
-        def fake_run_cli(command, args):
+        def fake_run_worker_cli(command, args):
             captured.append(command)
             return {"ok": True}
 
-        with patch.object(mcp_server, "run_cli", side_effect=fake_run_cli):
+        with patch.object(mcp_server, "run_worker_cli", side_effect=fake_run_worker_cli):
             mcp_server.run_claude({"goal": "fresh claude", "cwd": ".", "disable_memory": True})
             mcp_server.run_openai({"goal": "fresh openai", "cwd": ".", "disable_memory": True})
             mcp_server.run_codex({"goal": "fresh codex", "cwd": ".", "disable_memory": True})
@@ -7993,7 +7993,7 @@ class InstallerTests(unittest.TestCase):
 
         with TemporaryDirectory() as tmp:
             stub_log = Path(tmp) / "codex_calls.log"
-            stub = Path(tmp) / "codex"
+            stub = Path(tmp) / "codex-stub"
             stub.write_text(
                 "#!/usr/bin/env bash\n"
                 f'echo "$@" >> {stub_log}\n'
@@ -8032,7 +8032,17 @@ class InstallerTests(unittest.TestCase):
         from puppetmaster.installers import install_codex_mcp
 
         with TemporaryDirectory() as tmp:
-            stub = Path(tmp) / "codex"
+            codex_home = Path(tmp) / "codex"
+            codex_home.mkdir()
+            (codex_home / "config.toml").write_text(
+                "[mcp_servers.puppetmaster]\n"
+                f'command = "{sys.executable}"\n'
+                'args = ["-m", "puppetmaster.mcp_server"]\n'
+                "startup_timeout_sec = 30\n"
+                "tool_timeout_sec = 300\n",
+                encoding="utf-8",
+            )
+            stub = Path(tmp) / "codex-stub"
             stub.write_text(
                 "#!/usr/bin/env bash\n"
                 'if [ "$1" = "mcp" ] && [ "$2" = "get" ]; then\n'
@@ -8045,11 +8055,285 @@ class InstallerTests(unittest.TestCase):
                 encoding="utf-8",
             )
             stub.chmod(0o755)
-            result = install_codex_mcp(
-                codex_executable=str(stub),
-                skip_handshake=True,
-            )
+            with patch.dict(os.environ, {"CODEX_HOME": str(codex_home)}, clear=False):
+                result = install_codex_mcp(
+                    codex_executable=str(stub),
+                    skip_handshake=True,
+                )
             self.assertEqual(result.status, "unchanged")
+
+    def test_resolve_mcp_env_precedence_map_and_redaction(self):
+        from puppetmaster.installers import McpEnvRequest, resolve_mcp_env
+        from puppetmaster.redaction import clear_registered_secrets, redact_secrets
+
+        with TemporaryDirectory() as tmp:
+            clear_registered_secrets()
+            env_file = Path(tmp) / "env.zsh"
+            secret = "sk-" + "x" * 24
+            env_file.write_text(
+                f"export FOO=file\nSHARED=file\nOPENAI_API_KEY={secret}\n",
+                encoding="utf-8",
+            )
+            env_file.chmod(0o600)
+            try:
+                resolved = resolve_mcp_env(
+                    McpEnvRequest(
+                        direct=("FOO=direct",),
+                        inherit=("SHARED",),
+                        env_files=(env_file,),
+                        map_env=("CODEX_HOME=MY_CODEX_API_HOME",),
+                    ),
+                    existing_env={"FOO": "existing"},
+                    source_env={
+                        "SHARED": "inherited",
+                        "MY_CODEX_API_HOME": "/tmp/api-codex",
+                    },
+                )
+                self.assertTrue(resolved.ok, msg=resolved.errors)
+                self.assertEqual(resolved.env["FOO"], "existing")
+                self.assertEqual(resolved.env["SHARED"], "inherited")
+                self.assertEqual(resolved.env["CODEX_HOME"], "/tmp/api-codex")
+                self.assertNotIn(secret, redact_secrets(f"leaked {secret}") or "")
+            finally:
+                clear_registered_secrets()
+
+    def test_env_file_permission_warning_and_missing_file_error(self):
+        from puppetmaster.installers import McpEnvRequest, resolve_mcp_env
+
+        with TemporaryDirectory() as tmp:
+            env_file = Path(tmp) / "env.zsh"
+            env_file.write_text("export CODEX_HOME=/tmp/codex-api\n", encoding="utf-8")
+            env_file.chmod(0o644)
+            resolved = resolve_mcp_env(McpEnvRequest(env_files=(env_file,)))
+            self.assertTrue(resolved.ok, msg=resolved.errors)
+            self.assertEqual(resolved.env["CODEX_HOME"], "/tmp/codex-api")
+            self.assertTrue(any("group/world readable" in m for m in resolved.messages))
+
+            missing = resolve_mcp_env(McpEnvRequest(env_files=(Path(tmp) / "missing.env",)))
+            self.assertFalse(missing.ok)
+            self.assertTrue(any("env file not found" in e for e in missing.errors))
+
+    @unittest.skipIf(
+        sys.platform == "win32",
+        "bash CLI stub is POSIX-only scaffolding; installer logic is OS-agnostic "
+        "and covered on Linux + macOS",
+    )
+    def test_install_codex_idempotent_entry_still_sets_missing_timeouts(self):
+        from puppetmaster.installers import (
+            CODEX_STARTUP_TIMEOUT_SEC,
+            CODEX_TOOL_TIMEOUT_SEC,
+            install_codex_mcp,
+        )
+
+        with TemporaryDirectory() as tmp:
+            codex_home = Path(tmp) / "codex"
+            codex_home.mkdir()
+            config = codex_home / "config.toml"
+            config.write_text(
+                "[mcp_servers.puppetmaster]\n"
+                f'command = "{sys.executable}"\n'
+                'args = ["-m", "puppetmaster.mcp_server"]\n',
+                encoding="utf-8",
+            )
+            stub = Path(tmp) / "codex-stub"
+            stub.write_text(
+                "#!/usr/bin/env bash\n"
+                'if [ "$1" = "mcp" ] && [ "$2" = "get" ]; then\n'
+                '  echo "name: puppetmaster"\n'
+                f'  echo "command: {sys.executable}"\n'
+                '  echo "args: -m puppetmaster.mcp_server"\n'
+                "  exit 0\n"
+                "fi\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            stub.chmod(0o755)
+            with patch.dict(os.environ, {"CODEX_HOME": str(codex_home)}, clear=False):
+                result = install_codex_mcp(codex_executable=str(stub), skip_handshake=True)
+
+            self.assertEqual(result.status, "installed", msg=result.messages)
+            text = config.read_text("utf-8")
+            self.assertIn(f"startup_timeout_sec = {CODEX_STARTUP_TIMEOUT_SEC}", text)
+            self.assertIn(f"tool_timeout_sec = {CODEX_TOOL_TIMEOUT_SEC}", text)
+
+    @unittest.skipIf(
+        sys.platform == "win32",
+        "bash CLI stub is POSIX-only scaffolding; installer logic is OS-agnostic "
+        "and covered on Linux + macOS",
+    )
+    def test_install_codex_preserves_existing_env_unless_force_env(self):
+        from puppetmaster.installers import install_codex_mcp
+
+        with TemporaryDirectory() as tmp:
+            codex_home = Path(tmp) / "codex"
+            codex_home.mkdir()
+            (codex_home / "config.toml").write_text(
+                "[mcp_servers.puppetmaster]\n"
+                f'command = "{sys.executable}"\n'
+                'args = ["-m", "puppetmaster.mcp_server"]\n\n'
+                "[mcp_servers.puppetmaster.env]\n"
+                'FOO = "old"\n',
+                encoding="utf-8",
+            )
+            stub_log = Path(tmp) / "codex_calls.log"
+            stub = Path(tmp) / "codex-stub"
+            stub.write_text(
+                "#!/usr/bin/env bash\n"
+                f'echo "$@" >> {stub_log}\n'
+                'if [ "$1" = "mcp" ] && [ "$2" = "add" ] && [ "$3" = "--help" ]; then\n'
+                '  echo "--env <KEY=VALUE>"\n'
+                "  exit 0\n"
+                "fi\n"
+                'if [ "$1" = "mcp" ] && [ "$2" = "get" ]; then\n'
+                '  echo "name: puppetmaster"\n'
+                f'  echo "command: {sys.executable}"\n'
+                '  echo "args: -m puppetmaster.mcp_server"\n'
+                "  exit 0\n"
+                "fi\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            stub.chmod(0o755)
+            with patch.dict(os.environ, {"CODEX_HOME": str(codex_home)}, clear=False):
+                result = install_codex_mcp(
+                    codex_executable=str(stub),
+                    env=("FOO=new", "BAR=1"),
+                    skip_handshake=True,
+                )
+                self.assertEqual(result.status, "installed", msg=result.messages)
+                log = stub_log.read_text("utf-8")
+                self.assertIn("--env FOO=old", log)
+                self.assertIn("--env BAR=1", log)
+                self.assertNotIn("--env FOO=new", log)
+
+                stub_log.write_text("", encoding="utf-8")
+                forced = install_codex_mcp(
+                    codex_executable=str(stub),
+                    env=("FOO=new",),
+                    force_env=True,
+                    skip_handshake=True,
+                )
+                self.assertEqual(forced.status, "installed", msg=forced.messages)
+                forced_log = stub_log.read_text("utf-8")
+                self.assertIn("--env FOO=new", forced_log)
+
+    @unittest.skipIf(
+        sys.platform == "win32",
+        "bash CLI stub is POSIX-only scaffolding; installer logic is OS-agnostic "
+        "and covered on Linux + macOS",
+    )
+    def test_install_codex_env_file_uses_wrapper_without_raw_secret_in_outputs(self):
+        from puppetmaster.installers import install_codex_mcp
+
+        with TemporaryDirectory() as tmp:
+            secret = "sk-" + "z" * 24
+            env_file = Path(tmp) / "env.zsh"
+            env_file.write_text(
+                f"export OPENAI_API_KEY={secret}\nexport CODEX_HOME={Path(tmp) / 'api-home'}\n",
+                encoding="utf-8",
+            )
+            env_file.chmod(0o600)
+            codex_home = Path(tmp) / "codex"
+            codex_home.mkdir()
+            (codex_home / "config.toml").write_text(
+                "[mcp_servers.puppetmaster]\n"
+                f'command = "{sys.executable}"\n'
+                'args = ["-m", "puppetmaster.mcp_server"]\n\n'
+                "[mcp_servers.puppetmaster.env]\n"
+                'LEGACY = "keep-me"\n',
+                encoding="utf-8",
+            )
+            stub_log = Path(tmp) / "codex_calls.log"
+            stub = Path(tmp) / "codex-stub"
+            stub.write_text(
+                "#!/usr/bin/env bash\n"
+                f'echo "$@" >> {stub_log}\n'
+                'if [ "$1" = "mcp" ] && [ "$2" = "add" ] && [ "$3" = "--help" ]; then\n'
+                '  echo "--env <KEY=VALUE>"\n'
+                "  exit 0\n"
+                "fi\n"
+                'if [ "$1" = "mcp" ] && [ "$2" = "get" ]; then\n'
+                '  echo "name: puppetmaster"\n'
+                f'  echo "command: {sys.executable}"\n'
+                '  echo "args: -m puppetmaster.mcp_server"\n'
+                "  exit 0\n"
+                "fi\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            stub.chmod(0o755)
+            wrapper = Path(tmp) / "codex-mcp-wrapper.py"
+            managed_env = Path(tmp) / "codex-mcp.env.json"
+            with patch.dict(os.environ, {"CODEX_HOME": str(codex_home)}, clear=False), \
+                    patch("puppetmaster.installers._CODEX_WRAPPER_PATH", wrapper), \
+                    patch("puppetmaster.installers._CODEX_MANAGED_ENV_PATH", managed_env):
+                result = install_codex_mcp(
+                    codex_executable=str(stub),
+                    env_files=(env_file,),
+                    skip_handshake=True,
+                )
+            self.assertEqual(result.status, "installed", msg=result.messages)
+            self.assertTrue(wrapper.exists())
+            self.assertTrue(managed_env.exists())
+            self.assertEqual(managed_env.stat().st_mode & 0o777, 0o600)
+            self.assertNotIn(secret, wrapper.read_text("utf-8"))
+            log = stub_log.read_text("utf-8")
+            self.assertNotIn("--env", log)
+            self.assertNotIn(secret, log)
+            self.assertNotIn(secret, "\n".join(result.messages))
+            managed = json.loads(managed_env.read_text("utf-8"))
+            self.assertEqual(managed["LEGACY"], "keep-me")
+            self.assertEqual(managed["OPENAI_API_KEY"], secret)
+
+    @unittest.skipIf(
+        sys.platform == "win32",
+        "bash CLI stub is POSIX-only scaffolding; installer logic is OS-agnostic "
+        "and covered on Linux + macOS",
+    )
+    def test_install_codex_without_env_support_uses_wrapper_not_env_flags(self):
+        from puppetmaster.installers import install_codex_mcp
+
+        with TemporaryDirectory() as tmp:
+            codex_home = Path(tmp) / "codex"
+            codex_home.mkdir()
+            (codex_home / "config.toml").write_text(
+                "[mcp_servers.puppetmaster]\n"
+                f'command = "{sys.executable}"\n'
+                'args = ["-m", "puppetmaster.mcp_server"]\n\n'
+                "[mcp_servers.puppetmaster.env]\n"
+                'FOO = "old"\n',
+                encoding="utf-8",
+            )
+            stub_log = Path(tmp) / "codex_calls.log"
+            stub = Path(tmp) / "codex-stub"
+            stub.write_text(
+                "#!/usr/bin/env bash\n"
+                f'echo "$@" >> {stub_log}\n'
+                'if [ "$1" = "mcp" ] && [ "$2" = "add" ] && [ "$3" = "--help" ]; then\n'
+                '  echo "Usage: codex mcp add <NAME> -- <COMMAND>"\n'
+                "  exit 0\n"
+                "fi\n"
+                'if [ "$1" = "mcp" ] && [ "$2" = "get" ]; then\n'
+                '  echo "name: puppetmaster"\n'
+                f'  echo "command: {sys.executable}"\n'
+                '  echo "args: -m puppetmaster.mcp_server"\n'
+                "  exit 0\n"
+                "fi\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            stub.chmod(0o755)
+            wrapper = Path(tmp) / "codex-mcp-wrapper.py"
+            managed_env = Path(tmp) / "codex-mcp.env.json"
+            with patch.dict(os.environ, {"CODEX_HOME": str(codex_home)}, clear=False), \
+                    patch("puppetmaster.installers._CODEX_WRAPPER_PATH", wrapper), \
+                    patch("puppetmaster.installers._CODEX_MANAGED_ENV_PATH", managed_env):
+                result = install_codex_mcp(codex_executable=str(stub), skip_handshake=True)
+            self.assertEqual(result.status, "installed", msg=result.messages)
+            log = stub_log.read_text("utf-8")
+            self.assertNotIn("--env", log)
+            self.assertIn(f"mcp add puppetmaster -- {sys.executable} {wrapper}", log)
+            self.assertTrue(managed_env.exists())
 
     def test_install_claude_reports_error_when_cli_missing(self):
         from puppetmaster.installers import install_claude_mcp
@@ -9153,7 +9437,7 @@ class PlatformBillingDetectionTests(unittest.TestCase):
             def _boom(cmd):
                 raise AssertionError("subprocess must not run when auth.json present")
 
-            s = detect_codex_billing(run=_boom, home=home)
+            s = detect_codex_billing(run=_boom, env={}, home=home)
             self.assertEqual(s.billing, "api")
             self.assertIn("codex_auth:apikey", s.evidence)
 
@@ -9165,9 +9449,43 @@ class PlatformBillingDetectionTests(unittest.TestCase):
                 _json.dumps({"auth_mode": "chatgpt", "tokens": {"access": "x"}}),
                 encoding="utf-8",
             )
-            s = detect_codex_billing(run=lambda cmd: (1, "", ""), home=home)
+            s = detect_codex_billing(run=lambda cmd: (1, "", ""), env={}, home=home)
             self.assertEqual(s.billing, "plan")
             self.assertIn("codex_auth:chatgpt", s.evidence)
+
+    def test_codex_billing_uses_codex_home_auth_before_default_home(self) -> None:
+        import json as _json
+
+        from puppetmaster.platform_billing import detect_codex_billing
+
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            codex_home = Path(tmp) / "api-codex-home"
+            (home / ".codex").mkdir(parents=True)
+            codex_home.mkdir()
+            (home / ".codex" / "auth.json").write_text(
+                _json.dumps({"auth_mode": "chatgpt", "tokens": {"access": "x"}}),
+                encoding="utf-8",
+            )
+            (codex_home / "auth.json").write_text(
+                _json.dumps({"OPENAI_API_KEY": "sk-x", "auth_mode": "apikey"}),
+                encoding="utf-8",
+            )
+
+            api = detect_codex_billing(
+                run=lambda cmd: (_ for _ in ()).throw(
+                    AssertionError("subprocess must not run when auth.json exists")
+                ),
+                env={"CODEX_HOME": str(codex_home)},
+                home=home,
+            )
+            self.assertEqual(api.billing, "api")
+            self.assertIn("codex_auth_path:$CODEX_HOME/auth.json", api.evidence)
+            self.assertIn("auth_context:process", api.evidence)
+
+            plan = detect_codex_billing(run=lambda cmd: (1, "", ""), env={}, home=home)
+            self.assertEqual(plan.billing, "plan")
+            self.assertIn("codex_auth_path:~/.codex/auth.json", plan.evidence)
 
     def test_codex_billing_falls_back_to_login_status(self) -> None:
         from puppetmaster.platform_billing import detect_codex_billing
@@ -9176,19 +9494,29 @@ class PlatformBillingDetectionTests(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             home = Path(tmp)  # empty: no ~/.codex/auth.json
             api = detect_codex_billing(
-                run=lambda cmd: (0, "Logged in using an API key - sk-***", ""), home=home
+                run=lambda cmd: (0, "Logged in using an API key - sk-***", ""),
+                env={},
+                home=home,
             )
             self.assertEqual(api.billing, "api")
             chatgpt = detect_codex_billing(
-                run=lambda cmd: (0, "Logged in using ChatGPT", ""), home=home
+                run=lambda cmd: (0, "Logged in using ChatGPT", ""),
+                env={},
+                home=home,
             )
             self.assertEqual(chatgpt.billing, "plan")
             missing = detect_codex_billing(
-                run=lambda cmd: (127, "", "command not found"), home=home
+                run=lambda cmd: (127, "", "command not found"),
+                env={},
+                home=home,
             )
             self.assertEqual(missing.billing, "unknown")
             self.assertFalse(missing.healthy)
-            out = detect_codex_billing(run=lambda cmd: (1, "Not logged in", ""), home=home)
+            out = detect_codex_billing(
+                run=lambda cmd: (1, "Not logged in", ""),
+                env={},
+                home=home,
+            )
             self.assertEqual(out.billing, "unknown")
             self.assertFalse(out.healthy)
 
@@ -14626,6 +14954,32 @@ class UninstallTests(unittest.TestCase):
             self.assertIn("[features]", text)
             again, _ = _remove_codex_puppetmaster_table(config)
             self.assertFalse(again)
+
+    def test_uninstall_codex_mcp_removes_managed_wrapper_files(self):
+        from puppetmaster.installers import uninstall_codex_mcp
+
+        with TemporaryDirectory() as tmp:
+            codex_home = Path(tmp) / "codex"
+            codex_home.mkdir()
+            config = codex_home / "config.toml"
+            config.write_text(
+                "[mcp_servers.puppetmaster]\n"
+                f'command = "{sys.executable}"\n'
+                'args = ["-m", "puppetmaster.mcp_server"]\n',
+                encoding="utf-8",
+            )
+            wrapper = Path(tmp) / "codex-mcp-wrapper.py"
+            managed_env = Path(tmp) / "codex-mcp.env.json"
+            wrapper.write_text("# managed\n", encoding="utf-8")
+            managed_env.write_text("{}\n", encoding="utf-8")
+            with patch.dict(os.environ, {"CODEX_HOME": str(codex_home)}, clear=False), \
+                    patch("puppetmaster.installers._CODEX_WRAPPER_PATH", wrapper), \
+                    patch("puppetmaster.installers._CODEX_MANAGED_ENV_PATH", managed_env):
+                result = uninstall_codex_mcp(codex_executable="/nonexistent/codex")
+            self.assertEqual(result.status, "removed", msg=result.messages)
+            self.assertFalse(wrapper.exists())
+            self.assertFalse(managed_env.exists())
+            self.assertNotIn("[mcp_servers.puppetmaster]", config.read_text("utf-8"))
 
     def test_uninstall_hooks_preserves_foreign_hooks(self):
         from puppetmaster.hook_installers import install_hooks, uninstall_hooks


### PR DESCRIPTION
## Summary

- add explicit Codex MCP env configuration via `--env`, `--inherit-env`, `--env-file`, `--map-env`, and `--force-env`
- preserve existing Codex MCP env entries unless `--force-env` is passed
- keep secret-like values out of installer output, logs, and Codex config by using native `--env` only when safe and a managed private wrapper/env file otherwise
- make Codex billing detection read `$CODEX_HOME/auth.json` before falling back to `~/.codex/auth.json`
- surface credential env visibility and billing-source evidence in doctor output without printing values

## Why

Puppetmaster Codex MCP installs currently depend on whatever environment the MCP host happens to launch with. On Codex, that can silently select the wrong auth context: a user may have an API-key Codex home available, but the MCP server falls back to default `codex` and `~/.codex/auth.json`, hitting ChatGPT/Codex plan usage limits instead of the intended billing path.

This makes credential inheritance explicit, auditable, and provider-shaped. Puppetmaster does not inherit the full parent environment and does not decide a global billing method; users opt specific provider variables into the MCP server environment, including mapping local names into provider-canonical names like `CODEX_HOME`.

## Tests

- `python3 -m py_compile puppetmaster/installers.py puppetmaster/cli.py puppetmaster/diagnostics.py puppetmaster/platform_billing.py puppetmaster/mcp_server.py puppetmaster/redaction.py tests/test_puppetmaster.py`
- `python3 -m pytest tests/test_puppetmaster.py -q -k 'install_codex or uninstall_codex or resolve_mcp_env or codex_billing or doctor or adapter_status or billing or mcp_server'`
- `python3 -m pytest tests/test_puppetmaster.py -q`
- `python3 -m puppetmaster install-codex-mcp --dry-run --env-file ~/.config/puppetmaster/env.zsh`
- `python3 -m puppetmaster install-codex-mcp --help`
- `CODEX_HOME=<api-key-codex-home> python3 -m puppetmaster doctor --json`
- `git diff --check