### PR TITLE
Keep default swarms read-only through routing

### DIFF
--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -2626,6 +2626,8 @@ def write_generated_swarm_config(args: JsonObject, roles: list[str], adapter: st
     min_capability = args.get("min_capability")
     required_tags = args.get("required_tags")
     workers = []
+    from puppetmaster.workers import ANALYSIS_NO_EDIT_PAYLOAD
+
     for role in roles:
         prompt = (
             f"Role: {role}\n"
@@ -2642,9 +2644,7 @@ def write_generated_swarm_config(args: JsonObject, roles: list[str], adapter: st
             # artifacts and must be able to review the caller's dirty diff.
             # If routing lands on an edit-capable adapter such as Codex, keep
             # it on the adapter's existing read-only/no-edit path.
-            "read_only": True,
-            "sandbox": "read-only",
-            "dangerously_bypass_approvals_and_sandbox": False,
+            **ANALYSIS_NO_EDIT_PAYLOAD,
         }
         if adapter == "cursor":
             payload["model"] = model

--- a/puppetmaster/workers.py
+++ b/puppetmaster/workers.py
@@ -53,6 +53,18 @@ class WorkerSpec:
     depends_on_roles: list[str] = field(default_factory=list)
 
 
+# Shared by DEFAULT_WORKERS and write_generated_swarm_config so analysis
+# swarms keep read-only intent when auto_route lands on an edit-capable
+# adapter (claude-code → permission_mode=plan; codex → sandbox read-only).
+# Without these, a Claude-only lock routing the "implement" *planning*
+# role to claude-code incorrectly takes acceptEdits and trips worktree
+# / dirty-tree guards.
+ANALYSIS_NO_EDIT_PAYLOAD = {
+    "read_only": True,
+    "sandbox": "read-only",
+    "dangerously_bypass_approvals_and_sandbox": False,
+}
+
 # Built-in worker specs ship with ``auto_route: True`` so any swarm
 # started via the MCP ``puppetmaster_start_*`` tools or ``python -m
 # puppetmaster run`` consults the router and lets each role land on
@@ -60,21 +72,9 @@ class WorkerSpec:
 # frontier for redteam/audit). If the user has not run
 # ``puppetmaster models init``, the orchestrator quietly skips routing
 # and falls back to the spec's declared adapter — opting in is safe.
-#
-# They also carry the explicit no-edit fields the generated custom-swarm
-# path sets, so a *default* analysis role keeps its read-only intent through
-# routing. Without these, a Claude-only platform lock auto-routing the
-# "implement" planning role to claude-code lands it at acceptEdits/full-edit
-# and trips the Git worktree/dirty-tree guards. ``read_only`` keeps
-# ``spec_edits_files`` False (→ ``swarm_mode`` == analysis) and drives the
-# claude-code adapter to ``permission_mode=plan``; ``sandbox='read-only'`` and
-# ``dangerously_bypass_approvals_and_sandbox=False`` do the same for the
-# codex/sandbox-aware adapters.
 _DEFAULT_AUTO_ROUTE_PAYLOAD = {
     "auto_route": True,
-    "read_only": True,
-    "sandbox": "read-only",
-    "dangerously_bypass_approvals_and_sandbox": False,
+    **ANALYSIS_NO_EDIT_PAYLOAD,
 }
 
 

--- a/puppetmaster/workers.py
+++ b/puppetmaster/workers.py
@@ -60,7 +60,22 @@ class WorkerSpec:
 # frontier for redteam/audit). If the user has not run
 # ``puppetmaster models init``, the orchestrator quietly skips routing
 # and falls back to the spec's declared adapter — opting in is safe.
-_DEFAULT_AUTO_ROUTE_PAYLOAD = {"auto_route": True}
+#
+# They also carry the explicit no-edit fields the generated custom-swarm
+# path sets, so a *default* analysis role keeps its read-only intent through
+# routing. Without these, a Claude-only platform lock auto-routing the
+# "implement" planning role to claude-code lands it at acceptEdits/full-edit
+# and trips the Git worktree/dirty-tree guards. ``read_only`` keeps
+# ``spec_edits_files`` False (→ ``swarm_mode`` == analysis) and drives the
+# claude-code adapter to ``permission_mode=plan``; ``sandbox='read-only'`` and
+# ``dangerously_bypass_approvals_and_sandbox=False`` do the same for the
+# codex/sandbox-aware adapters.
+_DEFAULT_AUTO_ROUTE_PAYLOAD = {
+    "auto_route": True,
+    "read_only": True,
+    "sandbox": "read-only",
+    "dangerously_bypass_approvals_and_sandbox": False,
+}
 
 
 DEFAULT_WORKERS = [

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -18014,6 +18014,69 @@ class PuppetmasterFrictionFixTests(unittest.TestCase):
             )
         )
 
+    def test_default_workers_carry_no_edit_fields(self) -> None:
+        """Every built-in worker payload declares the same explicit no-edit
+        fields the generated custom-swarm path sets, so a bare
+        ``puppetmaster_start_swarm`` preserves read-only intent through routing
+        (a Claude-only lock auto-routing the ``implement`` planning role to
+        claude-code must not become full-edit and trip the worktree guard)."""
+        from puppetmaster.workers import DEFAULT_WORKERS, swarm_mode
+
+        self.assertEqual(swarm_mode(DEFAULT_WORKERS), "analysis")
+        for spec in DEFAULT_WORKERS:
+            with self.subTest(role=spec.role):
+                self.assertTrue(spec.payload.get("auto_route"))
+                self.assertTrue(spec.payload.get("read_only"))
+                self.assertEqual(spec.payload.get("sandbox"), "read-only")
+                self.assertIs(
+                    spec.payload.get("dangerously_bypass_approvals_and_sandbox"),
+                    False,
+                )
+
+    def test_default_worker_routed_to_claude_code_plans_and_skips_guard(self) -> None:
+        """A default worker (the ``implement`` planning role) auto-routed to
+        claude-code must run at ``permission_mode=plan`` and skip the
+        write-capable worktree guard — sourced from the real DEFAULT_WORKERS
+        payload, not a hand-written one."""
+        from puppetmaster.workers import DEFAULT_WORKERS
+
+        spec = next(s for s in DEFAULT_WORKERS if s.role == "implement")
+        streamed = StreamedProcess(
+            returncode=0,
+            stdout='{"result":"Produced an implementation plan; no edits."}',
+            stderr="",
+            timed_out=False,
+            live_log_path=None,
+        )
+        task = Task(
+            id="t-default-claude-plan",
+            job_id="job-default-claude-plan",
+            role=spec.role,
+            instruction=spec.instruction,
+            adapter="claude-code",
+            payload={**spec.payload, "cwd": ".", "disable_codegraph": True},
+        )
+        dirty = {
+            "sha": "s",
+            "tree": "t",
+            "changed_files": ["puppetmaster/workers.py"],
+            "untracked_files": [],
+            "diff": "diff --git a/puppetmaster/workers.py b/puppetmaster/workers.py",
+        }
+        with patch("puppetmaster.adapters.resolve_command", return_value="/usr/bin/claude"), patch(
+            "puppetmaster.adapters.git_snapshot", side_effect=[dirty, dirty]
+        ), patch("puppetmaster.adapters.worktree_guard") as guard, patch(
+            "puppetmaster.adapters.run_streamed_subprocess", return_value=streamed
+        ) as run:
+            artifacts = ClaudeCodeAdapter().run(task, "goal", "worker")
+
+        guard.assert_not_called()
+        command = run.call_args.kwargs["command"]
+        self.assertIn("--permission-mode", command)
+        self.assertIn("plan", command)
+        self.assertEqual(artifacts[0].payload["permission_mode"], "plan")
+        self.assertIn("permission_mode:plan", artifacts[0].evidence)
+
     # --- browser swarm (first-class browser-QA via Hermes) --------------
     def test_browser_spec_carries_browser_toolset_and_guardrails(self) -> None:
         from puppetmaster.browser import (

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -18020,18 +18020,18 @@ class PuppetmasterFrictionFixTests(unittest.TestCase):
         ``puppetmaster_start_swarm`` preserves read-only intent through routing
         (a Claude-only lock auto-routing the ``implement`` planning role to
         claude-code must not become full-edit and trip the worktree guard)."""
-        from puppetmaster.workers import DEFAULT_WORKERS, swarm_mode
+        from puppetmaster.workers import (
+            ANALYSIS_NO_EDIT_PAYLOAD,
+            DEFAULT_WORKERS,
+            swarm_mode,
+        )
 
         self.assertEqual(swarm_mode(DEFAULT_WORKERS), "analysis")
         for spec in DEFAULT_WORKERS:
             with self.subTest(role=spec.role):
                 self.assertTrue(spec.payload.get("auto_route"))
-                self.assertTrue(spec.payload.get("read_only"))
-                self.assertEqual(spec.payload.get("sandbox"), "read-only")
-                self.assertIs(
-                    spec.payload.get("dangerously_bypass_approvals_and_sandbox"),
-                    False,
-                )
+                for key, value in ANALYSIS_NO_EDIT_PAYLOAD.items():
+                    self.assertEqual(spec.payload.get(key), value)
 
     def test_default_worker_routed_to_claude_code_plans_and_skips_guard(self) -> None:
         """A default worker (the ``implement`` planning role) auto-routed to


### PR DESCRIPTION
## Summary

- mark the built-in `DEFAULT_WORKERS` payload as explicitly read-only
- preserve analysis intent when default swarm roles auto-route to Claude Code or another edit-capable adapter
- add regression coverage for analysis classification, Claude `permission_mode=plan`, and clean-tree guard bypass

## Why

This is a narrow follow-up to #12, integrated as `9eb22ee`. That change made generated custom MCP swarm configs read-only, but a bare `puppetmaster_start_swarm` still uses `DEFAULT_WORKERS`, whose shared payload only carried `auto_route: true`.

With a Claude-only platform lock, the semantic `implement` planning role can therefore route to the full-edit Claude Code adapter, use `acceptEdits`, and incorrectly require a Git worktree or clean tree. Carrying the same no-edit fields as the generated-swarm path keeps default swarms on the adapter's existing analysis path without changing real edit or implement verbs.

## Tests

- `python3 -m unittest tests.test_puppetmaster.PuppetmasterFrictionFixTests.test_default_workers_carry_no_edit_fields tests.test_puppetmaster.PuppetmasterFrictionFixTests.test_default_worker_routed_to_claude_code_plans_and_skips_guard`
- `python3 -m unittest -v tests.test_puppetmaster.PuppetmasterFrictionFixTests` — 41 passed
- `uv run --with pytest --with pyyaml python -m pytest tests/test_puppetmaster.py -q` — 1,173 passed, 2 skipped
- `python3 -m puppetmaster doctor`
- `python3 -m puppetmaster run "Contributor smoke test" --config examples/enterprise-workflow.json`
- `PUPPETMASTER_MODELS_PATH=/tmp/puppetmaster-no-models.json python3 -m puppetmaster crash-demo`
- `git diff --check`

A full local `unittest discover` completed 1,302 tests with two environment-dependent failures; both reproduce unchanged on a detached `upstream/main` worktree under the same environment (`AgenticLoopTests.test_implement_verify_bounces_failure_then_accepts_on_pass` and `SetupHooksStepTests.test_setup_installs_hooks`).
