### PR TITLE
MVP: consume community SWE-bench evidence for model routing

### DIFF
--- a/docs/MODEL_ROUTING.md
+++ b/docs/MODEL_ROUTING.md
@@ -53,6 +53,45 @@ still only writes the global scalar.
 `effective_capability_score`, `score_provenance`, and `sample_count`
 when present. Empty cards keep today's picks.
 
+### SWE-bench Bash Only Python connector
+
+The narrow community-data MVP is available as a Python import. It fetches the
+latest commit that changed SWE-bench's public `bash-only` leaderboard, then
+fetches the leaderboard by that immutable commit SHA. Model identity is always
+an explicit mapping; unknown or duplicate names fail closed and no fuzzy or
+cross-adapter inference occurs.
+
+```python
+import json
+from pathlib import Path
+
+from puppetmaster.swebench_baseline import (
+    RegistryModelMapping,
+    fetch_swebench_bash_only_bundle,
+)
+
+bundle = fetch_swebench_bash_only_bundle([
+    RegistryModelMapping(
+        registry_id="codex/gpt-5-2",
+        adapter="codex",
+        adapter_model_name="gpt-5.2",
+        leaderboard_name="GPT 5.2 Codex",
+    )
+])
+Path("swe-bench-bash-only.json").write_text(
+    json.dumps(bundle, indent=2) + "\n",
+    encoding="utf-8",
+)
+```
+
+The bundle is accepted by `puppetmaster models import-baseline <bundle.json>
+--dry-run`. It maps SWE-bench to the `implement` role, preserves resolved rate,
+cost, calls, sample count, exact source revision, and card-level provenance.
+The provisional capability translation is the submission's weak percentile
+rank among comparable `mini-SWE-agent` Bash Only entries (0–100). This is a
+transparent community prior, not an absolute accuracy claim or cross-adapter
+benchmark result; review the generated bundle before import.
+
 ## Where it kicks in automatically (and where it doesn't)
 
 This is the part to be honest about:

--- a/puppetmaster/router.py
+++ b/puppetmaster/router.py
@@ -904,9 +904,13 @@ def _decision_score_fields(pick: ModelSpec, role: str) -> dict:
     card = (pick.role_scorecards or {}).get(role) if used_card else None
     if not isinstance(card, dict):
         card = {}
+    provenance = dict(pick.score_provenance or {})
+    card_provenance = card.get("provenance") if used_card else None
+    if isinstance(card_provenance, dict):
+        provenance.update(card_provenance)
     sample = card.get("sample_count") if used_card else None
     if isinstance(sample, bool) or not isinstance(sample, int):
-        sample = (pick.score_provenance or {}).get("sample_count")
+        sample = provenance.get("sample_count")
         if isinstance(sample, bool) or not isinstance(sample, int):
             sample = None
     quality = card.get("quality") if used_card else None
@@ -923,7 +927,7 @@ def _decision_score_fields(pick: ModelSpec, role: str) -> dict:
         "role": role or "",
         "effective_capability_score": effective,
         "score_source": "role_card" if used_card else "manual",
-        "score_provenance": dict(pick.score_provenance or {}),
+        "score_provenance": provenance,
         "sample_count": sample,
         "predicted_quality": quality,
         "predicted_latency_p50_ms": latency,

--- a/puppetmaster/swebench_baseline.py
+++ b/puppetmaster/swebench_baseline.py
@@ -1,0 +1,335 @@
+"""Turn public SWE-bench results into Puppetmaster role cards.
+
+This module does one small job. It reads the public SWE-bench "Bash Only"
+leaderboard and creates an ``implement`` scorecard that Puppetmaster already
+knows how to import.
+
+The leaderboard tests every model with mini-SWE-agent. Puppetmaster may run the
+same model through Codex, Cursor, or another adapter. Those are not identical
+setups, so this module never guesses the mapping. The caller must name the exact
+leaderboard row and the exact Puppetmaster registry entry that should receive
+it. The saved provenance keeps the original mini-SWE-agent source visible.
+"""
+from __future__ import annotations
+
+import json
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Optional
+
+
+# SWE-bench publishes the website's leaderboard data in this repository. We
+# read the JSON source directly instead of scraping the rendered web page.
+_SWEBENCH_REPO = "SWE-bench/swe-bench.github.io"
+_SWEBENCH_PATH = "data/leaderboards.json"
+_COMMITS_URL = (
+    f"https://api.github.com/repos/{_SWEBENCH_REPO}/commits"
+    f"?path={_SWEBENCH_PATH}&per_page=1"
+)
+_RAW_URL = (
+    "https://raw.githubusercontent.com/"
+    f"{_SWEBENCH_REPO}/{{revision}}/{_SWEBENCH_PATH}"
+)
+_BENCHMARK_ID = "swe-bench-bash-only"
+_AGENT = "mini-SWE-agent"
+# The Bash Only board currently contains 500 tasks. Some leaderboard rows embed
+# all 500 task results and some only publish the aggregate. In the latter case,
+# this public board size is the honest sample count available to us.
+_MIN_COMPARABLE_ROWS = 5
+_BASH_ONLY_SAMPLE_COUNT = 500
+
+
+@dataclass(frozen=True)
+class RegistryModelMapping:
+    """A deliberate link between one leaderboard row and one local model.
+
+    ``leaderboard_name`` must match the row's published ``name`` exactly. The
+    other three fields identify the existing Puppetmaster registry entry. This
+    small amount of explicit setup prevents a similar-looking model name from
+    receiving evidence that belongs to another model or adapter.
+    """
+
+    registry_id: str
+    adapter: str
+    adapter_model_name: str
+    leaderboard_name: str
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "registry_id",
+            "adapter",
+            "adapter_model_name",
+            "leaderboard_name",
+        ):
+            if not str(getattr(self, field_name) or "").strip():
+                raise ValueError(f"{field_name} must be non-empty")
+
+
+JsonGetter = Callable[[str], Any]
+
+
+def _stdlib_get_json(url: str) -> Any:
+    """Read one trusted GitHub JSON document without adding a dependency."""
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "puppetmaster-swebench-import",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _bash_only_rows(payload: dict) -> list[dict]:
+    """Return valid mini-SWE-agent rows from the Bash Only board.
+
+    Other SWE-bench boards use different task sets or agent setups. Mixing them
+    would make the comparison meaningless, so this function accepts only one
+    named board and one named agent.
+    """
+    boards = payload.get("leaderboards") if isinstance(payload, dict) else None
+    if not isinstance(boards, list):
+        raise ValueError("SWE-bench payload has no leaderboards list")
+    board = next(
+        (item for item in boards if isinstance(item, dict) and item.get("name") == "bash-only"),
+        None,
+    )
+    if board is None:
+        raise ValueError("SWE-bench payload has no bash-only leaderboard")
+    results = board.get("results")
+    if not isinstance(results, list):
+        raise ValueError("SWE-bench bash-only leaderboard has no results list")
+    rows = [
+        row
+        for row in results
+        if isinstance(row, dict)
+        and row.get("agent") == _AGENT
+        and isinstance(row.get("resolved"), (int, float))
+        and not isinstance(row.get("resolved"), bool)
+    ]
+    if len(rows) < _MIN_COMPARABLE_ROWS:
+        raise ValueError(
+            f"SWE-bench bash-only leaderboard has only {len(rows)} comparable {_AGENT} rows; "
+            f"need at least {_MIN_COMPARABLE_ROWS}"
+        )
+    return rows
+
+
+def _percentile_capability(rows: list[dict], resolved: float) -> int:
+    """Place one result from last to first on a 0-100 scale.
+
+    The raw resolved rate stays in the scorecard as ``quality``. Puppetmaster's
+    router also needs a 0-100 capability value, so the MVP uses position within
+    the comparable leaderboard group. A value of 80 means the submission ranks
+    at or above roughly 80 percent of that group. It does not mean 80 percent of
+    SWE-bench tasks passed.
+
+    Ties receive the same rank. The exact source revision and comparison count
+    are saved so the number can always be reproduced.
+    """
+    values = sorted(float(row["resolved"]) for row in rows)
+    below_or_equal = sum(1 for value in values if value <= resolved)
+    percentile = (below_or_equal - 1) / (len(values) - 1)
+    return max(0, min(100, round(percentile * 100)))
+
+
+def _mapped_row(rows: list[dict], mapping: RegistryModelMapping) -> dict:
+    """Find the one row the caller named, or stop if the name is not unique."""
+    matches = [row for row in rows if str(row.get("name") or "") == mapping.leaderboard_name]
+    if not matches:
+        raise ValueError(
+            f"SWE-bench model mapping not found: {mapping.leaderboard_name!r} "
+            f"for {mapping.registry_id}"
+        )
+    if len(matches) != 1:
+        raise ValueError(
+            f"SWE-bench model mapping is ambiguous: {mapping.leaderboard_name!r} "
+            f"matched {len(matches)} rows"
+        )
+    return matches[0]
+
+
+def build_swebench_bash_only_bundle(
+    payload: dict,
+    *,
+    mappings: Iterable[RegistryModelMapping],
+    source_revision: str,
+    published: str,
+    source_url: str = "",
+) -> dict:
+    """Build an importable Puppetmaster bundle from one pinned leaderboard."""
+    revision = str(source_revision or "").strip()
+    published_at = str(published or "").strip()
+    if not revision:
+        raise ValueError("source_revision must be non-empty")
+    if not published_at:
+        raise ValueError("published must be non-empty")
+    # First narrow the source to one board and one agent. Later, each mapping is
+    # narrowed again to the target row's exact mini-SWE-agent version.
+    rows = _bash_only_rows(payload)
+    mapping_list = list(mappings)
+    if not mapping_list:
+        raise ValueError("at least one explicit model mapping is required")
+    ids = [mapping.registry_id for mapping in mapping_list]
+    if len(ids) != len(set(ids)):
+        raise ValueError("registry model mappings must have unique registry_id values")
+
+    pinned_url = source_url or _RAW_URL.format(revision=revision)
+    entries: list[dict] = []
+    for mapping in mapping_list:
+        # The caller chooses the row. We do not normalize, guess, or choose the
+        # newest model on their behalf.
+        row = _mapped_row(rows, mapping)
+        resolved = float(row["resolved"])
+        if not 0.0 <= resolved <= 100.0:
+            raise ValueError(
+                f"SWE-bench row {mapping.leaderboard_name!r} resolved must be 0..100"
+            )
+        for field_name in ("instance_cost", "instance_calls"):
+            value = row.get(field_name)
+            if (
+                isinstance(value, (int, float))
+                and not isinstance(value, bool)
+                and float(value) < 0.0
+            ):
+                raise ValueError(
+                    f"SWE-bench row {mapping.leaderboard_name!r} "
+                    f"{field_name} must be non-negative"
+                )
+        harness_version = str(row.get("mini-swe-agent_version") or "").strip()
+        if not harness_version:
+            raise ValueError(
+                f"SWE-bench row {mapping.leaderboard_name!r} has no mini-SWE-agent version"
+            )
+        # mini-SWE-agent changes over time. Compare the model only with rows that
+        # used the same version, otherwise the agent change would affect rank.
+        comparable = [
+            candidate
+            for candidate in rows
+            if str(candidate.get("mini-swe-agent_version") or "").strip()
+            == harness_version
+        ]
+        if len(comparable) < _MIN_COMPARABLE_ROWS:
+            raise ValueError(
+                f"SWE-bench harness version {harness_version!r} has only "
+                f"{len(comparable)} comparable rows; need at least {_MIN_COMPARABLE_ROWS}"
+            )
+        details = row.get("per_instance_details")
+        if isinstance(details, dict) and details:
+            # Prefer the task-level evidence when the row includes it.
+            sample_count = len(details)
+            sample_count_source = "embedded_per_instance_details"
+        else:
+            # Some public rows omit task details. The board still represents the
+            # fixed 500-task Bash Only set, so record that source explicitly.
+            sample_count = _BASH_ONLY_SAMPLE_COUNT
+            sample_count_source = "bash_only_board_contract"
+        capability = _percentile_capability(comparable, resolved)
+        # Keep this evidence on the role card itself. A model may later combine
+        # local evidence for one role with community evidence for another.
+        provenance = {
+            "source": "community_benchmark",
+            "benchmark": _BENCHMARK_ID,
+            "leaderboard": "bash-only",
+            "agent": _AGENT,
+            "harness_version": harness_version,
+            "comparison_count": len(comparable),
+            "source_url": pinned_url,
+            "source_revision": revision,
+            "raw_model_name": mapping.leaderboard_name,
+            "capability_method": "leaderboard_percentile",
+            "sample_count_source": sample_count_source,
+        }
+        card = {
+            "capability": capability,
+            "quality": round(resolved / 100.0, 6),
+            "sample_count": sample_count,
+            "last_calibrated": str(row.get("date") or published_at),
+            "provenance": provenance,
+        }
+        if isinstance(row.get("instance_cost"), (int, float)):
+            card["cost_per_task_usd"] = round(float(row["instance_cost"]), 6)
+        if isinstance(row.get("instance_calls"), (int, float)):
+            card["calls_per_task"] = round(float(row["instance_calls"]), 6)
+        # ``adapter`` is copied from the caller's explicit mapping. This does not
+        # claim that SWE-bench ran that adapter; the provenance above names the
+        # mini-SWE-agent harness that actually produced the result.
+        entries.append(
+            {
+                "id": mapping.registry_id,
+                "adapter": mapping.adapter,
+                "adapter_model_name": mapping.adapter_model_name,
+                "role_scorecards": {"implement": card},
+                "score_provenance": {
+                    "source": "community_baseline",
+                    "sample_count": sample_count,
+                    "notes": (
+                        f"{_BENCHMARK_ID} {_AGENT}; explicit mapping from "
+                        f"{mapping.leaderboard_name!r}"
+                    ),
+                },
+            }
+        )
+
+    return {
+        "bundle_id": _BENCHMARK_ID,
+        "version": revision[:12],
+        "published": published_at,
+        "adapter_scoped": True,
+        "not_ground_truth": True,
+        "methodology": [
+            "SWE-bench Bash Only",
+            f"fixed agent={_AGENT}",
+            "capability=weak percentile rank among comparable submissions",
+        ],
+        "notes": (
+            "Community model prior translated by explicit registry mapping. "
+            "Review with import-baseline --dry-run before writing."
+        ),
+        "source_url": pinned_url,
+        "entries": entries,
+    }
+
+
+def fetch_swebench_bash_only_bundle(
+    mappings: Iterable[RegistryModelMapping],
+    *,
+    get_json: Optional[JsonGetter] = None,
+    published: Optional[str] = None,
+) -> dict:
+    """Fetch the latest leaderboard revision and build a reproducible bundle.
+
+    GitHub's default-branch URL can change between runs. We first ask which
+    commit last changed the leaderboard file, then fetch the file through that
+    immutable commit. The bundle stores both values, so another person can read
+    the same bytes later.
+    """
+    getter = get_json or _stdlib_get_json
+    commits = getter(_COMMITS_URL)
+    if not isinstance(commits, list) or not commits or not isinstance(commits[0], dict):
+        raise ValueError("SWE-bench commit lookup returned no revision")
+    revision = str(commits[0].get("sha") or "").strip()
+    if not revision:
+        raise ValueError("SWE-bench commit lookup returned an empty revision")
+    # Fetch through the commit SHA, not through ``main`` or ``master``.
+    source_url = _RAW_URL.format(revision=revision)
+    payload = getter(source_url)
+    commit = commits[0].get("commit")
+    committer = commit.get("committer") if isinstance(commit, dict) else None
+    committed_at = committer.get("date") if isinstance(committer, dict) else None
+    if published is None:
+        # Use the source commit's date instead of today's date. Fetching the same
+        # commit tomorrow should produce the same bundle.
+        if not isinstance(committed_at, str) or len(committed_at) < 10:
+            raise ValueError("SWE-bench commit lookup returned no publication date")
+        published_at = committed_at[:10]
+    else:
+        published_at = published
+    return build_swebench_bash_only_bundle(
+        payload,
+        mappings=mappings,
+        source_revision=revision,
+        published=published_at,
+        source_url=source_url,
+    )

--- a/tests/test_swebench_baseline.py
+++ b/tests/test_swebench_baseline.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import unittest
+
+
+class SweBenchBaselineTests(unittest.TestCase):
+    @staticmethod
+    def _payload() -> dict:
+        rows = []
+        for index, resolved in enumerate((20.0, 40.0, 60.0, 80.0, 90.0), start=1):
+            rows.append(
+                {
+                    "agent": "mini-SWE-agent",
+                    "name": f"Model {index}",
+                    "model_display": f"Model {index}",
+                    "mini-swe-agent_version": "2.0.0",
+                    "resolved": resolved,
+                    "instance_cost": index / 10,
+                    "instance_calls": index * 2,
+                    "date": "2026-08-18",
+                    "per_instance_details": {
+                        f"task-{index}-a": {"resolved": True},
+                        f"task-{index}-b": {"resolved": False},
+                    },
+                }
+            )
+        rows.append(
+            {
+                "agent": "OtherAgent",
+                "name": "Model 3",
+                "model_display": "Model 3",
+                "resolved": 100.0,
+                "per_instance_details": {"other": {"resolved": True}},
+            }
+        )
+        return {"leaderboards": [{"name": "bash-only", "results": rows}]}
+
+    def test_builds_adapter_scoped_implement_card_from_exact_model_mapping(self) -> None:
+        from puppetmaster.swebench_baseline import (
+            RegistryModelMapping,
+            build_swebench_bash_only_bundle,
+        )
+
+        bundle = build_swebench_bash_only_bundle(
+            self._payload(),
+            mappings=[
+                RegistryModelMapping(
+                    registry_id="codex/model-3",
+                    adapter="codex",
+                    adapter_model_name="model-3",
+                    leaderboard_name="Model 3",
+                )
+            ],
+            source_revision="abc123",
+            published="2026-08-18",
+        )
+
+        self.assertTrue(bundle["adapter_scoped"])
+        self.assertEqual(bundle["version"], "abc123")
+        entry = bundle["entries"][0]
+        self.assertEqual(entry["id"], "codex/model-3")
+        self.assertEqual(entry["adapter"], "codex")
+        card = entry["role_scorecards"]["implement"]
+        self.assertEqual(card["capability"], 50)
+        self.assertEqual(card["quality"], 0.6)
+        self.assertEqual(card["sample_count"], 2)
+        self.assertEqual(card["cost_per_task_usd"], 0.3)
+        self.assertEqual(card["calls_per_task"], 6.0)
+        self.assertEqual(card["provenance"]["benchmark"], "swe-bench-bash-only")
+        self.assertEqual(card["provenance"]["source_revision"], "abc123")
+        self.assertEqual(card["provenance"]["raw_model_name"], "Model 3")
+        self.assertEqual(card["provenance"]["capability_method"], "leaderboard_percentile")
+
+    def test_bundle_import_changes_only_role_capability(self) -> None:
+        from puppetmaster.model_registry import ModelSpec
+        from puppetmaster.scorecards import effective_capability_score, import_community_baseline
+        from puppetmaster.swebench_baseline import (
+            RegistryModelMapping,
+            build_swebench_bash_only_bundle,
+        )
+
+        spec = ModelSpec(
+            id="codex/model-3",
+            adapter="codex",
+            adapter_model_name="model-3",
+            capability_score=97,
+        )
+        bundle = build_swebench_bash_only_bundle(
+            self._payload(),
+            mappings=[RegistryModelMapping("codex/model-3", "codex", "model-3", "Model 3")],
+            source_revision="abc123",
+            published="2026-08-18",
+        )
+
+        imported, report = import_community_baseline([spec], bundle)
+
+        self.assertEqual(report["matched"], ["codex/model-3"])
+        self.assertEqual(imported[0].capability_score, 97)
+        self.assertEqual(effective_capability_score(imported[0], "implement"), 50)
+        self.assertEqual(
+            imported[0].role_scorecards["implement"]["provenance"]["benchmark"],
+            "swe-bench-bash-only",
+        )
+        from puppetmaster.router import TaskSignals, route_task
+
+        decision = route_task(
+            TaskSignals(instruction="implement a feature", role="implement"),
+            imported,
+            policy="quality",
+        )
+        self.assertEqual(
+            decision.to_artifact_payload()["score_provenance"]["benchmark"],
+            "swe-bench-bash-only",
+        )
+        self.assertEqual(
+            decision.to_artifact_payload()["score_provenance"]["source_revision"],
+            "abc123",
+        )
+
+    def test_uses_published_bash_only_sample_count_when_details_are_not_embedded(self) -> None:
+        from puppetmaster.swebench_baseline import (
+            RegistryModelMapping,
+            build_swebench_bash_only_bundle,
+        )
+
+        payload = self._payload()
+        del payload["leaderboards"][0]["results"][2]["per_instance_details"]
+        bundle = build_swebench_bash_only_bundle(
+            payload,
+            mappings=[RegistryModelMapping("codex/model-3", "codex", "model-3", "Model 3")],
+            source_revision="abc123",
+            published="2026-08-18",
+        )
+
+        card = bundle["entries"][0]["role_scorecards"]["implement"]
+        self.assertEqual(card["sample_count"], 500)
+        self.assertEqual(card["provenance"]["sample_count_source"], "bash_only_board_contract")
+
+    def test_percentile_compares_only_the_same_harness_version(self) -> None:
+        from puppetmaster.swebench_baseline import (
+            RegistryModelMapping,
+            build_swebench_bash_only_bundle,
+        )
+
+        payload = self._payload()
+        payload["leaderboards"][0]["results"].append(
+            {
+                "agent": "mini-SWE-agent",
+                "name": "Old harness winner",
+                "model_display": "Old harness winner",
+                "mini-swe-agent_version": "1.0.0",
+                "resolved": 100.0,
+                "per_instance_details": {"old": {"resolved": True}},
+            }
+        )
+        bundle = build_swebench_bash_only_bundle(
+            payload,
+            mappings=[RegistryModelMapping("codex/model-3", "codex", "model-3", "Model 3")],
+            source_revision="abc123",
+            published="2026-08-18",
+        )
+
+        card = bundle["entries"][0]["role_scorecards"]["implement"]
+        self.assertEqual(card["capability"], 50)
+        self.assertEqual(card["provenance"]["harness_version"], "2.0.0")
+
+    def test_rejects_out_of_range_quality_and_negative_economics(self) -> None:
+        from puppetmaster.swebench_baseline import (
+            RegistryModelMapping,
+            build_swebench_bash_only_bundle,
+        )
+
+        mapping = RegistryModelMapping("codex/model-3", "codex", "model-3", "Model 3")
+        payload = self._payload()
+        payload["leaderboards"][0]["results"][2]["resolved"] = 101.0
+        with self.assertRaisesRegex(ValueError, "resolved must be 0..100"):
+            build_swebench_bash_only_bundle(
+                payload,
+                mappings=[mapping],
+                source_revision="abc123",
+                published="2026-08-18",
+            )
+
+        payload = self._payload()
+        payload["leaderboards"][0]["results"][2]["instance_cost"] = -1.0
+        with self.assertRaisesRegex(ValueError, "instance_cost must be non-negative"):
+            build_swebench_bash_only_bundle(
+                payload,
+                mappings=[mapping],
+                source_revision="abc123",
+                published="2026-08-18",
+            )
+
+    def test_unknown_or_ambiguous_model_mapping_fails_closed(self) -> None:
+        from puppetmaster.swebench_baseline import (
+            RegistryModelMapping,
+            build_swebench_bash_only_bundle,
+        )
+
+        with self.assertRaisesRegex(ValueError, "not found"):
+            build_swebench_bash_only_bundle(
+                self._payload(),
+                mappings=[RegistryModelMapping("codex/missing", "codex", "missing", "Missing")],
+                source_revision="abc123",
+                published="2026-08-18",
+            )
+
+        payload = self._payload()
+        payload["leaderboards"][0]["results"].append(
+            {
+                **payload["leaderboards"][0]["results"][2],
+                "resolved": 61.0,
+            }
+        )
+        with self.assertRaisesRegex(ValueError, "ambiguous"):
+            build_swebench_bash_only_bundle(
+                payload,
+                mappings=[RegistryModelMapping("codex/model-3", "codex", "model-3", "Model 3")],
+                source_revision="abc123",
+                published="2026-08-18",
+            )
+
+    def test_fetches_latest_pinned_leaderboard_with_stdlib_callback(self) -> None:
+        from puppetmaster.swebench_baseline import (
+            RegistryModelMapping,
+            fetch_swebench_bash_only_bundle,
+        )
+
+        requested: list[str] = []
+
+        def get_json(url: str):
+            requested.append(url)
+            if "/commits?" in url:
+                return [
+                    {
+                        "sha": "deadbeefcafebabe",
+                        "commit": {"committer": {"date": "2026-08-17T23:59:58Z"}},
+                    }
+                ]
+            self.assertIn("deadbeefcafebabe", url)
+            return self._payload()
+
+        bundle = fetch_swebench_bash_only_bundle(
+            [RegistryModelMapping("codex/model-3", "codex", "model-3", "Model 3")],
+            get_json=get_json,
+        )
+
+        self.assertEqual(bundle["version"], "deadbeefcafe")
+        self.assertEqual(bundle["published"], "2026-08-17")
+        self.assertEqual(len(requested), 2)
+        self.assertIn("deadbeefcafebabe", bundle["source_url"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Puppetmaster v1.22.8 has role-scorecard and baseline-import plumbing, but its bundled baseline does not yet consume real community performance data. We should not build another model-testing system inside Puppetmaster when the community already maintains trusted benchmarks.

This MVP deliberately starts with SWE-bench's community-led Bash Only leaderboard. Puppetmaster consumes that evidence, preserves where it came from, and translates it into the existing `implement` role-card format.

## What this PR does

- Adds a small standard-library Python connector for SWE-bench's public Bash Only JSON.
- Requires an exact, human-reviewed mapping between a published leaderboard row and a Puppetmaster registry entry. It never fuzzy-matches model names.
- Compares submissions only when they used the same mini-SWE-agent version.
- Preserves the raw resolved rate, sample count, cost, calls, source commit, harness version, comparison count, and model name.
- Converts leaderboard position into a provisional 0-100 `implement` capability prior because the current router requires that scale.
- Emits a bundle accepted by the existing `puppetmaster models import-baseline <bundle.json> --dry-run` path.
- Exposes role-card provenance in ROUTING artifacts when that card drives a route.
- Documents why each translation and trust boundary exists in plain language.

## Intentional product choice

This PR does **not** add an LLM judge, a Puppetmaster benchmark lab, hidden evaluation tasks, telemetry, or automatic retraining.

The community has already done the expensive comparative work. Puppetmaster's job here is to consume a trusted result, translate it openly, and use it to make a better deterministic routing decision.

The benchmark ran `GPT 5.2 Codex` through mini-SWE-agent, not through Puppetmaster's Codex adapter. The result is therefore labeled as a community prior with the original harness in provenance. This PR does not claim that the Codex adapter itself achieved the benchmark score.

## Real live evidence

Fetched twice from the live SWE-bench repository and produced identical bundles:

```text
source revision: f42505b21a0eb31a9cc1204caafcbe0da6c1a259
source publication date: 2026-08-10
leaderboard: bash-only
agent: mini-SWE-agent
harness version: 2.0.0
same-harness comparison rows: 13
published model row: GPT 5.2 Codex
resolved quality: 0.728
sample count: 500
provisional percentile capability: 67
deterministic repeat: true
```

Disposable local import receipt:

```text
import-baseline (dry-run): matched=1 skipped_adapter_mismatch=0 cards_added=1
matched: codex/gpt-5-2

import-baseline: matched=1 skipped_adapter_mismatch=0 cards_added=1
wrote disposable /tmp registry
```

The import left the registry's manual global score at 97 and added an `implement` role score of 67.

Routing receipt for `role=implement`, `min_capability=80`:

```text
selected: codex/workhorse (manual capability 85)
rejected: codex/gpt-5-2 — capability_score 67 < needed 80
```

Routing receipt for `role=implement`, `min_capability=60`, restricted to `codex/gpt-5-2`:

```text
selected: codex/gpt-5-2
score_source: role_card
effective_capability_score: 67
predicted_quality: 0.728
sample_count: 500
benchmark: swe-bench-bash-only
harness_version: 2.0.0
comparison_count: 13
source_revision: f42505b21a0eb31a9cc1204caafcbe0da6c1a259
capability_method: leaderboard_percentile
```

## Verification receipts

```text
SWE-bench connector + role-scorecard tests: 25 passed
Model router tests: 116 passed
Unique focused tests covered: 141
Python compilation: passed
git diff --check: passed
Static security scan: 0 secret/shell/eval/pickle findings
```

CI remains the authority for the full Python 3.9/3.12 and Linux/macOS/Windows matrix.

Independent review status is intentionally not overstated: the Codex review pilot hit the workspace spend cap and Cursor was disabled by the platform lock, so neither produced an accepted review artifact.

## Fragile assumptions under discussion

The `MVP:` title is intentional. This PR asks for feedback on a small, useful path while keeping its assumptions visible:

1. SWE-bench Bash Only is an appropriate community source for the `implement` role.
2. An explicit human-approved cross-harness model prior is useful when its original harness remains visible.
3. Same-harness leaderboard percentile is a reasonable provisional translation into Puppetmaster's existing 0-100 capability scale.
4. The public Bash Only board's 500-task contract is an acceptable sample count when a row omits task-level details.

Local role cards still win under the existing import behavior unless the user explicitly requests replacement.