### PR TITLE
fix: add compact status output for prompt-heavy jobs

### DIFF
--- a/puppetmaster/cli.py
+++ b/puppetmaster/cli.py
@@ -394,6 +394,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     status = subcommands.add_parser("status", help="Show task, artifact, and stale lease state.")
     status.add_argument("job_id")
+    status.add_argument(
+        "--compact",
+        action="store_true",
+        help=(
+            "Omit high-churn prompt bodies from JSON output and replace them "
+            "with deterministic char-count/SHA-256 refs."
+        ),
+    )
 
     watch = subcommands.add_parser("watch", help="Poll status for a job.")
     watch.add_argument("job_id")
@@ -1842,7 +1850,7 @@ def _main(argv: Optional[list[str]] = None) -> int:
         # status never reports a wedged job as live.
         _reap_quietly(store)
         _warn_job_liveness(store, args.job_id)
-        print(json.dumps(store.status_snapshot(args.job_id), indent=2))
+        print(json.dumps(store.status_snapshot(args.job_id, compact=args.compact), indent=2))
         return 0
 
     if args.command == "watch":

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -1282,8 +1282,8 @@ def _build_tools() -> list[McpTool]:
         McpTool(
             name="puppetmaster_status",
             description="Return task, artifact, and stale lease state for a Puppetmaster job.",
-            input_schema=job_schema(required=True),
-            handler=lambda args: run_cli(["status", require_string(args, "job_id")], args),
+            input_schema=status_schema(),
+            handler=run_status,
         ),
         McpTool(
             name="puppetmaster_logs",
@@ -2287,6 +2287,13 @@ def run_route_task(args: JsonObject) -> JsonObject:
     }
 
 
+def run_status(args: JsonObject) -> JsonObject:
+    command = ["status", require_string(args, "job_id")]
+    if args.get("compact"):
+        command.append("--compact")
+    return run_cli(command, args)
+
+
 def run_list_models(args: JsonObject) -> JsonObject:
     """Return the registry as JSON. Mirrors `puppetmaster models list --json`."""
     from dataclasses import asdict
@@ -2836,6 +2843,18 @@ def job_schema(required: bool = False) -> JsonObject:
     schema["properties"]["job_id"] = {"type": "string", "description": "Puppetmaster job id."}
     if required:
         schema["required"] = ["job_id"]
+    return schema
+
+
+def status_schema() -> JsonObject:
+    schema = job_schema(required=True)
+    schema["properties"]["compact"] = {
+        "type": "boolean",
+        "description": (
+            "Omit high-churn prompt bodies from status JSON and replace them "
+            "with deterministic char-count/SHA-256 refs."
+        ),
+    }
     return schema
 
 

--- a/puppetmaster/store.py
+++ b/puppetmaster/store.py
@@ -485,16 +485,58 @@ class SwarmStore:
             )
         return out
 
-    def status_snapshot(self, job_id: str) -> dict[str, Any]:
+    @staticmethod
+    def _compact_text_ref(value: Any) -> dict[str, Any]:
+        text = str(value)
+        return {
+            "chars": len(text),
+            "sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        }
+
+    @classmethod
+    def _compact_status_payload(cls, payload: Any) -> Any:
+        if not isinstance(payload, dict):
+            return payload
+        compacted = dict(payload)
+        prompt = compacted.pop("prompt", None)
+        if prompt is not None:
+            compacted["prompt_ref"] = cls._compact_text_ref(prompt)
+        return compacted
+
+    @classmethod
+    def _compact_status_job(cls, job: dict[str, Any]) -> dict[str, Any]:
+        compacted = dict(job)
+        goal = compacted.pop("goal", None)
+        if goal is not None:
+            compacted["goal_ref"] = cls._compact_text_ref(goal)
+        return compacted
+
+    @classmethod
+    def _compact_status_task(cls, task: dict[str, Any]) -> dict[str, Any]:
+        compacted = dict(task)
+        instruction = compacted.pop("instruction", None)
+        if instruction is not None:
+            compacted["instruction_ref"] = cls._compact_text_ref(instruction)
+        compacted["payload"] = cls._compact_status_payload(compacted.get("payload"))
+        return compacted
+
+    def status_snapshot(self, job_id: str, *, compact: bool = False) -> dict[str, Any]:
         self.refresh_blocked_tasks(job_id)
         tasks = self.list_tasks(job_id)
         status_counts: dict[str, int] = {}
         for task in tasks:
             status_counts[str(task.status)] = status_counts.get(str(task.status), 0) + 1
         artifacts = self.list_artifacts(job_id)
+        job_payload = to_jsonable(self.get_job(job_id))
+        task_payloads = [to_jsonable(task) for task in tasks]
+        if compact:
+            job_payload = self._compact_status_job(job_payload)
+            task_payloads = [
+                self._compact_status_task(task_payload) for task_payload in task_payloads
+            ]
         return {
-            "job": to_jsonable(self.get_job(job_id)),
-            "tasks": [to_jsonable(task) for task in tasks],
+            "job": job_payload,
+            "tasks": task_payloads,
             "task_counts": status_counts,
             "artifact_count": len(artifacts),
             "stale_task_ids": [task.id for task in tasks if self.is_task_stale(task)],

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -321,6 +321,21 @@ class PuppetmasterTests(unittest.TestCase):
             self.assertIn("demo local adapter", payload["error"])
             self.assertIn("puppetmaster_start_cursor_swarm", payload["fix"])
 
+    def test_mcp_status_compact_arg_maps_to_cli_flag(self) -> None:
+        from puppetmaster import mcp_server
+
+        captured = {}
+
+        def fake_run_cli(command, args):
+            captured["command"] = command
+            return {"content": [{"type": "text", "text": "{}"}], "isError": False}
+
+        with patch.object(mcp_server, "run_cli", side_effect=fake_run_cli):
+            result = mcp_server.run_status({"job_id": "job_x", "compact": True})
+
+        self.assertFalse(result["isError"])
+        self.assertEqual(captured["command"], ["status", "job_x", "--compact"])
+
     def test_mcp_adapter_generates_config_for_custom_roles(self) -> None:
         with TemporaryDirectory() as tmp:
             before_process_count = len(ASYNC_PROCESSES)
@@ -873,7 +888,12 @@ class PuppetmasterTests(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             store = SwarmStore(Path(tmp) / ".puppetmaster")
             job = store.create_job("inspect runtime state")
-            task = Task(job_id=job.id, role="reviewer", instruction="look for risks")
+            task = Task(
+                job_id=job.id,
+                role="reviewer",
+                instruction="look for risks",
+                payload={"prompt": "review the long prompt body"},
+            )
             store.save_task(task)
             claimed = store.claim_task(task.id, "worker-a", lease_seconds=60)
             store.save_task(replace(claimed, lease_expires_at=seconds_from_now(-1)))
@@ -881,8 +901,46 @@ class PuppetmasterTests(unittest.TestCase):
             snapshot = store.status_snapshot(job.id)
 
             self.assertIsNotNone(claimed)
+            self.assertEqual(snapshot["job"]["goal"], "inspect runtime state")
+            self.assertEqual(snapshot["tasks"][0]["instruction"], "look for risks")
+            self.assertEqual(
+                snapshot["tasks"][0]["payload"]["prompt"],
+                "review the long prompt body",
+            )
             self.assertEqual(snapshot["task_counts"][str(TaskStatus.RUNNING)], 1)
             self.assertEqual(snapshot["stale_task_ids"], [task.id])
+
+    def test_status_snapshot_compact_omits_prompt_bodies(self) -> None:
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("inspect runtime state")
+            task = Task(
+                job_id=job.id,
+                role="reviewer",
+                instruction="look for risks",
+                payload={"prompt": "review the long prompt body", "model": "m"},
+            )
+            store.save_task(task)
+
+            snapshot = store.status_snapshot(job.id, compact=True)
+            task_snapshot = snapshot["tasks"][0]
+
+            self.assertNotIn("goal", snapshot["job"])
+            self.assertEqual(snapshot["job"]["goal_ref"]["chars"], len("inspect runtime state"))
+            self.assertEqual(len(snapshot["job"]["goal_ref"]["sha256"]), 64)
+            self.assertNotIn("instruction", task_snapshot)
+            self.assertEqual(
+                task_snapshot["instruction_ref"]["chars"],
+                len("look for risks"),
+            )
+            self.assertEqual(len(task_snapshot["instruction_ref"]["sha256"]), 64)
+            self.assertNotIn("prompt", task_snapshot["payload"])
+            self.assertEqual(
+                task_snapshot["payload"]["prompt_ref"]["chars"],
+                len("review the long prompt body"),
+            )
+            self.assertEqual(len(task_snapshot["payload"]["prompt_ref"]["sha256"]), 64)
+            self.assertEqual(task_snapshot["payload"]["model"], "m")
 
     def test_stitching_is_deterministic_for_existing_artifacts(self) -> None:
         with TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- add opt-in compact JSON output for `puppetmaster status`
- replace high-churn prompt bodies with deterministic `chars` + `sha256` refs
- expose compact status through the MCP `puppetmaster_status` tool
- preserve full status output as the default for compatibility
- add regression coverage for default output, compact refs, and MCP arg forwarding

## Why

Large Puppetmaster swarms can repeat the same prompt bodies through job goals, task instructions, and task payload prompts. For prompt-heavy jobs, every status check can reintroduce tens of thousands of characters into agent context even when the caller only needs task state, counts, leases, and stable identity.

This keeps the existing `status` contract intact while giving agents and tooling an explicit low-churn path. Compact mode avoids arbitrary preview limits: it omits the bodies entirely and emits deterministic length/hash refs so callers can still compare identity without paying the context cost.

On a real large BI adversarial swarm, compact status reduced output from `40,835` bytes to `5,059` bytes, an `87.6%` reduction.

## Tests

- `python3 -m pytest tests/test_puppetmaster.py -q -k 'status_snapshot or mcp_status_compact or mcp_lists_puppetmaster_agent_tools'`
- `python3 -m compileall -q puppetmaster/store.py puppetmaster/cli.py puppetmaster/mcp_server.py tests/test_puppetmaster.py`
- `env -u CODEX_COMMAND -u CODEX_CI -u CODEX_HOME -u CODEX_PATH -u CODEX_THREAD_ID python3 -m pytest tests/test_puppetmaster.py -q`
- `git diff --check`
- Puppetmaster confidence review:
  - implementation review `job_9888527e9ccc`: no blocking compatibility issue
  - tests review `job_7acac095b90b`: no blocking test coverage issue