### PR TITLE
fix: throttle worker heartbeat noise and align sidecar state

### DIFF
--- a/puppetmaster/orchestrator.py
+++ b/puppetmaster/orchestrator.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import contextlib
+import os
 import subprocess
 import sys
 import time
@@ -60,6 +62,19 @@ def _memory_injection_enabled(spec: WorkerSpec) -> bool:
     if override is False:
         return True
     return spec.role not in _FRESH_JUDGMENT_ROLES
+
+
+@contextlib.contextmanager
+def _temporary_env_var(name: str, value: str):
+    previous = os.environ.get(name)
+    os.environ[name] = value
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = previous
 
 
 def merge_routing_payload(payload: dict, decision, extra_fields: Optional[dict] = None) -> dict:
@@ -1486,39 +1501,40 @@ class Orchestrator:
         allowed_task_ids: Optional[set[str]] = None,
     ) -> None:
         allowed_task_ids = allowed_task_ids or {task.id for task in tasks}
-        while True:
-            record_orchestrator_heartbeat(self.store, job.id)
-            self.store.recover_stale_tasks(job.id)
-            self.store.refresh_blocked_tasks(job.id)
-            ready_tasks = [
-                task
-                for task in self.store.list_tasks(job.id)
-                if task.id in allowed_task_ids
-                and task.status in {TaskStatus.QUEUED, TaskStatus.RUNNING}
-            ]
-            if not ready_tasks:
-                if self._should_fail_closed(job, allowed_task_ids):
-                    raise RuntimeError("swarm exited with incomplete tasks")
-                # Either fully complete, or only recoverable adapter-billing
-                # failures remain — hand back to the auto-fallback sweep.
-                return
+        with _temporary_env_var("PUPPETMASTER_STATE_DIR", str(self.store.root)):
+            while True:
+                record_orchestrator_heartbeat(self.store, job.id)
+                self.store.recover_stale_tasks(job.id)
+                self.store.refresh_blocked_tasks(job.id)
+                ready_tasks = [
+                    task
+                    for task in self.store.list_tasks(job.id)
+                    if task.id in allowed_task_ids
+                    and task.status in {TaskStatus.QUEUED, TaskStatus.RUNNING}
+                ]
+                if not ready_tasks:
+                    if self._should_fail_closed(job, allowed_task_ids):
+                        raise RuntimeError("swarm exited with incomplete tasks")
+                    # Either fully complete, or only recoverable adapter-billing
+                    # failures remain — hand back to the auto-fallback sweep.
+                    return
 
-            completed = 0
-            for role in sorted({task.role for task in ready_tasks}):
-                runtime = WorkerRuntime(
-                    store=self.store,
-                    job_id=job.id,
-                    role=role,
-                    worker_id=f"worker-{role}-inline",
-                    lease_seconds=lease_seconds,
-                )
-                completed += runtime.run_until_idle()
-            if completed == 0:
-                if self._should_fail_closed(job, allowed_task_ids):
-                    raise RuntimeError("swarm exited with incomplete tasks")
-                # No progress and only recoverable failures left — stop spinning
-                # and let auto_fallback re-route on a funded adapter.
-                return
+                completed = 0
+                for role in sorted({task.role for task in ready_tasks}):
+                    runtime = WorkerRuntime(
+                        store=self.store,
+                        job_id=job.id,
+                        role=role,
+                        worker_id=f"worker-{role}-inline",
+                        lease_seconds=lease_seconds,
+                    )
+                    completed += runtime.run_until_idle()
+                if completed == 0:
+                    if self._should_fail_closed(job, allowed_task_ids):
+                        raise RuntimeError("swarm exited with incomplete tasks")
+                    # No progress and only recoverable failures left — stop spinning
+                    # and let auto_fallback re-route on a funded adapter.
+                    return
 
     def _wait_for_daemon_workers(
         self,
@@ -1781,4 +1797,3 @@ class Orchestrator:
             self.store.save_artifact(artifact)
         except Exception:
             pass
-

--- a/puppetmaster/worker_runtime.py
+++ b/puppetmaster/worker_runtime.py
@@ -29,6 +29,7 @@ class WorkerRuntime:
         worker_id: str,
         lease_seconds: int = 5,
         poll_seconds: float = 0.1,
+        heartbeat_seconds: Optional[float] = None,
         simulate_seconds: float = 0.0,
         crash_after_claim: bool = False,
     ) -> None:
@@ -38,9 +39,16 @@ class WorkerRuntime:
         self.worker_id = worker_id
         self.lease_seconds = lease_seconds
         self.poll_seconds = poll_seconds
+        self.heartbeat_seconds = heartbeat_seconds
         self.simulate_seconds = simulate_seconds
         self.crash_after_claim = crash_after_claim
         self._lease_lost = threading.Event()
+
+    def _heartbeat_interval(self) -> float:
+        configured = self.heartbeat_seconds
+        if configured is None:
+            configured = 2.0 if self.poll_seconds == 0.1 else self.poll_seconds
+        return max(0.01, min(configured, max(0.1, self.lease_seconds / 3)))
 
     def run_once(self) -> bool:
         task = self.store.claim_next_task(
@@ -70,7 +78,9 @@ class WorkerRuntime:
 
         deadline = time.monotonic() + self.simulate_seconds
         while time.monotonic() < deadline:
-            time.sleep(min(self.poll_seconds, max(0.0, deadline - time.monotonic())))
+            time.sleep(
+                min(self._heartbeat_interval(), max(0.0, deadline - time.monotonic()))
+            )
             run = self.store.heartbeat_run(run)
             self.store.renew_task_lease(task.id, self.worker_id, self.lease_seconds)
 
@@ -298,7 +308,7 @@ class WorkerRuntime:
         task_id: str,
         stop: threading.Event,
     ) -> None:
-        while not stop.wait(self.poll_seconds):
+        while not stop.wait(self._heartbeat_interval()):
             run = self.store.heartbeat_run(run)
             renewed = self.store.renew_task_lease(
                 task_id, self.worker_id, self.lease_seconds
@@ -400,6 +410,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--worker-id")
     parser.add_argument("--lease-seconds", type=int, default=5)
     parser.add_argument("--poll-seconds", type=float, default=0.1)
+    parser.add_argument("--heartbeat-seconds", type=float)
     parser.add_argument("--simulate-seconds", type=float, default=0.0)
     parser.add_argument("--crash-after-claim", action="store_true")
     return parser
@@ -457,6 +468,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             worker_id=worker_id,
             lease_seconds=args.lease_seconds,
             poll_seconds=args.poll_seconds,
+            heartbeat_seconds=args.heartbeat_seconds,
             simulate_seconds=args.simulate_seconds,
             crash_after_claim=args.crash_after_claim,
         )
@@ -472,4 +484,3 @@ def main(argv: Optional[list[str]] = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -15141,12 +15141,78 @@ class AuditFixTests(unittest.TestCase):
             role="coder",
             worker_id="worker-a",
             poll_seconds=0.01,
+            heartbeat_seconds=0.01,
         )
         stop = threading.Event()
         run = MagicMock()
         runtime._heartbeat_until_stopped(run, "task_x", stop)
         self.assertTrue(stop.is_set())
         self.assertTrue(runtime._lease_lost.is_set())
+
+    def test_heartbeat_loop_uses_heartbeat_interval_not_poll_interval(self) -> None:
+        from puppetmaster.worker_runtime import WorkerRuntime
+
+        store = MagicMock()
+        store.heartbeat_run.side_effect = lambda run: run
+        store.renew_task_lease.return_value = MagicMock()
+        runtime = WorkerRuntime(
+            store=store,
+            job_id="job_x",
+            role="coder",
+            worker_id="worker-a",
+            lease_seconds=10,
+            poll_seconds=0.01,
+            heartbeat_seconds=0.25,
+        )
+        stop = MagicMock()
+        stop.wait.side_effect = [False, True]
+
+        runtime._heartbeat_until_stopped(MagicMock(), "task_x", stop)
+
+        stop.wait.assert_any_call(0.25)
+        self.assertEqual(store.heartbeat_run.call_count, 1)
+        self.assertEqual(store.renew_task_lease.call_count, 1)
+
+    def test_heartbeat_interval_keeps_margin_for_short_leases(self) -> None:
+        from puppetmaster.worker_runtime import WorkerRuntime
+
+        runtime = WorkerRuntime(
+            store=MagicMock(),
+            job_id="job_x",
+            role="coder",
+            worker_id="worker-a",
+            lease_seconds=2,
+            heartbeat_seconds=2.0,
+        )
+
+        self.assertAlmostEqual(runtime._heartbeat_interval(), 2 / 3)
+
+    def test_inline_workers_scope_state_dir_env_to_store_root(self) -> None:
+        from puppetmaster.orchestrator import Orchestrator
+
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("inline state dir")
+            task = Task(job_id=job.id, role="codex", instruction="x")
+            store.save_task(task)
+            seen = []
+
+            def complete_task(runtime):
+                seen.append(os.environ.get("PUPPETMASTER_STATE_DIR"))
+                stored = store.get_task_by_id(task.id)
+                store.update_task_status(stored, TaskStatus.COMPLETE)
+                return 1
+
+            with patch.dict(os.environ, {"PUPPETMASTER_STATE_DIR": "parent-state"}):
+                with patch(
+                    "puppetmaster.orchestrator.WorkerRuntime.run_until_idle",
+                    autospec=True,
+                    side_effect=complete_task,
+                ):
+                    Orchestrator(store)._run_inline_workers(job, [task])
+                self.assertEqual(os.environ["PUPPETMASTER_STATE_DIR"], "parent-state")
+
+            self.assertEqual(seen, [str(store.root)])
 
     def test_redact_secrets_scrubs_argument_supplied_keys(self) -> None:
         from puppetmaster.redaction import (


### PR DESCRIPTION
## Summary

- throttle worker heartbeat/lease renewal away from the hot `poll_seconds=0.1` loop
- add explicit `--heartbeat-seconds` support while preserving non-default `--poll-seconds` as the compatibility fallback
- keep heartbeat cadence safely below lease expiry for short leases
- scope `PUPPETMASTER_STATE_DIR` around inline workers so adapter sidecars land under the owning store root
- add regression coverage for heartbeat cadence, short-lease margin, and inline state-dir restoration

## Why

Puppetmaster workers were renewing leases and emitting heartbeat/save events every `0.1s`, producing thousands of events for ordinary runs and making logs/status debugging noisy. Slowing the default heartbeat path cuts that event churn while preserving lease safety and existing callers that tuned `--poll-seconds`.

Inline worker mode also did not export the resolved store root through `PUPPETMASTER_STATE_DIR`, so adapter sidecar logs could be written under the wrong project state dir when the parent environment pointed elsewhere.

## Tests

- `python3 -m pytest tests/test_puppetmaster.py -q -k 'heartbeat or inline_workers_scope_state_dir'`
- `env -u CODEX_COMMAND -u CODEX_CI -u CODEX_HOME -u CODEX_PATH -u CODEX_THREAD_ID python3 -m pytest tests/test_puppetmaster.py -q`
- `git diff --check`
- Puppetmaster confidence review:
  - tests review `job_391b13303b3b`: no blocking issue
  - inline state-dir review `job_08b8c258fd9e`: no blocking issue
  - heartbeat review `job_d5fb9427fc66`: surfaced compatibility/short-lease findings addressed in this PR