### PR TITLE
fix: prefer exact model registry IDs over aliases

### DIFF
--- a/puppetmaster/model_registry.py
+++ b/puppetmaster/model_registry.py
@@ -1165,19 +1165,25 @@ def resolve_model_pin(
     if not needle:
         return None
 
+    eligible = [
+        spec
+        for spec in enabled_specs(registry)
+        if adapter is None or spec.adapter == adapter
+    ]
+    exact_ids = [spec for spec in eligible if spec.id == needle]
+
     token = _normalize_model_token(needle.split("/")[-1])
-    candidates: list[ModelSpec] = []
-    for spec in enabled_specs(registry):
-        if adapter is not None and spec.adapter != adapter:
-            continue
-        if spec.id == needle or spec.adapter_model_name == needle:
-            candidates.append(spec)
-            continue
-        if token and (
-            _normalize_model_token(spec.adapter_model_name) == token
-            or _normalize_model_token(spec.id.split("/")[-1]) == token
-        ):
-            candidates.append(spec)
+    candidates: list[ModelSpec] = list(exact_ids)
+    if not candidates:
+        for spec in eligible:
+            if spec.adapter_model_name == needle:
+                candidates.append(spec)
+                continue
+            if token and (
+                _normalize_model_token(spec.adapter_model_name) == token
+                or _normalize_model_token(spec.id.split("/")[-1]) == token
+            ):
+                candidates.append(spec)
 
     if not candidates:
         return None

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -15153,6 +15153,37 @@ class CursorModelPinTests(unittest.TestCase):
             self.assertEqual(pin.registry_id, "cursor/grok-4-5")
             self.assertEqual(pin.adapter_model_name, "grok-4.5")
 
+    def test_resolve_exact_registry_id_wins_over_ambiguous_model_alias(self) -> None:
+        from puppetmaster.model_registry import ModelSpec, resolve_model_pin
+
+        registry = [
+            ModelSpec(
+                id="agentic/gpt-5.6-sol",
+                adapter="agentic",
+                adapter_model_name="gpt-5.6-sol",
+                enabled=True,
+                payload_defaults={"provider": "openai-api"},
+            ),
+            ModelSpec(
+                id="agentic/openai-codex/gpt-5.6-sol",
+                adapter="agentic",
+                adapter_model_name="gpt-5.6-sol",
+                enabled=True,
+                payload_defaults={"provider": "openai-codex"},
+            ),
+        ]
+
+        pin = resolve_model_pin(
+            "agentic/gpt-5.6-sol",
+            registry,
+            adapter="agentic",
+        )
+
+        self.assertIsNotNone(pin)
+        assert pin is not None
+        self.assertEqual(pin.registry_id, "agentic/gpt-5.6-sol")
+        self.assertEqual(pin.spec.payload_defaults["provider"], "openai-api")
+
     def test_resolve_rejects_ambiguous_pin(self) -> None:
         from puppetmaster.model_registry import AmbiguousModelPinError, ModelSpec, resolve_model_pin
 


### PR DESCRIPTION
## Problem
When two enabled registry entries expose the same adapter model name through different provider namespaces, resolving a fully qualified registry ID also collects normalized alias matches from the sibling entry. The exact pin is then rejected as ambiguous, so callers cannot use the registry ID itself to disambiguate API and subscription-backed routes.

## Summary
- resolve an exact enabled registry ID before adapter-model and normalized-token aliases
- preserve fail-closed ambiguity for bare model names
- support duplicate provider namespaces that expose the same underlying model name

## Verification
- RED reproduced ambiguity for exact `agentic/gpt-5.6-sol` with an enabled Codex alias
- `CursorModelPinTests` — 10 passed
- routing/model-guard selection — 27 passed
- `py_compile` and `git diff --check` passed
- independent Sol review passed with no findings or risks