### PR TITLE
Normalize flat Codex artifacts

### DIFF
--- a/puppetmaster/adapters/cursor.py
+++ b/puppetmaster/adapters/cursor.py
@@ -588,17 +588,9 @@ def cursor_artifact_from_item(
             wrapped = item[wrapped_type]
             item = {**wrapped, "type": wrapped.get("type", wrapped_type)}
         elif adapter == "codex":
-            semantic_types = [
-                kind
-                for kind, field in (
-                    ("finding", "claim"),
-                    ("risk", "risk"),
-                    ("decision", "decision"),
-                )
-                if field in item
-            ]
-            if len(semantic_types) == 1:
-                item = {**item, "type": semantic_types[0]}
+            inferred = _infer_codex_flat_semantic_type(item)
+            if inferred:
+                item = {**item, "type": inferred}
     artifact_type = str(item.get("type") or "").lower().strip()
     if artifact_type in {"findings", "swarm.finding"}:
         artifact_type = "finding"
@@ -717,6 +709,63 @@ def _json_prefix_decode(text: str) -> Optional[Any]:
             continue
         if isinstance(decoded, (dict, list)):
             return decoded
+    return None
+
+
+def _meaningful_semantic_string(value: object) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _codex_semantic_field_state(item: dict[str, Any], field: str) -> str:
+    """Classify a flat semantic field as absent, meaningful, or malformed."""
+    if field not in item:
+        return "absent"
+    value = item[field]
+    if value is None:
+        return "absent"
+    if _meaningful_semantic_string(value) is not None:
+        return "meaningful"
+    if isinstance(value, str):
+        return "absent"
+    return "malformed"
+
+
+def _infer_codex_flat_semantic_type(item: dict[str, Any]) -> Optional[str]:
+    """Infer artifact type from flat Codex items using semantic values, not keys.
+
+    Finding accepts ``summary`` as a fallback (consistent with typed parsing).
+    Priority is finding > risk > decision so findings that carry risk/severity
+    metadata are not treated as ambiguous.
+    """
+    for field in ("claim", "risk", "decision"):
+        if _codex_semantic_field_state(item, field) == "malformed":
+            return None
+
+    finding_state = _codex_semantic_field_state(item, "claim")
+    if finding_state == "absent" and "summary" in item:
+        summary = item["summary"]
+        if summary is None:
+            pass
+        elif _meaningful_semantic_string(summary) is not None:
+            finding_state = "meaningful"
+        elif not isinstance(summary, str):
+            return None
+
+    has_finding = finding_state == "meaningful"
+    has_risk = _codex_semantic_field_state(item, "risk") == "meaningful"
+    has_decision = _codex_semantic_field_state(item, "decision") == "meaningful"
+
+    if has_finding:
+        return "finding"
+    if has_risk and has_decision:
+        return None
+    if has_risk:
+        return "risk"
+    if has_decision:
+        return "decision"
     return None
 
 

--- a/puppetmaster/adapters/cursor.py
+++ b/puppetmaster/adapters/cursor.py
@@ -587,6 +587,18 @@ def cursor_artifact_from_item(
         if wrapped_type:
             wrapped = item[wrapped_type]
             item = {**wrapped, "type": wrapped.get("type", wrapped_type)}
+        elif adapter == "codex":
+            semantic_types = [
+                kind
+                for kind, field in (
+                    ("finding", "claim"),
+                    ("risk", "risk"),
+                    ("decision", "decision"),
+                )
+                if field in item
+            ]
+            if len(semantic_types) == 1:
+                item = {**item, "type": semantic_types[0]}
     artifact_type = str(item.get("type") or "").lower().strip()
     if artifact_type in {"findings", "swarm.finding"}:
         artifact_type = "finding"

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -25165,6 +25165,214 @@ class JsonPrefixDecodeTests(unittest.TestCase):
             [],
         )
 
+    def test_flat_finding_with_risk_metadata_is_not_ambiguous(self) -> None:
+        """A finding that carries risk/severity metadata must stay a finding."""
+        from puppetmaster.adapters import cursor_result_artifacts
+
+        task = Task(
+            job_id="job",
+            role="codex-review",
+            instruction="inspect",
+            adapter="codex",
+            payload={},
+        )
+        text = json.dumps(
+            {
+                "artifacts": [
+                    {
+                        "claim": "behavior",
+                        "risk": "high",
+                        "severity": "critical",
+                        "evidence": ["a.py:1"],
+                        "confidence": 0.9,
+                    }
+                ]
+            }
+        )
+
+        artifacts = cursor_result_artifacts(task, "worker-codex", text, adapter="codex")
+
+        self.assertEqual(len(artifacts), 1)
+        self.assertEqual(artifacts[0].type, ArtifactType.FINDING)
+        self.assertEqual(artifacts[0].payload["claim"], "behavior")
+        self.assertEqual(artifacts[0].payload["risk"], "high")
+        self.assertEqual(artifacts[0].payload["severity"], "critical")
+
+    def test_flat_semantic_null_and_empty_companions_are_ignored(self) -> None:
+        from puppetmaster.adapters import cursor_result_artifacts
+
+        task = Task(
+            job_id="job",
+            role="codex-review",
+            instruction="inspect",
+            adapter="codex",
+            payload={},
+        )
+        text = json.dumps(
+            {
+                "artifacts": [
+                    {
+                        "claim": "behavior",
+                        "risk": None,
+                        "decision": "",
+                        "evidence": ["a.py:1"],
+                        "confidence": 0.9,
+                    }
+                ]
+            }
+        )
+
+        artifacts = cursor_result_artifacts(task, "worker-codex", text, adapter="codex")
+
+        self.assertEqual(len(artifacts), 1)
+        self.assertEqual(artifacts[0].type, ArtifactType.FINDING)
+
+    def test_flat_semantic_malformed_non_string_primary_is_rejected(self) -> None:
+        from puppetmaster.adapters import cursor_result_artifacts
+
+        task = Task(
+            job_id="job",
+            role="codex-review",
+            instruction="inspect",
+            adapter="codex",
+            payload={},
+        )
+        for item in (
+            {"claim": 123, "evidence": ["a.py:1"], "confidence": 0.9},
+            {"risk": {"detail": "nested"}, "evidence": ["a.py:1"], "confidence": 0.9},
+            {"decision": ["ship"], "evidence": ["a.py:1"], "confidence": 0.9},
+        ):
+            with self.subTest(item=item):
+                text = json.dumps({"artifacts": [item]})
+                self.assertEqual(
+                    cursor_result_artifacts(task, "worker-codex", text, adapter="codex"),
+                    [],
+                )
+
+    def test_flat_semantic_empty_primary_values_are_rejected(self) -> None:
+        from puppetmaster.adapters import cursor_result_artifacts
+
+        task = Task(
+            job_id="job",
+            role="codex-review",
+            instruction="inspect",
+            adapter="codex",
+            payload={},
+        )
+        text = json.dumps(
+            {
+                "artifacts": [
+                    {
+                        "claim": "",
+                        "risk": "   ",
+                        "decision": None,
+                        "evidence": ["a.py:1"],
+                        "confidence": 0.9,
+                    }
+                ]
+            }
+        )
+
+        self.assertEqual(
+            cursor_result_artifacts(task, "worker-codex", text, adapter="codex"),
+            [],
+        )
+
+    def test_flat_finding_summary_fallback_matches_typed_behavior(self) -> None:
+        from puppetmaster.adapters import cursor_result_artifacts
+
+        task = Task(
+            job_id="job",
+            role="codex-review",
+            instruction="inspect",
+            adapter="codex",
+            payload={},
+        )
+        text = json.dumps(
+            {
+                "artifacts": [
+                    {
+                        "summary": "behavior",
+                        "evidence": ["a.py:1"],
+                        "confidence": 0.9,
+                    }
+                ]
+            }
+        )
+
+        artifacts = cursor_result_artifacts(task, "worker-codex", text, adapter="codex")
+
+        self.assertEqual(len(artifacts), 1)
+        self.assertEqual(artifacts[0].type, ArtifactType.FINDING)
+        self.assertEqual(artifacts[0].payload["claim"], "behavior")
+
+    def test_codex_flat_lifecycle_promotion_preserves_metadata(self) -> None:
+        """End-to-end: flat finding with risk metadata promotes without degrading."""
+        agent_text = json.dumps(
+            {
+                "artifacts": [
+                    {
+                        "claim": "behavior",
+                        "risk": "high",
+                        "evidence": ["a.py:1"],
+                        "confidence": 0.9,
+                    }
+                ]
+            }
+        )
+        events_stdout = "\n".join(
+            [
+                json.dumps({"type": "thread.started", "thread_id": "th_test"}),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {"type": "agent_message", "text": agent_text},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "turn.completed",
+                        "usage": {"input_tokens": 1, "output_tokens": 1},
+                    }
+                ),
+            ]
+        )
+        streamed = StreamedProcess(
+            returncode=0,
+            stdout=events_stdout,
+            stderr="",
+            timed_out=False,
+            live_log_path=None,
+        )
+        task = Task(
+            id="t-codex-flat-meta",
+            job_id="job-codex-flat-meta",
+            role="codex-review",
+            adapter="codex",
+            instruction="Review the repo.",
+            payload={
+                "cwd": str(Path.cwd()),
+                "sandbox": "read-only",
+                "disable_codegraph": True,
+            },
+        )
+        clean = {"sha": "s", "changed_files": [], "untracked_files": [], "diff": ""}
+        with patch(
+            "puppetmaster.adapters.resolve_command", return_value="/usr/bin/codex"
+        ), patch(
+            "puppetmaster.adapters.git_snapshot", side_effect=[clean, clean]
+        ), patch(
+            "puppetmaster.adapters.run_streamed_subprocess", return_value=streamed
+        ):
+            artifacts = CodexAdapter().run(task, "goal", "worker")
+
+        self.assertEqual(artifacts[0].payload["result"], "passed")
+        self.assertIsNone(artifacts[0].payload["failure"])
+        self.assertEqual(len(artifacts), 2)
+        self.assertEqual(artifacts[1].type, ArtifactType.FINDING)
+        self.assertEqual(artifacts[1].payload["claim"], "behavior")
+        self.assertEqual(artifacts[1].payload["risk"], "high")
+
     def test_typed_artifact_with_nested_wrapper_dict_is_not_clobbered(self) -> None:
         """A typed item that also carries a nested finding/risk/decision dict
         must keep its top-level fields — unwrap only when type is absent.

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -6834,6 +6834,91 @@ print(json.dumps({"result": "ok", "usage": {"input_tokens": 321, "output_tokens"
         )
         self.assertFalse(any(a.type == ArtifactType.RISK and "without structured" in a.payload.get("risk", "") for a in artifacts))
 
+    def test_codex_read_only_flat_artifacts_promote_without_degrading(self) -> None:
+        agent_text = json.dumps(
+            {
+                "artifacts": [
+                    {
+                        "decision": "first",
+                        "why": "one",
+                        "evidence": ["a.py:1"],
+                        "confidence": 0.9,
+                    },
+                    {
+                        "decision": "second",
+                        "why": "two",
+                        "evidence": ["b.py:2"],
+                        "confidence": 0.8,
+                    },
+                    {
+                        "risk": "breakage",
+                        "mitigation": "test",
+                        "evidence": ["c.py:3"],
+                        "confidence": 0.7,
+                    },
+                ]
+            }
+        )
+        events_stdout = "\n".join(
+            [
+                json.dumps({"type": "thread.started", "thread_id": "th_test"}),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {"type": "agent_message", "text": agent_text},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "turn.completed",
+                        "usage": {"input_tokens": 1, "output_tokens": 1},
+                    }
+                ),
+            ]
+        )
+        streamed = StreamedProcess(
+            returncode=0,
+            stdout=events_stdout,
+            stderr="",
+            timed_out=False,
+            live_log_path=None,
+        )
+        task = Task(
+            id="t-codex-flat",
+            job_id="job-codex-flat",
+            role="codex-review",
+            adapter="codex",
+            instruction="Review the repo.",
+            payload={
+                "cwd": str(Path.cwd()),
+                "sandbox": "read-only",
+                "disable_codegraph": True,
+            },
+        )
+        clean = {"sha": "s", "changed_files": [], "untracked_files": [], "diff": ""}
+        with patch(
+            "puppetmaster.adapters.resolve_command", return_value="/usr/bin/codex"
+        ), patch(
+            "puppetmaster.adapters.git_snapshot", side_effect=[clean, clean]
+        ), patch(
+            "puppetmaster.adapters.run_streamed_subprocess", return_value=streamed
+        ):
+            artifacts = CodexAdapter().run(task, "goal", "worker")
+
+        self.assertEqual(artifacts[0].payload["result"], "passed")
+        self.assertIsNone(artifacts[0].payload["failure"])
+        self.assertEqual(
+            [artifact.type for artifact in artifacts[1:]],
+            [ArtifactType.DECISION, ArtifactType.DECISION, ArtifactType.RISK],
+        )
+        self.assertFalse(
+            any(
+                artifact.type == ArtifactType.RISK
+                and "without structured" in artifact.payload.get("risk", "")
+                for artifact in artifacts
+            )
+        )
+
     def test_codex_read_only_prose_still_degrades(self) -> None:
         """Read-only Codex (review-style) keeps strict semantics: prose without
         structured artifacts is degraded, with the RISK marker preserved."""
@@ -24913,6 +24998,172 @@ class JsonPrefixDecodeTests(unittest.TestCase):
             [ArtifactType.FINDING, ArtifactType.RISK, ArtifactType.DECISION],
         )
         self.assertEqual([a.evidence for a in artifacts], [["a.py:1"], ["b.py:2"], ["c.py:3"]])
+
+    def test_flat_semantic_artifacts_parse_when_unambiguous(self) -> None:
+        from puppetmaster.adapters import cursor_result_artifacts
+
+        task = Task(
+            job_id="job",
+            role="codex-review",
+            instruction="inspect",
+            adapter="codex",
+            payload={},
+        )
+        text = json.dumps(
+            {
+                "artifacts": [
+                    {
+                        "decision": "first",
+                        "why": "one",
+                        "evidence": ["a.py:1"],
+                        "confidence": 0.9,
+                    },
+                    {
+                        "decision": "second",
+                        "why": "two",
+                        "evidence": ["b.py:2"],
+                        "confidence": 0.8,
+                    },
+                    {
+                        "risk": "breakage",
+                        "mitigation": "test",
+                        "evidence": ["c.py:3"],
+                        "confidence": 0.7,
+                    },
+                ]
+            }
+        )
+
+        artifacts = cursor_result_artifacts(task, "worker-codex", text, adapter="codex")
+
+        self.assertEqual(
+            [artifact.type for artifact in artifacts],
+            [ArtifactType.DECISION, ArtifactType.DECISION, ArtifactType.RISK],
+        )
+        self.assertEqual(
+            [artifact.payload.get("decision") or artifact.payload.get("risk") for artifact in artifacts],
+            ["first", "second", "breakage"],
+        )
+
+    def test_flat_finding_parses_when_unambiguous(self) -> None:
+        from puppetmaster.adapters import cursor_result_artifacts
+
+        task = Task(
+            job_id="job",
+            role="codex-review",
+            instruction="inspect",
+            adapter="codex",
+            payload={},
+        )
+        text = json.dumps(
+            {
+                "artifacts": [
+                    {
+                        "claim": "behavior",
+                        "evidence": ["a.py:1"],
+                        "confidence": 0.9,
+                    }
+                ]
+            }
+        )
+
+        artifacts = cursor_result_artifacts(task, "worker-codex", text, adapter="codex")
+
+        self.assertEqual(len(artifacts), 1)
+        self.assertEqual(artifacts[0].type, ArtifactType.FINDING)
+        self.assertEqual(artifacts[0].payload["claim"], "behavior")
+
+    def test_ambiguous_flat_semantic_artifact_is_rejected(self) -> None:
+        from puppetmaster.adapters import cursor_result_artifacts
+
+        task = Task(
+            job_id="job",
+            role="codex-review",
+            instruction="inspect",
+            adapter="codex",
+            payload={},
+        )
+        text = json.dumps(
+            {
+                "artifacts": [
+                    {
+                        "risk": "breakage",
+                        "decision": "ship",
+                        "evidence": ["a.py:1"],
+                        "confidence": 0.9,
+                    }
+                ]
+            }
+        )
+
+        self.assertEqual(
+            cursor_result_artifacts(task, "worker-codex", text, adapter="codex"),
+            [],
+        )
+
+    def test_flat_semantic_inference_is_codex_scoped(self) -> None:
+        from puppetmaster.adapters import (
+            cursor_artifact_from_item,
+            cursor_result_artifacts,
+        )
+
+        task = Task(
+            job_id="job",
+            role="review",
+            instruction="inspect",
+            adapter="codex",
+            payload={},
+        )
+        item = {
+            "claim": "behavior",
+            "evidence": ["a.py:1"],
+            "confidence": 0.9,
+        }
+        text = json.dumps({"artifacts": [item]})
+
+        for adapter in ("cursor-sdk", "hermes", "openai"):
+            with self.subTest(adapter=adapter):
+                self.assertEqual(
+                    cursor_result_artifacts(
+                        task,
+                        f"worker-{adapter}",
+                        text,
+                        adapter=adapter,
+                    ),
+                    [],
+                )
+        self.assertIsNone(
+            cursor_artifact_from_item(
+                task,
+                "worker-agentic",
+                item,
+                adapter="agentic",
+            )
+        )
+
+    def test_codex_flat_semantic_item_requires_artifact_container(self) -> None:
+        from puppetmaster.adapters import cursor_result_artifacts
+
+        task = Task(
+            job_id="job",
+            role="codex-review",
+            instruction="inspect",
+            adapter="codex",
+            payload={},
+        )
+        text = json.dumps(
+            {
+                "decision": "ship",
+                "why": "tested",
+                "evidence": ["a.py:1"],
+                "confidence": 0.9,
+            }
+        )
+
+        self.assertEqual(
+            cursor_result_artifacts(task, "worker-codex", text, adapter="codex"),
+            [],
+        )
 
     def test_typed_artifact_with_nested_wrapper_dict_is_not_clobbered(self) -> None:
         """A typed item that also carries a nested finding/risk/decision dict


### PR DESCRIPTION
 ## Summary

 - recognize unambiguous flat `claim`, `risk`, and `decision` objects from Codex responses
 - preserve existing typed and nested-wrapper behavior
 - reject ambiguous flat objects
 - keep inference Codex-specific so other adapters remain unchanged
 - add parser and complete Codex lifecycle regression coverage

 ## Problem

 A successful Codex read-only worker returned exit code 0 and useful JSON inside an `artifacts` container. Because its objects lacked explicit `type` fields, Puppetmaster discarded them and incorrectly classified the run as `empty-or-unstructured`.

 ## Testing

 - full pytest suite: 1220 passed, 2 skipped
 - contribution unittest suite: 1594 passed, 2 skipped
 - focused parser and Codex tests: 27 passed
 - enterprise workflow smoke test passed
 - isolated crash-recovery demo recovered one abandoned task