### PR TITLE
Exempt Puppetmaster workers from the delegate-first rule

### DIFF
--- a/.cursor/rules/puppetmaster-workflow.mdc
+++ b/.cursor/rules/puppetmaster-workflow.mdc
@@ -3,9 +3,28 @@ description: Default to Puppetmaster swarms for multi-step exploration, analysis
 alwaysApply: true
 ---
 
+# First: are you a Puppetmaster worker?
+
+**If your prompt was issued by Puppetmaster, none of the "start a swarm" guidance
+below applies to you.** You *are* the swarm. Do the analysis or the edit
+yourself and return the artifacts your prompt asks for.
+
+You are a Puppetmaster worker if your prompt contains a `Puppetmaster artifact
+contract:` block, a `Role: <role>` + `Goal: <goal>` header, or an instruction to
+finish by calling `submit_findings` / `submit_report`. Workers run as plain
+agent CLIs with **no Puppetmaster MCP tools**, so delegating is impossible;
+attempting it burns the context window and returns a clarifying question instead
+of findings. Roll your own grep/read loop — that is your job.
+
+The rest of this file addresses an interactive agent working with the user,
+which does have the MCP tools.
+
 # Puppetmaster is the Default Subagent Runtime
 
-When this repo is open, Puppetmaster's MCP tools are the **primary** path for fanning out work. Do not roll your own grep/read exploration loops or invoke ad-hoc subagents when a Puppetmaster swarm is available.
+When this repo is open — and you are *not* a Puppetmaster worker (see above) —
+Puppetmaster's MCP tools are the **primary** path for fanning out work. Do not
+roll your own grep/read exploration loops or invoke ad-hoc subagents when a
+Puppetmaster swarm is available.
 
 ## When you MUST start a Puppetmaster swarm (no permission needed)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,33 @@
 
 Repo-level guidance for AI coding agents (Cursor, Claude Code, Codex, etc.) working in this repository. Cursor users see the same directive via `.cursor/rules/puppetmaster-workflow.mdc`.
 
+## First: are you a Puppetmaster worker?
+
+**If your prompt was issued by Puppetmaster, everything below about starting a
+swarm does not apply to you.** You *are* the swarm. Do the analysis or the edit
+yourself, directly, and return the artifacts your prompt asks for.
+
+You are a Puppetmaster worker if your prompt contains any of:
+
+- a `Puppetmaster artifact contract:` / `Return only Puppetmaster artifact JSON` block,
+- a `Role: <role>` + `Goal: <goal>` header,
+- an instruction to finish by calling `submit_findings` or `submit_report`.
+
+Workers are spawned by `puppetmaster.worker_runtime` as plain agent CLIs. They
+have **no Puppetmaster MCP tools**, so "start a swarm before exploring" is an
+instruction they cannot follow — following it costs a full context load and
+returns a request for clarification instead of findings. Roll your own
+grep/read loop; that is your job.
+
+The rest of this file addresses an **interactive agent working with the user**,
+which has the MCP tools available.
+
 ## Default subagent runtime: Puppetmaster
 
-When this repo is open, **Puppetmaster's MCP tools are the primary path for fanning out work**. Do not roll your own grep/read exploration loops or invoke ad-hoc subagents when a Puppetmaster swarm is available.
+When this repo is open — and you are *not* a Puppetmaster worker (see above) —
+**Puppetmaster's MCP tools are the primary path for fanning out work**. Do not
+roll your own grep/read exploration loops or invoke ad-hoc subagents when a
+Puppetmaster swarm is available.
 
 ## When to start a Puppetmaster swarm (do this by default)
 

--- a/puppetmaster/rules.py
+++ b/puppetmaster/rules.py
@@ -59,6 +59,20 @@ RULE_BODY = textwrap.dedent(
     `puppetmaster install-codex-mcp`), the `puppetmaster_*` MCP tools are
     available in this environment.
 
+    ## Are you a Puppetmaster worker? (check this first)
+
+    **If Puppetmaster issued your prompt, every delegation rule below is void
+    for you.** You *are* the worker it delegated to. Do the analysis or the
+    edit yourself and return the artifacts your prompt asks for.
+
+    You are a Puppetmaster worker if your prompt contains a `Puppetmaster
+    artifact contract:` block, a `Role: <role>` + `Goal: <goal>` header, or an
+    instruction to finish by calling `submit_findings` / `submit_report`.
+    Workers run as plain agent CLIs with **no `puppetmaster_*` MCP tools**, so
+    delegating is impossible; attempting it spends the whole context window and
+    returns a clarifying question instead of findings. Explore with your own
+    native tools — that is the job you were spawned for.
+
     ## Trigger convention (must obey)
 
     When the user says **"Use Puppetmaster to …"**, **"PM this …"**, or

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -13913,6 +13913,29 @@ class InstallRulesTests(unittest.TestCase):
                 msg="the worker exemption must precede the delegate-first gate",
             )
 
+    def test_hand_maintained_rules_exempt_puppetmaster_workers(self):
+        """Repo ``AGENTS.md`` and ``puppetmaster-workflow.mdc`` are not rendered
+        from ``RULE_BODY``. They must carry the same worker exemption, ahead of
+        the swarm-start language, or a Codex/Cursor worker in this repo still
+        hits the original self-delegation loop."""
+        root = Path(__file__).resolve().parents[1]
+        files = (
+            root / "AGENTS.md",
+            root / ".cursor" / "rules" / "puppetmaster-workflow.mdc",
+        )
+        for path in files:
+            text = path.read_text(encoding="utf-8")
+            flattened = " ".join(text.split())
+            lowered = flattened.lower()
+            self.assertIn("are you a puppetmaster worker", lowered)
+            self.assertIn("Puppetmaster artifact contract:", flattened)
+            self.assertIn("submit_findings", flattened)
+            self.assertLess(
+                lowered.index("are you a puppetmaster worker"),
+                lowered.index("start a puppetmaster swarm"),
+                msg=f"{path.name} must exempt workers before telling them to start a swarm",
+            )
+
     def test_rules_nudge_labeling_every_job(self):
         """Every platform's managed rules (they share RULE_BODY) must tell the
         agent to pass a short `label` on start_*/edit verbs so dashboard jobs

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -13889,6 +13889,30 @@ class InstallRulesTests(unittest.TestCase):
             self.assertIn("Partial coverage is still coverage", flattened)
             self.assertIn("never re-crawl directories the graph already covers", flattened)
 
+    def test_rules_exempt_puppetmaster_workers_from_delegation(self):
+        """A Puppetmaster worker runs as a plain agent CLI with no
+        ``puppetmaster_*`` MCP tools, but it still reads the managed rule
+        block (workspace ``AGENTS.md``, ``~/.codex/instructions.md``,
+        ``~/.claude/CLAUDE.md``, the Cursor ``.mdc``). Without an explicit
+        exemption the delegate-first gate tells it to start a swarm it cannot
+        reach, so it burns its context and returns a clarifying question
+        instead of findings. The exemption must appear in every render, and
+        ahead of the gate it overrides."""
+        from puppetmaster.rules import RULE_BODY, render_agents_block, render_cursor_mdc
+
+        for content in (RULE_BODY, render_cursor_mdc(), render_agents_block()):
+            flattened = " ".join(content.split())
+            self.assertIn("Are you a Puppetmaster worker? (check this first)", flattened)
+            self.assertIn("every delegation rule below is void", flattened)
+            self.assertIn("Puppetmaster artifact contract:", flattened)
+            self.assertIn("submit_findings", flattened)
+            self.assertIn("no `puppetmaster_*` MCP tools", flattened)
+            self.assertLess(
+                flattened.index("Are you a Puppetmaster worker?"),
+                flattened.index("Delegate-first gate"),
+                msg="the worker exemption must precede the delegate-first gate",
+            )
+
     def test_rules_nudge_labeling_every_job(self):
         """Every platform's managed rules (they share RULE_BODY) must tell the
         agent to pass a short `label` on start_*/edit verbs so dashboard jobs


### PR DESCRIPTION
## The problem

A Puppetmaster worker is spawned by `puppetmaster.worker_runtime` as a plain Codex / Claude Code / Cursor CLI. It has **no `puppetmaster_*` MCP tools**.

But it starts inside the user's repository, so it loads exactly the rule files `install-rules` writes, and reads:

> **Puppetmaster's MCP tools are the primary path for fanning out work.** Do not roll your own grep/read exploration loops... start a Puppetmaster swarm **before** spending tokens on your own exploration.

It cannot start a swarm. So it spends its context deciding what to do about an instruction it has no way to follow, and returns a clarifying question instead of findings.

Observed on this repository while running a multi-role analysis swarm: both Codex analysis workers gave up in ~17 seconds having consumed **27,250 input tokens to emit 127 output tokens**.

This is not limited to this repo. `RULE_BODY` in `puppetmaster/rules.py` is written to:

| Target | Scope |
|---|---|
| workspace `AGENTS.md` | every repo `install-rules` touches |
| `~/.codex/instructions.md` | **global** — every Codex session on the machine |
| `~/.claude/CLAUDE.md` | **global** — every Claude Code session on the machine |
| `.cursor/rules/puppetmaster.mdc` | workspace, `alwaysApply: true` |
| `~/.hermes/SOUL.md` | **global** |

A Codex or Claude Code worker Puppetmaster spawns in *any* repo reads the global block. So the delegate-first gate is served to the very processes that exist to satisfy it.

## Why the existing fallback doesn't cover it

`RULE_BODY` already ends with:

> ## Fallback
> If `puppetmaster_*` tools are not connected, fall back to native tooling — do not pretend the tools exist.

Too weak and too late. It sits *after* the delegate-first gate, and it reads as advice about a broken MCP connection, not about being the worker that was delegated to. In practice the models resolve the conflict by asking rather than by proceeding.

## The change

Add an explicit exemption **ahead of the gate it overrides**, in all four places an agent can pick the directive up:

- **`RULE_BODY` in `puppetmaster/rules.py`** — feeds every managed render (`render_agents_block`, `render_cursor_mdc`, the Codex/Claude global blocks, the Hermes SOUL block), so every install gets the fix.
- **this repo's `AGENTS.md`** and **`.cursor/rules/puppetmaster-workflow.mdc`** — hand-maintained, not generated from `RULE_BODY`.

Workers have no marker env var (`_spawn_worker` passes only `TRACEPARENT` / `PUPPETMASTER_TRACEPARENT` beyond the inherited environment), so the exemption keys on what a worker can actually observe about *itself*:

- a `Puppetmaster artifact contract:` block,
- a `Role: <role>` + `Goal: <goal>` header,
- an instruction to finish by calling `submit_findings` / `submit_report`.

All three come from `puppetmaster/adapters/_prompts.py` and `puppetmaster/swarm_launch.py` and are present on every analysis and implement worker prompt.

## Test

`test_rules_exempt_puppetmaster_workers_from_delegation` asserts the exemption appears in `RULE_BODY`, `render_cursor_mdc()`, and `render_agents_block()`, and that it is **ordered before** the delegate-first gate.

## Verification

Fork CI (this repo's own `ci.yml`) on the branch head: https://github.com/bsmi021/Puppetmaster/actions/runs/32193878452 — all legs green.

**Correction to an earlier version of this description**, which claimed a green local full-suite run. That claim was based on `python -m unittest discover 2>&1 | tail -8`, whose exit status is `tail`'s, not `unittest`'s — so it proved nothing. A correctly-measured local run on this machine reports 13 failures. I then ran the same suite against **unmodified `main`** on the same machine: also 13 failures, 12 of them the identical test names (the 13th differs only between two tests in the same order-sensitive memory-retrieval area). So they are pre-existing here and environmental — `test_models_path_points_at_missing_sentinel` fails because a *populated* model registry appears at the path the hermetic harness pins to a deliberately-missing sentinel, and the routing failures downstream show agentic/gemini picks where the test expected a pinned or local adapter. This machine has live plan auth and provider keys that CI does not. Fork CI, which runs the same suite without them, is green.

## Note

No `docs/CHANGELOG.md` entry: three sibling PRs from this review are open concurrently and would all conflict on the same `## Unreleased` heading. Happy to add one on request.


