### PR TITLE
Fix Windows spawn failure: send Codex/Claude Code prompts on stdin, not argv

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,49 @@
+## Unreleased
+
+**Fix: Codex and Claude Code worker runs failed to spawn on Windows once the
+prompt got large — `[WinError 206] The filename or extension is too long`.**
+
+Both adapters passed the fully enriched prompt as an argv element
+(`codex exec … "<prompt>"`, `claude --print "<prompt>"`). On Windows the whole
+command line goes through `CreateProcessW`, which caps it at **32767
+characters**, so a prompt carrying repo census + CodeGraph context + a pasted
+diff failed the spawn outright. The error names the *filename*, not the length,
+so it reads like a missing or misresolved CLI — the failure was routinely
+misdiagnosed. Linux/macOS have a far larger `ARG_MAX` and were unaffected.
+
+- **Prompts now travel on stdin, not argv.** `build_codex_exec_command` emits a
+  trailing `-` (Codex reads instructions from stdin) and
+  `build_claude_code_command` emits `--print` with no prompt positional (same
+  behavior). Neither passes a prompt positional *and* pipes stdin: Codex would
+  otherwise append the piped text as a separate `<stdin>` block rather than
+  treating it as the task.
+- **`run_streamed_subprocess(..., stdin_data=...)`.** New optional keyword. When
+  omitted, stdin stays `DEVNULL` exactly as before, so every other adapter is
+  byte-for-byte unchanged. When supplied, the payload is written by a **daemon
+  thread started after the stdout/stderr readers**, then stdin is closed. Doing
+  the write inline would block before `process.wait(timeout=...)` could time out
+  a child that never drains stdin — trading a hard spawn failure for a silent
+  stall, the exact thing the original `stdin=DEVNULL` comment guards against.
+- **`WinError 206` now explains itself.** The spawn-error path appends the
+  measured command-line length and the 32767 cap, so any future argv regression
+  (long `extra_args`, deep `cwd`, long executable path) reports the real cause
+  instead of looking like a missing CLI.
+- **Signatures stay source-compatible.** `build_codex_exec_command` and
+  `build_claude_code_command` are exported from `puppetmaster.adapters`, so
+  `prompt` is retained as an optional keyword and simply ignored rather than
+  removed.
+
+Not affected: the Cursor adapter already ships its prompt through the
+`PUPPETMASTER_CURSOR_INPUT` environment variable (the Windows Unicode
+environment block has no comparable limit). `hermes.py`'s `chat -q <prompt>` has
+the same argv shape but is left alone here — its stdin behavior was not
+verifiable in this environment.
+
+Verified on Windows 11 with codex-cli 0.147.0: a 42,543-character prompt fails
+to spawn on `main` (command line 42,816 chars → WinError 206) and completes
+through stdin after the fix, with the instruction on the payload's final line to
+prove the whole stream is read.
+
 ## v1.22.6
 
 **Agentic/OpenRouter browser-swarm parity and durable autoresearch.**

--- a/puppetmaster/adapters/_streaming.py
+++ b/puppetmaster/adapters/_streaming.py
@@ -174,6 +174,7 @@ def run_streamed_subprocess(
     cwd: Optional[str] = None,
     heartbeat_seconds: float = 30.0,
     start_new_session: bool = False,
+    stdin_data: Optional[str] = None,
 ) -> StreamedProcess:
     """Run ``command`` while teeing its output to a live sidecar log.
 
@@ -184,6 +185,16 @@ def run_streamed_subprocess(
     they arrive and writes a ``still working`` heartbeat every
     ``heartbeat_seconds`` of the run, so the log visibly grows. Returns separate
     stdout/stderr buffers so existing artifact payloads are unchanged.
+
+    ``stdin_data`` feeds text to the child on stdin instead of closing it. Agent
+    CLIs take their prompt either as an argv positional or on stdin, and on
+    Windows argv is not an option for a large prompt: ``CreateProcess`` caps the
+    whole command line at 32767 characters, so an enriched prompt fails the spawn
+    outright with ``[WinError 206] The filename or extension is too long``. The
+    payload is written from a daemon thread (never the caller's) so the
+    ``process.wait(timeout=...)`` below keeps governing a child that does not
+    drain stdin, and stdin is always closed afterwards to preserve the "an agent
+    CLI must never block forever on terminal input" invariant.
     """
     import threading
     import time as _time
@@ -243,7 +254,9 @@ def run_streamed_subprocess(
             # Close stdin: an agent CLI launched in a non-interactive worker must
             # never block forever waiting on terminal input (a silent "stall").
             # Callers that previously passed input="" rely on this EOF behavior.
-            stdin=subprocess.DEVNULL,
+            # When stdin_data is supplied the pipe is opened instead, written by
+            # the daemon writer below, and then closed — same EOF guarantee.
+            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             # Never decode Cursor/agent SDK output with the Windows ANSI code
@@ -261,6 +274,16 @@ def run_streamed_subprocess(
         # leak, and surface a structured failure instead of letting the OSError
         # escape the adapter.
         message = redact_secrets(f"{type(exc).__name__}: {exc}") or "spawn_error"
+        if getattr(exc, "winerror", None) == 206:
+            # WinError 206 reads like a bad path ("filename or extension is too
+            # long") but is really the 32767-char CreateProcess command-line cap.
+            # Name the real cause so this is not misdiagnosed as a missing CLI.
+            message = (
+                f"{message} (command line is "
+                f"{len(subprocess.list2cmdline(command))} characters; Windows "
+                "CreateProcess caps it at 32767 - send large input via "
+                "stdin_data instead of argv)"
+            )
         if live_handle is not None:
             try:
                 live_handle.write(f"[puppetmaster] spawn failed: {message}\n")
@@ -299,6 +322,25 @@ def run_streamed_subprocess(
     ]
     for thread in threads:
         thread.start()
+
+    if stdin_data is not None and getattr(process, "stdin", None) is not None:
+        # Daemon, and started only after the readers are draining: a large
+        # payload can exceed the pipe buffer, so writing from this function
+        # would block before process.wait() below could time the child out.
+        def _writer() -> None:
+            try:
+                process.stdin.write(stdin_data)
+            except (BrokenPipeError, OSError, ValueError):
+                # Child exited or closed stdin early; its returncode and stderr
+                # are the real signal, so never let this thread raise.
+                pass
+            finally:
+                try:
+                    process.stdin.close()  # EOF, so the child never waits on us
+                except Exception:
+                    pass
+
+        threading.Thread(target=_writer, daemon=True).start()
 
     stop_heartbeat = threading.Event()
     started = _time.monotonic()

--- a/puppetmaster/adapters/claude_code.py
+++ b/puppetmaster/adapters/claude_code.py
@@ -202,6 +202,8 @@ class ClaudeCodeAdapter(CliWorkerAdapter):
         return CliInvocation(
             command=command,
             sidecar_name="claude_implement",
+            # The prompt travels on stdin, not argv — see build_claude_code_command.
+            subprocess_kwargs={"stdin_data": prompt},
             extras={
                 "prompt": prompt,
                 "codegraph_used": codegraph_used,
@@ -389,7 +391,7 @@ class ClaudeCodeAdapter(CliWorkerAdapter):
 
 def build_claude_code_command(
     *,
-    prompt: str,
+    prompt: Optional[str] = None,
     executable: Union[str, list[str]] = "claude",
     model: object = None,
     output_format: str = "json",
@@ -398,8 +400,18 @@ def build_claude_code_command(
     disallowed_tools: object = None,
     extra_args: object = None,
 ) -> list[str]:
+    """Build the non-interactive ``claude --print`` argv.
+
+    ``--print`` with no prompt positional makes the CLI read its prompt from
+    stdin, which the caller supplies via
+    ``CliInvocation.subprocess_kwargs['stdin_data']``. Keeping the prompt out of
+    argv is what makes a large enriched prompt spawnable on Windows, where
+    ``CreateProcess`` rejects any command line past 32767 characters with
+    ``[WinError 206]``. ``prompt`` is accepted and ignored so this exported
+    signature stays source-compatible.
+    """
     command = command_parts(executable)
-    command.extend(["--print", prompt, "--output-format", output_format])
+    command.extend(["--print", "--output-format", output_format])
     if model:
         command.extend(["--model", str(model)])
     if permission_mode:

--- a/puppetmaster/adapters/codex.py
+++ b/puppetmaster/adapters/codex.py
@@ -132,7 +132,6 @@ class CodexAdapter(CliWorkerAdapter):
         skip_git_repo_check = bool(task.payload.get("skip_git_repo_check", True))
         command = build_codex_exec_command(
             executable=[resolved, *command_base[1:]],
-            prompt=prompt,
             model=model,
             cwd=cwd,
             sandbox=sandbox,
@@ -146,6 +145,8 @@ class CodexAdapter(CliWorkerAdapter):
         return CliInvocation(
             command=command,
             sidecar_name="codex_exec",
+            # The prompt travels on stdin, not argv — see build_codex_exec_command.
+            subprocess_kwargs={"stdin_data": prompt},
             extras={
                 "prompt": prompt,
                 "codegraph_used": codegraph_used,
@@ -417,7 +418,7 @@ class CodexAdapter(CliWorkerAdapter):
 def build_codex_exec_command(
     *,
     executable: Union[str, list[str]] = "codex",
-    prompt: str,
+    prompt: Optional[str] = None,
     model: Optional[str] = None,
     cwd: Optional[Path] = None,
     sandbox: str = "workspace-write",
@@ -427,6 +428,16 @@ def build_codex_exec_command(
     dangerously_bypass: bool = False,
     extra_args: object = None,
 ) -> list[str]:
+    """Build the non-interactive ``codex exec`` argv.
+
+    The prompt is **not** part of the command: the trailing ``-`` positional
+    tells ``codex exec`` to read its instructions from stdin, and the caller
+    feeds them through ``CliInvocation.subprocess_kwargs['stdin_data']``. An
+    enriched Puppetmaster prompt routinely runs past Windows' 32767-character
+    ``CreateProcess`` command-line cap, which fails the spawn outright with
+    ``[WinError 206]``; stdin has no such limit. ``prompt`` is accepted and
+    ignored so this exported signature stays source-compatible.
+    """
     command = command_parts(executable)
     command.append("exec")
     command.extend(["--json"])
@@ -445,7 +456,10 @@ def build_codex_exec_command(
         command.extend(["-m", str(model)])
     if extra_args:
         command.extend(command_parts(extra_args))
-    command.append(prompt)
+    # Read the prompt from stdin. Never pass a prompt positional as well: codex
+    # then appends the piped text as a separate `<stdin>` block instead of
+    # treating it as the instruction.
+    command.append("-")
     return command
 
 

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -5869,6 +5869,9 @@ class PuppetmasterTests(unittest.TestCase):
         )
 
         self.assertEqual(command[:2], ["claude", "--print"])
+        # The prompt is fed on stdin, never as argv: Windows caps a command line
+        # at 32767 chars and an enriched prompt blows straight past it.
+        self.assertNotIn("Implement the change", command)
         self.assertIn("--permission-mode", command)
         self.assertIn("acceptEdits", command)
         self.assertIn("--allowedTools", command)
@@ -7242,12 +7245,13 @@ print(json.dumps({"result": "ok", "usage": {"input_tokens": 321, "output_tokens"
         """The Codex command builder must produce the non-interactive
         flag soup that v0.7.0 ships by default: `exec --json`,
         `approval_policy="never"`, `--sandbox`, `--ephemeral`,
-        `--skip-git-repo-check`, `-C cwd`, `-m model`, and the prompt as
-        the final positional argument. Asserting on the exact command
-        shape protects against accidental regressions."""
+        `--skip-git-repo-check`, `-C cwd`, `-m model`, and `-` as the
+        final positional argument so the prompt is read from stdin
+        rather than argv (Windows caps a command line at 32767 chars).
+        Asserting on the exact command shape protects against accidental
+        regressions."""
         cmd = build_codex_exec_command(
             executable=["codex"],
-            prompt="hello world",
             model="gpt-5.4-mini",
             cwd=Path("/tmp/codex-test-cwd"),
             sandbox="workspace-write",
@@ -7270,18 +7274,167 @@ print(json.dumps({"result": "ok", "usage": {"input_tokens": 321, "output_tokens"
         self.assertIn(str(Path("/tmp/codex-test-cwd")), cmd)
         self.assertIn("-m", cmd)
         self.assertIn("gpt-5.4-mini", cmd)
-        self.assertEqual(cmd[-1], "hello world")
+        self.assertEqual(cmd[-1], "-")
         self.assertNotIn("--dangerously-bypass-approvals-and-sandbox", cmd)
 
     def test_build_codex_exec_command_with_danger_bypass(self) -> None:
         cmd = build_codex_exec_command(
             executable=["codex"],
-            prompt="audit",
             model=None,
             sandbox="workspace-write",
             dangerously_bypass=True,
         )
         self.assertIn("--dangerously-bypass-approvals-and-sandbox", cmd)
+
+    def test_codex_command_stays_under_windows_command_line_cap(self) -> None:
+        """Regression: a large enriched prompt used to be appended to argv, so
+        `CreateProcess` rejected the spawn outright with `[WinError 206] The
+        filename or extension is too long` once the joined command line passed
+        32767 characters. The prompt must not appear in argv at any size."""
+        import subprocess as _subprocess
+
+        prompt = "\n".join(f"# context filler line {i}" for i in range(2000))
+        self.assertGreater(len(prompt), 32767)
+        cmd = build_codex_exec_command(
+            executable=["codex"],
+            prompt=prompt,
+            model="gpt-5.4-mini",
+            cwd=Path("/tmp/codex-test-cwd"),
+        )
+        self.assertNotIn(prompt, cmd)
+        # list2cmdline is what subprocess hands to CreateProcess on Windows, so
+        # measure the real joined line rather than len(prompt): quote/backslash
+        # escaping inflates it well beyond the raw character count.
+        self.assertLess(len(_subprocess.list2cmdline(cmd)), 32767)
+
+    def test_codex_adapter_sends_prompt_on_stdin_not_argv(self) -> None:
+        """The adapter must hand the prompt to the runner as `stdin_data` and
+        leave a bare `-` in argv for `codex exec` to read stdin from."""
+        streamed = StreamedProcess(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "done"},
+                }
+            ),
+            stderr="",
+            timed_out=False,
+            live_log_path=None,
+        )
+        task = Task(
+            id="t-codex-stdin",
+            job_id="job-codex-stdin",
+            role="codex-review",
+            adapter="codex",
+            instruction="Review the repo.",
+            payload={"cwd": str(Path.cwd()), "sandbox": "read-only", "disable_codegraph": True},
+        )
+        clean = {"sha": "s", "changed_files": [], "untracked_files": [], "diff": ""}
+        with patch("puppetmaster.adapters.resolve_command", return_value="/usr/bin/codex"), patch(
+            "puppetmaster.adapters.git_snapshot", side_effect=[clean, clean]
+        ), patch(
+            "puppetmaster.adapters.run_streamed_subprocess", return_value=streamed
+        ) as streamed_run:
+            CodexAdapter().run(task, "goal", "worker")
+
+        kwargs = streamed_run.call_args.kwargs
+        command = kwargs["command"]
+        self.assertEqual(command[-1], "-")
+        stdin_data = kwargs["stdin_data"]
+        self.assertIn("Review the repo.", stdin_data)
+        # The prompt must not have leaked into argv alongside stdin: codex would
+        # then treat the piped text as a trailing `<stdin>` block, not the task.
+        self.assertNotIn(stdin_data, command)
+
+    def test_run_streamed_subprocess_feeds_stdin_data_to_child(self) -> None:
+        """`stdin_data` must reach the child verbatim and then EOF, so a CLI
+        that reads its prompt from stdin terminates instead of hanging."""
+        from puppetmaster.adapters import run_streamed_subprocess
+
+        task = Task(
+            id="t-stdin-data",
+            job_id="job-stdin-data",
+            role="codex-review",
+            adapter="codex",
+            instruction="x",
+            payload={},
+        )
+        result = run_streamed_subprocess(
+            command=[
+                sys.executable,
+                "-c",
+                "import sys; sys.stdout.write(sys.stdin.read())",
+            ],
+            env=None,
+            task=task,
+            sidecar_name="stdin_data_probe",
+            timeout_seconds=30,
+            stdin_data="hello from stdin",
+        )
+        self.assertFalse(result.timed_out)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("hello from stdin", result.stdout)
+
+    def test_run_streamed_subprocess_large_stdin_data_does_not_deadlock(self) -> None:
+        """A payload larger than the OS pipe buffer must not wedge the runner.
+
+        Writing from the calling thread would block before `process.wait()` can
+        time the child out; the write has to happen on its own thread while the
+        stdout readers keep draining.
+        """
+        from puppetmaster.adapters import run_streamed_subprocess
+
+        payload = "\n".join(f"line {i} of a very large prompt" for i in range(20000))
+        self.assertGreater(len(payload), 500_000)
+        task = Task(
+            id="t-stdin-big",
+            job_id="job-stdin-big",
+            role="codex-review",
+            adapter="codex",
+            instruction="x",
+            payload={},
+        )
+        result = run_streamed_subprocess(
+            command=[
+                sys.executable,
+                "-c",
+                "import sys; sys.stdout.write(str(len(sys.stdin.read())))",
+            ],
+            env=None,
+            task=task,
+            sidecar_name="stdin_big_probe",
+            timeout_seconds=60,
+            stdin_data=payload,
+        )
+        self.assertFalse(result.timed_out)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn(str(len(payload)), result.stdout)
+
+    def test_run_streamed_subprocess_stdin_data_survives_child_ignoring_it(self) -> None:
+        """A child that exits without draining stdin must not raise or hang the
+        runner — the writer swallows the broken pipe and the rc still lands."""
+        from puppetmaster.adapters import run_streamed_subprocess
+
+        task = Task(
+            id="t-stdin-ignored",
+            job_id="job-stdin-ignored",
+            role="codex-review",
+            adapter="codex",
+            instruction="x",
+            payload={},
+        )
+        result = run_streamed_subprocess(
+            command=[sys.executable, "-c", "print('ignored stdin')"],
+            env=None,
+            task=task,
+            sidecar_name="stdin_ignored_probe",
+            timeout_seconds=30,
+            stdin_data="\n".join(f"unread line {i}" for i in range(20000)),
+        )
+        self.assertFalse(result.timed_out)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("ignored stdin", result.stdout)
 
     def test_parse_codex_events_skips_banners_and_invalid_json(self) -> None:
         """Codex CLI mixes a few non-JSON banner lines into its --json

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -5877,6 +5877,22 @@ class PuppetmasterTests(unittest.TestCase):
         self.assertIn("--allowedTools", command)
         self.assertIn("Read,Edit,Bash", command)
 
+    def test_claude_command_stays_under_windows_command_line_cap(self) -> None:
+        """Regression: a large enriched prompt used to be appended after
+        `--print`, so `CreateProcess` rejected the spawn with WinError 206 once
+        the joined command line passed 32767 characters."""
+        import subprocess as _subprocess
+
+        prompt = "\n".join(f"# context filler line {i}" for i in range(2000))
+        self.assertGreater(len(prompt), 32767)
+        cmd = build_claude_code_command(
+            prompt=prompt,
+            executable=["claude"],
+            model="claude-opus-5",
+        )
+        self.assertNotIn(prompt, cmd)
+        self.assertLess(len(_subprocess.list2cmdline(cmd)), 32767)
+
     def test_claude_code_missing_cli_returns_blocked_artifact(self) -> None:
         task = Task(
             job_id="job",
@@ -7347,6 +7363,39 @@ print(json.dumps({"result": "ok", "usage": {"input_tokens": 321, "output_tokens"
         # then treat the piped text as a trailing `<stdin>` block, not the task.
         self.assertNotIn(stdin_data, command)
 
+    def test_claude_code_adapter_sends_prompt_on_stdin_not_argv(self) -> None:
+        """The adapter must hand the prompt to the runner as `stdin_data` and
+        leave `--print` without a prompt positional."""
+        streamed = StreamedProcess(
+            returncode=0,
+            stdout=json.dumps({"result": "done", "is_error": False}),
+            stderr="",
+            timed_out=False,
+            live_log_path=None,
+        )
+        task = Task(
+            id="t-claude-stdin",
+            job_id="job-claude-stdin",
+            role="claude-code",
+            adapter="claude-code",
+            instruction="Implement the change.",
+            payload={"cwd": str(Path.cwd()), "allow_dirty": True, "disable_codegraph": True},
+        )
+        clean = {"sha": "s", "changed_files": [], "untracked_files": [], "diff": ""}
+        with patch("puppetmaster.adapters.resolve_command", return_value="/usr/bin/claude"), patch(
+            "puppetmaster.adapters.worktree_guard", return_value=None
+        ), patch("puppetmaster.adapters.git_snapshot", side_effect=[clean, clean]), patch(
+            "puppetmaster.adapters.run_streamed_subprocess", return_value=streamed
+        ) as streamed_run:
+            ClaudeCodeAdapter().run(task, "goal", "worker")
+
+        kwargs = streamed_run.call_args.kwargs
+        command = kwargs["command"]
+        self.assertEqual(command[1], "--print")
+        stdin_data = kwargs["stdin_data"]
+        self.assertIn("Implement the change.", stdin_data)
+        self.assertNotIn(stdin_data, command)
+
     def test_run_streamed_subprocess_feeds_stdin_data_to_child(self) -> None:
         """`stdin_data` must reach the child verbatim and then EOF, so a CLI
         that reads its prompt from stdin terminates instead of hanging."""
@@ -7435,6 +7484,42 @@ print(json.dumps({"result": "ok", "usage": {"input_tokens": 321, "output_tokens"
         self.assertFalse(result.timed_out)
         self.assertEqual(result.returncode, 0)
         self.assertIn("ignored stdin", result.stdout)
+
+    def test_run_streamed_subprocess_winerror_206_reports_command_line_length(self) -> None:
+        """WinError 206 reads like a bad path; the spawn path must name the real
+        CreateProcess command-line cap so argv regressions are diagnosable."""
+        import subprocess as _subprocess
+        from unittest.mock import patch
+
+        from puppetmaster.adapters import run_streamed_subprocess
+
+        long_arg = "x" * 40000
+        command = ["codex", "exec", long_arg]
+        task = Task(
+            id="t-win206",
+            job_id="job-win206",
+            role="codex-review",
+            adapter="codex",
+            instruction="x",
+            payload={},
+        )
+        err = OSError()
+        err.winerror = 206  # type: ignore[attr-defined]
+        err.strerror = "The filename or extension is too long"
+        err.errno = 206
+
+        with patch.object(_subprocess, "Popen", side_effect=err):
+            result = run_streamed_subprocess(
+                command=command,
+                env=None,
+                task=task,
+                sidecar_name="win206_probe",
+                timeout_seconds=5,
+            )
+
+        self.assertIsNotNone(result.spawn_error)
+        self.assertIn("32767", result.spawn_error)
+        self.assertIn(str(len(_subprocess.list2cmdline(command))), result.spawn_error)
 
     def test_parse_codex_events_skips_banners_and_invalid_json(self) -> None:
         """Codex CLI mixes a few non-JSON banner lines into its --json
@@ -9345,6 +9430,7 @@ class ModelRouterTests(unittest.TestCase):
             model="claude-fable-5",
             extra_args=["--effort", "low"],
         )
+        self.assertNotIn("do the thing", command)
         self.assertIn("--effort", command)
         self.assertEqual(command[command.index("--effort") + 1], "low")
 


### PR DESCRIPTION
## The bug

On Windows, `codex` and `claude-code` worker runs fail to spawn once the prompt gets large:

```
FileNotFoundError: [WinError 206] The filename or extension is too long
```

Both adapters passed the fully enriched prompt as an **argv element** — `adapters/codex.py` did `command.append(prompt)`, `adapters/claude_code.py` did `command.extend(["--print", prompt, ...])`. `run_streamed_subprocess` spawns with `shell=False`, so Python joins the list and hands it to `CreateProcessW`, which caps the whole command line at **32,767 characters**.

Puppetmaster's own enrichment (structured scaffold ≈1.3 KB, repo census up to ≈6 KB, CodeGraph up to 4 KB, job brief, memory) sits on top of the caller's prompt, so a task carrying a pasted diff or file contents crosses the cap routinely.

The failure is easy to misdiagnose: WinError 206 says *"filename or extension"*, so it reads like a missing or misresolved CLI rather than a length problem. Linux and macOS have a far larger `ARG_MAX` and were never affected — this is Windows-only.

## The fix

Prompts travel on **stdin** instead of argv.

- `build_codex_exec_command` emits a trailing `-`; `codex exec` then reads instructions from stdin.
- `build_claude_code_command` emits `--print` with no prompt positional; the Claude CLI does the same.
- Neither passes a prompt positional *and* pipes stdin. Codex would otherwise append the piped text as a separate `<stdin>` block instead of treating it as the task (`codex exec --help`).

`run_streamed_subprocess` gains an optional `stdin_data` keyword:

- **Omitted → unchanged.** stdin stays `subprocess.DEVNULL`, so every other adapter and caller behaves exactly as before.
- **Supplied →** the payload is written by a **daemon thread started after the stdout/stderr readers**, and stdin is then closed.

That threading detail is the load-bearing part. The runner's ordering is `Popen` → readers → `process.wait(timeout=...)`. Writing the payload inline would block *before* the timeout path exists, so a child that fails to drain stdin would become a silent stall with no `TimeoutExpired` and no `_kill_process_tree` — trading a hard spawn failure for a hang, which is exactly what the original `stdin=DEVNULL` comment was written to prevent. A daemon writer keeps `process.wait(timeout=...)` governing, and the unconditional `close()` preserves the "an agent CLI must never block forever on terminal input" invariant.

Finally, `WinError 206` now explains itself — the spawn-error path appends the measured command-line length and the 32,767 cap, so any future argv regression (long `extra_args`, deep `cwd`, long executable path) names its real cause instead of looking like a missing CLI.

## Verification

Measured on Windows 11, codex-cli 0.147.0, Python 3.12.

Same 42,543-character prompt, with the instruction on the **last** line so the reply proves the whole stream was read:

| | argv command line | Result |
|---|---|---|
| `main` | 42,816 chars | `FileNotFoundError: [WinError 206]` — no process |
| this branch | **239 chars** | `rc=0`, `{"type":"item.completed", ... "text":"PONG"}` |

That run went through the patched `build_codex_exec_command` + `run_streamed_subprocess` against the real `codex.exe`, not a mock.

Claude Code was verified in the adapter's exact flag shape, not just `-p`:

```
printf 'Reply with exactly: PONG' | claude --print --output-format json --permission-mode acceptEdits
→ {"result":"PONG", "is_error":false, "subtype":"success", ...}
```

Empirical `CreateProcessW` ceiling on the test host: 32,000 OK / 33,000 → WinError 206.

## Scope

**Changed:** `codex`, `claude-code`.

**Deliberately not changed:**

- `adapters/cursor.py` already ships its prompt through the `PUPPETMASTER_CURSOR_INPUT` environment variable. The Windows Unicode environment block has no comparable limit (5 MB accepted in testing), so it was never affected.
- `adapters/hermes.py` (`chat -q <prompt>`) has the same argv shape, but the Hermes CLI was not installed on the test host, so its stdin behavior could not be verified. Left alone rather than changed blind — happy to follow up if a maintainer can confirm `hermes chat` reads stdin.

## Compatibility

`build_codex_exec_command` and `build_claude_code_command` are both in `puppetmaster.adapters.__all__`. Rather than removing the now-unused `prompt` parameter and breaking external callers with a `TypeError`, both retain it as an optional keyword that is accepted and ignored.

`stdin_data` is keyword-only with a `None` default, so no existing `run_streamed_subprocess` call site changes.

## Tests

Five new regression tests, plus one updated contract:

- `test_codex_command_stays_under_windows_command_line_cap` — builds with a >32 KB prompt and asserts `len(subprocess.list2cmdline(cmd)) < 32767`. It measures the **joined** line rather than `len(prompt)`, because quote/backslash escaping inflates JSON- and path-heavy prompts by ~1.24×.
- `test_codex_adapter_sends_prompt_on_stdin_not_argv` — asserts the adapter passes `stdin_data` and leaves a bare `-` in argv.
- `test_run_streamed_subprocess_feeds_stdin_data_to_child` — payload reaches the child verbatim, then EOF.
- `test_run_streamed_subprocess_large_stdin_data_does_not_deadlock` — 500 KB payload, well past the pipe buffer, must not wedge the runner.
- `test_run_streamed_subprocess_stdin_data_survives_child_ignoring_it` — a child that exits without draining stdin must not raise or hang.
- `test_build_codex_exec_command_emits_expected_flags` — its docstring pinned "the prompt as the final positional argument" as an intentional contract; updated to pin `-` and say why.

The existing `test_run_streamed_subprocess_decodes_stdout_as_utf8` assertion that stdin is `DEVNULL` still passes unchanged, which is the guard that the default path was not disturbed.

## Changelog

Added under `## Unreleased` — version numbering left to the maintainer.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
