### PR TITLE
Add `receipt` command for job run-efficiency metrics and supporting t…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ Puppetmaster keeps a **read-only, local, numbers-only** ledger of what it saved,
 
 ## MCP surface (quick reference)
 
-Orchestration: `puppetmaster_doctor`, `puppetmaster_start_swarm`, `puppetmaster_start_cursor_swarm`, `puppetmaster_start_cursor_review`, `puppetmaster_start_cursor_plan`, `puppetmaster_start_claude_implement`, `puppetmaster_start_browser_swarm`, `puppetmaster_status`, `puppetmaster_logs`, `puppetmaster_live_artifacts`, `puppetmaster_live_artifacts_follow`, `puppetmaster_partial_summary`, `puppetmaster_artifacts`, `puppetmaster_show`, `puppetmaster_last_job`, `puppetmaster_dashboard`.
+Orchestration: `puppetmaster_doctor`, `puppetmaster_start_swarm`, `puppetmaster_start_cursor_swarm`, `puppetmaster_start_cursor_review`, `puppetmaster_start_cursor_plan`, `puppetmaster_start_claude_implement`, `puppetmaster_start_browser_swarm`, `puppetmaster_status`, `puppetmaster_logs`, `puppetmaster_live_artifacts`, `puppetmaster_live_artifacts_follow`, `puppetmaster_partial_summary`, `puppetmaster_artifacts`, `puppetmaster_show`, `puppetmaster_job_cost`, `puppetmaster_job_receipt`, `puppetmaster_last_job`, `puppetmaster_dashboard`.
 
 Bundled CodeGraph: `puppetmaster_codegraph_search`, `puppetmaster_codegraph_context`, `puppetmaster_codegraph_affected`, `puppetmaster_codegraph_files`, `puppetmaster_codegraph_status`, `puppetmaster_codegraph_init`.
 
@@ -134,6 +134,8 @@ If any `puppetmaster_*` MCP tool returns `Tool execution error. Not connected`, 
 | `puppetmaster_partial_summary` | `python -m puppetmaster show <job_id> --partial` |
 | `puppetmaster_artifacts` | `python -m puppetmaster artifacts <job_id>` |
 | `puppetmaster_show` | `python -m puppetmaster show <job_id>` |
+| `puppetmaster_job_cost` | `python -m puppetmaster cost <job_id>` |
+| `puppetmaster_job_receipt` | `python -m puppetmaster receipt <job_id>` |
 | `puppetmaster_last_job` | `python -m puppetmaster last` |
 | `puppetmaster_jobs` | `python -m puppetmaster jobs [--all-projects]` |
 | `puppetmaster_mcp_status` | `python -m puppetmaster mcp list` |

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -89,6 +89,7 @@ Also available as the `puppetmaster_start_browser_swarm` MCP tool (async; return
 ```bash
 python -m puppetmaster route "instruction" --role <role>     # dry-run, returns picked model + cost
 python -m puppetmaster cost <job_id>                          # sum spend across all routing artifacts
+python -m puppetmaster receipt <job_id>                       # objective run-efficiency metrics
 python -m puppetmaster models init                            # write starter registry
 python -m puppetmaster models list                            # show registered models
 python -m puppetmaster models discover --source agentic --write   # seed keys-only agentic catalog (filtered by visible provider keys)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -36,7 +36,7 @@ Five production adapters live plus the keys-only `agentic` standalone worker; el
 | Memory | Promoted memory retrieval into later worker context and prompts; Wave 10 weighted ranking (scope, query overlap, recency); Wave 11 MMR diversity rerank so injected memory stays relevant without near-duplicates |
 | Memory cost accounting (v1.10.0+) | Every memory injection logs estimated tokens and USD to the local savings ledger (`python -m puppetmaster savings`); disable with `PUPPETMASTER_MEMORY_COST_LOG=0` |
 | Degraded-run honesty (v1.10.0+) | Empty agentic swarms and max-turns-with-no-findings runs classify as degraded with mitigation advice instead of looking successful in stitched summaries |
-| Run receipts | `puppetmaster receipt <job_id>` reports objective run-efficiency metrics: degraded tasks, typed artifacts, empty/unstructured signals, stdout-salvage markers, token totals, and tokens per typed artifact |
+| Run receipts | `puppetmaster receipt <job_id>` / `puppetmaster_job_receipt` reports objective run-efficiency metrics: degraded tasks, typed artifacts (finding/risk/decision/patch), empty/unstructured signals, stdout-salvage markers, token totals, and tokens per typed artifact |
 | Windows console hygiene (v1.10.0+) | Process-wide `CREATE_NO_WINDOW` default for child subprocesses under console-less hosts (Cursor MCP, workers, CodeGraph index). Escape hatch: `PUPPETMASTER_SHOW_CONSOLES=1` |
 | CodeGraph | Optional shared repo intelligence ([docs](CODEGRAPH.md)) |
 | Patch workflow | Patch artifacts, path locks, approval/rejection events, dirty-worktree guard |

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -36,6 +36,7 @@ Five production adapters live plus the keys-only `agentic` standalone worker; el
 | Memory | Promoted memory retrieval into later worker context and prompts; Wave 10 weighted ranking (scope, query overlap, recency); Wave 11 MMR diversity rerank so injected memory stays relevant without near-duplicates |
 | Memory cost accounting (v1.10.0+) | Every memory injection logs estimated tokens and USD to the local savings ledger (`python -m puppetmaster savings`); disable with `PUPPETMASTER_MEMORY_COST_LOG=0` |
 | Degraded-run honesty (v1.10.0+) | Empty agentic swarms and max-turns-with-no-findings runs classify as degraded with mitigation advice instead of looking successful in stitched summaries |
+| Run receipts | `puppetmaster receipt <job_id>` reports objective run-efficiency metrics: degraded tasks, typed artifacts, empty/unstructured signals, stdout-salvage markers, token totals, and tokens per typed artifact |
 | Windows console hygiene (v1.10.0+) | Process-wide `CREATE_NO_WINDOW` default for child subprocesses under console-less hosts (Cursor MCP, workers, CodeGraph index). Escape hatch: `PUPPETMASTER_SHOW_CONSOLES=1` |
 | CodeGraph | Optional shared repo intelligence ([docs](CODEGRAPH.md)) |
 | Patch workflow | Patch artifacts, path locks, approval/rejection events, dirty-worktree guard |

--- a/puppetmaster/cli/_dispatch.py
+++ b/puppetmaster/cli/_dispatch.py
@@ -117,6 +117,7 @@ from puppetmaster.cli.commands_gate import (
     _run_invocation_gate_command,
     _run_preflight_command,
     _run_proxy_command,
+    _run_receipt_command,
     _run_rollup_command,
     _run_route_command,
     _run_savings_command,
@@ -374,6 +375,7 @@ def _main(argv: Optional[list[str]] = None) -> int:
     # use the caller's workspace state.
     if args.command in {
         "show",
+        "receipt",
         "artifacts",
         "diff",
         "memory",
@@ -501,6 +503,9 @@ def _main(argv: Optional[list[str]] = None) -> int:
 
     if args.command == "cost":
         return _run_cost_command(args, store)
+
+    if args.command == "receipt":
+        return _run_receipt_command(args, store)
 
     if args.command == "adapters":
         print(json.dumps(adapter_status(Path.cwd()), indent=2))

--- a/puppetmaster/cli/_parser.py
+++ b/puppetmaster/cli/_parser.py
@@ -642,6 +642,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="Render a live summary from current artifacts without waiting for final stitching.",
     )
 
+    receipt = subcommands.add_parser(
+        "receipt",
+        help="Show objective run-efficiency metrics for a job.",
+    )
+    receipt.add_argument("job_id")
+    receipt.add_argument("--json", action="store_true", help="Emit JSON.")
+
     finalize = subcommands.add_parser(
         "finalize",
         help=(

--- a/puppetmaster/cli/commands_gate.py
+++ b/puppetmaster/cli/commands_gate.py
@@ -832,3 +832,46 @@ def _run_cost_command(args, store) -> int:
     print()
     _print_token_usage(artifacts)
     return 0
+
+
+def _run_receipt_command(args, store) -> int:
+    from puppetmaster.receipt import build_job_receipt
+
+    receipt = build_job_receipt(store, args.job_id)
+    if args.json:
+        print(json.dumps(receipt, indent=2))
+        return 0
+    print(f"job {receipt['job_id']}: receipt")
+    if receipt.get("elapsed_seconds") is not None:
+        print(f"  elapsed: {receipt['elapsed_seconds']}s")
+    tasks = receipt["tasks"]
+    artifacts = receipt["artifacts"]
+    signals = receipt["signals"]
+    efficiency = receipt["efficiency"]
+    tokens = receipt["tokens"]
+    print(
+        "  tasks: "
+        f"{tasks['total']} total, {tasks['complete']} complete, "
+        f"{tasks['failed']} failed, {tasks['degraded']} degraded"
+    )
+    print(
+        "  artifacts: "
+        f"{artifacts['typed_total']} typed / {artifacts['total']} total "
+        f"{artifacts['by_type']}"
+    )
+    print(
+        "  signals: "
+        f"empty_or_unstructured={signals['empty_or_unstructured']}, "
+        f"stdout_salvage={signals['stdout_salvage']}"
+    )
+    print(
+        "  tokens: "
+        f"{tokens['total_tokens']:,} total "
+        f"({tokens['measured_tokens_in']:,} in / {tokens['measured_tokens_out']:,} out measured)"
+    )
+    print(
+        "  efficiency: "
+        f"tokens_per_typed_artifact={efficiency['tokens_per_typed_artifact']}, "
+        f"degraded_rate={efficiency['degraded_rate']}"
+    )
+    return 0

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -1250,6 +1250,21 @@ def _build_tools() -> list[McpTool]:
             ),
         ),
         McpTool(
+            name="puppetmaster_job_receipt",
+            description=(
+                "Objective run-efficiency receipt for a job: degraded tasks, "
+                "typed artifacts (finding/risk/decision/patch), empty/unstructured "
+                "and stdout-salvage signals, token totals, and tokens per typed "
+                "artifact. Use when asking 'was this run useful or mostly "
+                "transport/degrade tax?' — complements puppetmaster_job_cost "
+                "(dollars) with structural yield. No prose synthesis."
+            ),
+            input_schema=job_schema(required=True),
+            handler=lambda args: run_cli(
+                ["receipt", require_string(args, "job_id"), "--json"], args
+            ),
+        ),
+        McpTool(
             name="puppetmaster_cursor_review",
             description="Run a Cursor SDK review worker through Puppetmaster and wait for completion.",
             input_schema=goal_schema(

--- a/puppetmaster/receipt.py
+++ b/puppetmaster/receipt.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Any
+
+from puppetmaster.models import Artifact, ArtifactType, parse_iso
+from puppetmaster.usage import aggregate_token_usage
+
+_TYPED = {ArtifactType.FINDING, ArtifactType.RISK, ArtifactType.DECISION}
+_EMPTY_MARKER = "empty-or-unstructured"
+_EMPTY_FAILURE = "empty_or_unstructured"
+
+
+def build_job_receipt(store: Any, job_id: str) -> dict[str, Any]:
+    """Return objective run-efficiency telemetry for one job.
+
+    This is deliberately not a stitched summary: no subjective accepted/rejected
+    labels, no prose synthesis. It only aggregates durable job/task/artifact
+    state so operators can spot context and transport tax at a glance.
+    """
+    job = store.get_job(job_id)
+    tasks = store.list_tasks(job_id)
+    artifacts = store.list_artifacts(job_id)
+    token_usage = aggregate_token_usage(artifacts)
+    by_type = Counter(str(artifact.type) for artifact in artifacts)
+    typed_total = sum(by_type[str(kind)] for kind in _TYPED)
+    degraded_tasks = _degraded_task_ids(artifacts)
+    empty_tasks = _empty_or_unstructured_task_ids(artifacts)
+    stdout_salvage = _stdout_salvage_count(artifacts)
+    elapsed = _elapsed_seconds(job.created_at, job.completed_at)
+    total_tokens = int(token_usage.get("total_tokens") or 0)
+    return {
+        "job_id": job_id,
+        "status": str(job.status),
+        "elapsed_seconds": elapsed,
+        "tasks": {
+            "total": len(tasks),
+            "complete": _task_status_count(tasks, "complete"),
+            "failed": _task_status_count(tasks, "failed"),
+            "blocked": _task_status_count(tasks, "blocked"),
+            "degraded": len(degraded_tasks),
+        },
+        "artifacts": {
+            "total": len(artifacts),
+            "typed_total": typed_total,
+            "by_type": dict(sorted(by_type.items())),
+        },
+        "signals": {
+            "empty_or_unstructured": len(empty_tasks),
+            "stdout_salvage": stdout_salvage,
+        },
+        "tokens": token_usage,
+        "efficiency": {
+            "tokens_per_typed_artifact": round(total_tokens / typed_total, 3) if typed_total else None,
+            "degraded_rate": round(len(degraded_tasks) / len(tasks), 3) if tasks else 0.0,
+        },
+    }
+
+
+def _task_status_count(tasks: list[Any], status: str) -> int:
+    return sum(1 for task in tasks if str(getattr(task, "status", "")) == status)
+
+
+def _degraded_task_ids(artifacts: list[Artifact]) -> set[str]:
+    return {
+        artifact.task_id
+        for artifact in artifacts
+        if artifact.type == ArtifactType.VERIFICATION
+        and str((artifact.payload or {}).get("result") or "").lower() == "degraded"
+    }
+
+
+def _empty_or_unstructured_task_ids(artifacts: list[Artifact]) -> set[str]:
+    out: set[str] = set()
+    for artifact in artifacts:
+        payload = artifact.payload or {}
+        evidence = " ".join(str(item) for item in (artifact.evidence or []))
+        failure = str(payload.get("failure") or "")
+        if _EMPTY_FAILURE in failure or _EMPTY_MARKER in evidence:
+            out.add(artifact.task_id)
+    return out
+
+
+def _stdout_salvage_count(artifacts: list[Artifact]) -> int:
+    count = 0
+    for artifact in artifacts:
+        payload = artifact.payload or {}
+        evidence = " ".join(str(item) for item in (artifact.evidence or []))
+        if _EMPTY_MARKER not in evidence and _EMPTY_FAILURE not in str(payload.get("failure") or ""):
+            continue
+        if any(key in payload for key in ("stdout_excerpt", "stdout_capture", "last_message_capture")):
+            count += 1
+    return count
+
+
+def _elapsed_seconds(created_at: str, completed_at: str | None) -> float | None:
+    if not created_at or not completed_at:
+        return None
+    try:
+        return round((parse_iso(completed_at) - parse_iso(created_at)).total_seconds(), 3)
+    except Exception:
+        return None

--- a/puppetmaster/receipt.py
+++ b/puppetmaster/receipt.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 from collections import Counter
-from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Optional
 
 from puppetmaster.models import Artifact, ArtifactType, parse_iso
 from puppetmaster.usage import aggregate_token_usage
 
-_TYPED = {ArtifactType.FINDING, ArtifactType.RISK, ArtifactType.DECISION}
+# Useful operator-facing outputs (not transport/meta). PATCH counts so implement
+# jobs are not scored as zero-typed when they only shipped a diff.
+_TYPED = {
+    ArtifactType.FINDING,
+    ArtifactType.RISK,
+    ArtifactType.DECISION,
+    ArtifactType.PATCH,
+}
 _EMPTY_MARKER = "empty-or-unstructured"
 _EMPTY_FAILURE = "empty_or_unstructured"
 
@@ -94,7 +100,7 @@ def _stdout_salvage_count(artifacts: list[Artifact]) -> int:
     return count
 
 
-def _elapsed_seconds(created_at: str, completed_at: str | None) -> float | None:
+def _elapsed_seconds(created_at: str, completed_at: Optional[str]) -> Optional[float]:
     if not created_at or not completed_at:
         return None
     try:

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -455,6 +455,15 @@ class PuppetmasterTests(unittest.TestCase):
                     ),
                     Artifact(
                         job_id=job.id,
+                        task_id="task_good",
+                        type=ArtifactType.PATCH,
+                        created_by="worker-good",
+                        payload={"change": "fix bug", "files": ["file.py"]},
+                        confidence=0.9,
+                        evidence=["file.py"],
+                    ),
+                    Artifact(
+                        job_id=job.id,
                         task_id="task_degraded",
                         type=ArtifactType.VERIFICATION,
                         created_by="worker-bad",
@@ -490,13 +499,14 @@ class PuppetmasterTests(unittest.TestCase):
         self.assertEqual(receipt["job_id"], job.id)
         self.assertEqual(receipt["tasks"]["total"], 2)
         self.assertEqual(receipt["tasks"]["degraded"], 1)
-        self.assertEqual(receipt["artifacts"]["typed_total"], 2)
+        self.assertEqual(receipt["artifacts"]["typed_total"], 3)
         self.assertEqual(receipt["artifacts"]["by_type"]["finding"], 1)
+        self.assertEqual(receipt["artifacts"]["by_type"]["patch"], 1)
         self.assertEqual(receipt["artifacts"]["by_type"]["risk"], 1)
         self.assertEqual(receipt["signals"]["empty_or_unstructured"], 1)
         self.assertEqual(receipt["signals"]["stdout_salvage"], 1)
         self.assertEqual(receipt["tokens"]["total_tokens"], 460)
-        self.assertEqual(receipt["efficiency"]["tokens_per_typed_artifact"], 230)
+        self.assertEqual(receipt["efficiency"]["tokens_per_typed_artifact"], round(460 / 3, 3))
         self.assertEqual(receipt["efficiency"]["degraded_rate"], 0.5)
 
     def test_job_receipt_command_parses_explicit_json_flag(self) -> None:

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -408,6 +408,106 @@ class PuppetmasterTests(unittest.TestCase):
             self.assertGreaterEqual(len(memory), 4)
             self.assertTrue(all(artifact.sha256 for artifact in artifacts))
 
+    def test_job_receipt_summarizes_run_efficiency_metrics(self) -> None:
+        from puppetmaster.receipt import build_job_receipt
+
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("audit the repo")
+            tasks = [
+                Task(
+                    id="task_good",
+                    job_id=job.id,
+                    role="review",
+                    instruction="find issues",
+                    adapter="codex",
+                    status=TaskStatus.COMPLETE,
+                ),
+                Task(
+                    id="task_degraded",
+                    job_id=job.id,
+                    role="audit",
+                    instruction="find drift",
+                    adapter="codex",
+                    status=TaskStatus.COMPLETE,
+                ),
+            ]
+            store.save_tasks(tasks)
+            store.save_artifacts(
+                [
+                    Artifact(
+                        job_id=job.id,
+                        task_id="task_good",
+                        type=ArtifactType.VERIFICATION,
+                        created_by="worker-good",
+                        payload={"check": "find issues", "result": "passed", "tokens_in": 100, "tokens_out": 20},
+                        confidence=0.9,
+                        evidence=["adapter:codex"],
+                    ),
+                    Artifact(
+                        job_id=job.id,
+                        task_id="task_good",
+                        type=ArtifactType.FINDING,
+                        created_by="worker-good",
+                        payload={"claim": "real finding"},
+                        confidence=0.9,
+                        evidence=["file.py:1"],
+                    ),
+                    Artifact(
+                        job_id=job.id,
+                        task_id="task_degraded",
+                        type=ArtifactType.VERIFICATION,
+                        created_by="worker-bad",
+                        payload={
+                            "check": "find drift",
+                            "result": "degraded",
+                            "failure": "empty_or_unstructured_codex_result",
+                            "tokens_in": 300,
+                            "tokens_out": 40,
+                        },
+                        confidence=0.65,
+                        evidence=["adapter:codex"],
+                    ),
+                    Artifact(
+                        job_id=job.id,
+                        task_id="task_degraded",
+                        type=ArtifactType.RISK,
+                        created_by="worker-bad",
+                        payload={
+                            "risk": "Codex call completed without structured Puppetmaster findings.",
+                            "mitigation": "Inspect stdout.",
+                            "stdout_excerpt": "{...}",
+                        },
+                        confidence=0.85,
+                        evidence=["adapter:codex", "result:empty-or-unstructured"],
+                    ),
+                ]
+            )
+            store.update_job_status(job.id, JobStatus.COMPLETE)
+
+            receipt = build_job_receipt(store, job.id)
+
+        self.assertEqual(receipt["job_id"], job.id)
+        self.assertEqual(receipt["tasks"]["total"], 2)
+        self.assertEqual(receipt["tasks"]["degraded"], 1)
+        self.assertEqual(receipt["artifacts"]["typed_total"], 2)
+        self.assertEqual(receipt["artifacts"]["by_type"]["finding"], 1)
+        self.assertEqual(receipt["artifacts"]["by_type"]["risk"], 1)
+        self.assertEqual(receipt["signals"]["empty_or_unstructured"], 1)
+        self.assertEqual(receipt["signals"]["stdout_salvage"], 1)
+        self.assertEqual(receipt["tokens"]["total_tokens"], 460)
+        self.assertEqual(receipt["efficiency"]["tokens_per_typed_artifact"], 230)
+        self.assertEqual(receipt["efficiency"]["degraded_rate"], 0.5)
+
+    def test_job_receipt_command_parses_explicit_json_flag(self) -> None:
+        from puppetmaster.cli._parser import build_parser
+
+        args = build_parser().parse_args(["receipt", "job_123", "--json"])
+
+        self.assertEqual(args.command, "receipt")
+        self.assertEqual(args.job_id, "job_123")
+        self.assertTrue(args.json)
+
     def test_live_artifact_feed_and_partial_summary_are_available(self) -> None:
         with TemporaryDirectory() as tmp:
             store = SwarmStore(Path(tmp) / ".puppetmaster")


### PR DESCRIPTION
## Summary
Add an explicit puppetmaster receipt <job_id> command for objective run-efficiency telemetry.
This keeps existing show, status, and cost behavior unchanged while giving operators one compact receipt for context/performance    tax: degraded tasks, typed artifacts, empty/unstructured signals, stdout-salvage markers, token totals, and tokens per typed    artifact.

## Why
 No direct answer for: “Was this run useful, or mostly transport/degrade/context tax?” Operators currently infer that    manually from stitched summaries, verification artifacts, token ledgers, and stdout captures.

## Tests

• python3 -m pytest tests/test_puppetmaster.py::PuppetmasterTests::test_job_receipt_summarizes_run_efficiency_metricstests/test_puppetmaster.py::PuppetmasterTests::test_job_receipt_command_parses_explicit_json_flag -q
• python3 -m py_compile puppetmaster/receipt.py puppetmaster/cli/_parser.py puppetmaster/cli/_dispatch.pypuppetmaster/cli/commands_gate.py
• python3 -m puppetmaster receipt <last_job> --json | python3 -m json.tool
• python3 -m pytest tests/test_puppetmaster.py -q -k 'not test_claude_and_codex_gate_on_resolvable_binary and nottest_setup_installs_hooks'