### PR TITLE
Add Grok Bot remote MCP e2e fixture under examples/

### DIFF
--- a/docs/GROK_BOT.md
+++ b/docs/GROK_BOT.md
@@ -228,3 +228,4 @@ See also [SECURITY.md](SECURITY.md) — the "no remote control" claim now has th
 - [ADAPTERS.md](ADAPTERS.md) — worker adapters (Grok Bot is a *pilot*, not an adapter)
 - [CLI_REFERENCE.md](CLI_REFERENCE.md) — `mcp serve-remote` flags
 - [SECURITY.md](SECURITY.md) — threat model
+- [examples/grok-bot-remote-e2e/](../examples/grok-bot-remote-e2e/) — shippable fixture cwd for Plugins review/implement e2e

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,4 +19,6 @@ puppetmaster run "demo goal" --config examples/enterprise-workflow.json
 
 The [`transcripts/`](transcripts) folder holds captured example outputs for reference.
 
+[`grok-bot-remote-e2e/`](grok-bot-remote-e2e) is a tiny Node fixture workspace for Grok Bot Plugins → Puppetmaster remote MCP review/implement validation (see [docs/GROK_BOT.md](../docs/GROK_BOT.md)).
+
 The workflow config schema (roles, adapters, payloads, routing overrides, DAG edges) is documented in [docs/CLI_REFERENCE.md](../docs/CLI_REFERENCE.md).

--- a/examples/grok-bot-remote-e2e/.gitignore
+++ b/examples/grok-bot-remote-e2e/.gitignore
@@ -1,0 +1,30 @@
+# Dependencies
+node_modules/
+package-lock.json
+npm-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Env / secrets
+.env
+.env.*
+!.env.example
+
+# Puppetmaster / CodeGraph local state
+.puppetmaster/
+.codegraph/codegraph.db
+.codegraph/codegraph.db-*
+
+# Logs and OS junk
+*.log
+.DS_Store
+Thumbs.db
+*.swp
+*~
+
+# Build / coverage artifacts
+dist/
+build/
+coverage/
+.coverage
+.nyc_output/

--- a/examples/grok-bot-remote-e2e/GROK_BOT_E2E.md
+++ b/examples/grok-bot-remote-e2e/GROK_BOT_E2E.md
@@ -1,0 +1,10 @@
+# Grok Bot e2e — baseline OK
+
+Marker for the Grok Bot Plugins → Puppetmaster remote MCP review path.
+
+Status: **baseline OK** — fixture workspace is present, `package.json` /
+`index.js` resolve, and a read-only review/swarm against this directory should
+succeed without inventing APIs.
+
+Pair with [docs/GROK_BOT.md](../../docs/GROK_BOT.md) (`mcp serve-remote`,
+supervise or implement scope, tunnel + Add MCP server).

--- a/examples/grok-bot-remote-e2e/GROK_BOT_IMPLEMENT_OK.md
+++ b/examples/grok-bot-remote-e2e/GROK_BOT_IMPLEMENT_OK.md
@@ -1,0 +1,11 @@
+# Grok Bot e2e — implement path
+
+Marker for the Grok Bot Plugins → Puppetmaster remote MCP **implement** path
+(`--scope implement` / `puppetmaster_start_implement` / `puppetmaster_edit`).
+
+Status: **placeholder** — an implement job may update this file (or append a
+short line below) to record a successful full-edit pass against this fixture.
+Do not delete the file; keep it tracked so dirty-tree / untracked-marker
+noise does not reappear.
+
+<!-- implement job may append below this line -->

--- a/examples/grok-bot-remote-e2e/README.md
+++ b/examples/grok-bot-remote-e2e/README.md
@@ -1,0 +1,44 @@
+# Grok Bot remote MCP e2e fixture
+
+Tiny Node workspace used as the **target cwd** when validating Grok Bot
+Plugins against Puppetmaster's authenticated remote MCP transport
+(`python -m puppetmaster mcp serve-remote`).
+
+It is not a product sample and does not define new MCP APIs. Connector setup,
+scopes, and the pilot loop live in [docs/GROK_BOT.md](../../docs/GROK_BOT.md).
+
+## Why this exists
+
+A live Grok Bot box once used a scratch workdir that accidentally tracked
+`node_modules`, lacked a `.gitignore`, and left implement markers untracked.
+This fixture is the shippable replacement: ignore rules, a real `main`, a
+green `npm test`, and tracked e2e markers.
+
+## Setup
+
+```bash
+cd examples/grok-bot-remote-e2e
+npm install --package-lock=false --no-audit
+npm test
+```
+
+`@cursor/sdk` uses the same major range as the repo root (`^1.0.26`) so a
+Cursor-adapter worker can resolve the SDK when this directory is the job cwd.
+
+## Pairing with remote MCP
+
+1. From the Puppetmaster repo (or any install), start remote MCP per
+   [GROK_BOT.md](../../docs/GROK_BOT.md) — typically
+   `python -m puppetmaster mcp serve-remote --scope supervise` (or
+   `--scope implement` when testing full-edit), then expose `/mcp` via a TLS
+   tunnel if Grok Bot is off-box.
+2. In Grok Bot → Add MCP server: URL `https://<tunnel-host>/mcp`, header
+   `Authorization: Bearer <PUPPETMASTER_MCP_TOKEN>`, streamable HTTP.
+3. Point review/implement jobs at **this directory** as `cwd` (or clone/copy
+   it). Markers:
+   - [`GROK_BOT_E2E.md`](GROK_BOT_E2E.md) — baseline / review path OK
+   - [`GROK_BOT_IMPLEMENT_OK.md`](GROK_BOT_IMPLEMENT_OK.md) — tracked
+     placeholder the implement job may update
+
+Do **not** commit `node_modules/`, `.env`, or `.puppetmaster/` state — all are
+gitignored here.

--- a/examples/grok-bot-remote-e2e/index.js
+++ b/examples/grok-bot-remote-e2e/index.js
@@ -1,0 +1,11 @@
+/**
+ * Minimal entry for the Grok Bot remote-MCP e2e fixture.
+ * Exists so package.json `main` resolves and review/implement workers
+ * have a real source file to touch — not a production API.
+ */
+
+export const FIXTURE_NAME = "puppetmaster-grok-bot-e2e";
+
+export function hello(name = "Grok Bot") {
+  return `hello from ${FIXTURE_NAME}, ${name}`;
+}

--- a/examples/grok-bot-remote-e2e/index.test.js
+++ b/examples/grok-bot-remote-e2e/index.test.js
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { FIXTURE_NAME, hello } from "./index.js";
+
+test("fixture exports a stable name", () => {
+  assert.equal(FIXTURE_NAME, "puppetmaster-grok-bot-e2e");
+});
+
+test("hello returns a greeting", () => {
+  assert.match(hello("e2e"), /puppetmaster-grok-bot-e2e/);
+  assert.match(hello("e2e"), /e2e/);
+});

--- a/examples/grok-bot-remote-e2e/package.json
+++ b/examples/grok-bot-remote-e2e/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "puppetmaster-grok-bot-e2e",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Minimal fixture workspace for Grok Bot Plugins → Puppetmaster remote MCP review/implement e2e validation.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --check index.js && node --test"
+  },
+  "dependencies": {
+    "@cursor/sdk": "^1.0.26"
+  },
+  "keywords": [
+    "puppetmaster",
+    "grok-bot",
+    "remote-mcp",
+    "e2e"
+  ],
+  "license": "MIT"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `examples/grok-bot-remote-e2e/` as a shippable fixture cwd for Grok Bot Plugins → Puppetmaster remote MCP review/implement validation (follow-up to the scratch workdir that tracked `node_modules` and left implement markers untracked).
- Include `.gitignore` (node_modules, logs, OS junk, Puppetmaster/CodeGraph state, `.env`), `package.json` (`puppetmaster-grok-bot-e2e`, `@cursor/sdk` `^1.0.26`, real `main` + green `npm test`), minimal `index.js` / `index.test.js`, tracked markers `GROK_BOT_E2E.md` + `GROK_BOT_IMPLEMENT_OK.md`, and a short README aligned with `docs/GROK_BOT.md`.
- Cross-link from `examples/README.md` and a single Related-docs line in `docs/GROK_BOT.md`. No remote MCP runtime changes.

## Test plan
- [ ] `cd examples/grok-bot-remote-e2e && npm install --package-lock=false --no-audit && npm test` exits 0
- [ ] `git check-ignore -v examples/grok-bot-remote-e2e/node_modules` confirms ignore; no `node_modules` in the PR diff
- [ ] CI matrix (unittest + existing examples JSON smokes) stays green
- [ ] Optional live: point Grok Bot remote MCP job `cwd` at this fixture; review uses `GROK_BOT_E2E.md`, implement may update `GROK_BOT_IMPLEMENT_OK.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bca4c75d-44b3-4ed6-ae23-886eb46cfc79?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bca4c75d-44b3-4ed6-ae23-886eb46cfc79&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

