### PR TITLE
Record whether a discovered catalog was live or curated

### DIFF
--- a/puppetmaster/cli/commands_models.py
+++ b/puppetmaster/cli/commands_models.py
@@ -728,6 +728,7 @@ def _run_models_discover(args, path: Path) -> int:
     import json as _json
 
     from puppetmaster.model_registry import (
+        DISCOVERY_ORIGIN_LIVE,
         catalog_content_hash,
         discovery_registry_diff,
         load_registry,
@@ -816,6 +817,7 @@ def _run_models_discover(args, path: Path) -> int:
                 model_ids=[item["id"] for item in catalogs.get(src, []) if item.get("id")],
                 catalog_hash=catalog_content_hash(catalogs.get(src, [])),
                 mode="apply",
+                origin=report.get("origin", DISCOVERY_ORIGIN_LIVE),
             )
         if not args.json:
             print(f"Wrote merged registry to {path}")
@@ -911,7 +913,18 @@ class _DiscoverSourceError(RuntimeError):
     pass
 
 def _discover_one_source(source: str, registry: list, *, prune: bool = False):
-    """Fetch + merge one catalog source; returns (registry, report, catalog)."""
+    """Fetch + merge one catalog source; returns (registry, report, catalog).
+
+    ``report["origin"]`` records whether the catalog was actually fetched from
+    the platform (``live``) or read out of the compiled-in curated list
+    (``curated``) -- Claude Code, Codex, Hermes, and the agentic providers
+    expose no queryable model API, so their "discovery" is a re-apply.
+    """
+    from puppetmaster.model_registry import (
+        DISCOVERY_ORIGIN_CURATED,
+        DISCOVERY_ORIGIN_LIVE,
+    )
+
     if source == "cursor":
         from puppetmaster.cursor_discovery import (
             CursorDiscoveryError,
@@ -927,6 +940,7 @@ def _discover_one_source(source: str, registry: list, *, prune: bool = False):
             registry, catalog, prune=prune
         )
         report["source"] = "cursor"
+        report["origin"] = DISCOVERY_ORIGIN_LIVE
         return merged, report, catalog
 
     if source == "hermes":
@@ -945,6 +959,7 @@ def _discover_one_source(source: str, registry: list, *, prune: bool = False):
             "hermes", "api", registry, allowed_providers=allowed
         )
         report["source"] = "hermes"
+        report["origin"] = DISCOVERY_ORIGIN_CURATED
         report["available_providers"] = sorted(allowed)
         catalog = [
             {"id": item["model"]}
@@ -980,6 +995,7 @@ def _discover_one_source(source: str, registry: list, *, prune: bool = False):
             except Exception as exc:
                 report["bedrock"] = {"error": repr(exc)}
         report["source"] = "agentic"
+        report["origin"] = DISCOVERY_ORIGIN_CURATED
         report["available_providers"] = sorted(allowed)
         if bedrock_present and "bedrock" not in allowed:
             report.setdefault("bedrock", {})
@@ -1029,6 +1045,7 @@ def _discover_one_source(source: str, registry: list, *, prune: bool = False):
         merged, report = merge_curated_into_registry(adapter, billing, registry)
         catalog = [{"id": item["model"]} for item in curated_catalog(adapter)]
         report["source"] = source
+        report["origin"] = DISCOVERY_ORIGIN_CURATED
         return merged, report, catalog
 
     from puppetmaster.api_discovery import (
@@ -1054,4 +1071,5 @@ def _discover_one_source(source: str, registry: list, *, prune: bool = False):
     except ApiDiscoveryError as exc:
         raise _DiscoverSourceError(str(exc)) from exc
     report["source"] = source
+    report["origin"] = DISCOVERY_ORIGIN_LIVE
     return merged, report, catalog

--- a/puppetmaster/diagnostics.py
+++ b/puppetmaster/diagnostics.py
@@ -121,8 +121,10 @@ def _catalog_freshness_check() -> Check:
     records when each source was last enumerated and its model membership;
     this surfaces a reminder before routing quietly uses an out-of-date view."""
     from puppetmaster.model_registry import (
+        DISCOVERY_ORIGIN_CURATED,
         catalog_staleness_days,
         discovery_catalog_changed,
+        discovery_origin,
         discovery_registry_drift,
         read_discovery_meta,
     )
@@ -141,6 +143,7 @@ def _catalog_freshness_check() -> Check:
         stale_threshold = 7.0
     stale: list[str] = []
     fresh: list[str] = []
+    curated: list[str] = []
     drift: list[str] = []
     changed: list[str] = []
     for source in meta:
@@ -148,7 +151,15 @@ def _catalog_freshness_check() -> Check:
         if age is None:
             continue
         label = f"{source} {age:.0f}d"
-        (stale if age > stale_threshold else fresh).append(label)
+        if discovery_origin(meta, source) == DISCOVERY_ORIGIN_CURATED:
+            # A curated catalog is compiled into the package: it does not go
+            # stale with wall-clock time and re-running discovery can never
+            # surface a model the installed version does not already list.
+            # Ageing it would nag the user toward a refresh that cannot help;
+            # calling it "fresh" would claim a live check that never happened.
+            curated.append(source)
+        else:
+            (stale if age > stale_threshold else fresh).append(label)
         if discovery_catalog_changed(meta, source):
             changed.append(source)
         membership = discovery_registry_drift(source=source)
@@ -175,10 +186,17 @@ def _catalog_freshness_check() -> Check:
             + ". Run `puppetmaster models discover --probe` to review, then "
             "`puppetmaster models discover --write` to apply.",
         )
+    details = []
+    if fresh:
+        details.append(f"catalog fresh ({', '.join(fresh)})")
+    if curated:
+        details.append(
+            f"curated (compiled into this build, not queryable): {', '.join(sorted(curated))}"
+        )
     return Check(
         "catalog-freshness",
         "ok",
-        f"catalog fresh ({', '.join(fresh) or 'recently discovered'})",
+        ". ".join(details) or "catalog fresh (recently discovered)",
     )
 
 

--- a/puppetmaster/model_registry.py
+++ b/puppetmaster/model_registry.py
@@ -919,6 +919,30 @@ def discovery_meta_path(registry_path: Optional[Path] = None) -> Path:
     return resolved.with_name(resolved.stem + ".discovery.json")
 
 
+DISCOVERY_ORIGIN_LIVE = "live"
+"""The platform's own model API was queried for this snapshot."""
+
+DISCOVERY_ORIGIN_CURATED = "curated"
+"""The snapshot came from the hand-maintained catalog compiled into the
+package, because the platform exposes no queryable model list."""
+
+DISCOVERY_ORIGINS = frozenset({DISCOVERY_ORIGIN_LIVE, DISCOVERY_ORIGIN_CURATED})
+
+
+def discovery_origin(meta: dict[str, Any], source: str) -> str:
+    """How ``source``'s recorded snapshot was obtained.
+
+    Defaults to ``"live"`` for entries written before the field existed, which
+    keeps every pre-existing sidecar readable instead of failing closed on a
+    missing key.
+    """
+    entry = meta.get(source)
+    if not isinstance(entry, dict):
+        return DISCOVERY_ORIGIN_LIVE
+    value = str(entry.get("origin") or DISCOVERY_ORIGIN_LIVE)
+    return value if value in DISCOVERY_ORIGINS else DISCOVERY_ORIGIN_LIVE
+
+
 def read_discovery_meta(registry_path: Optional[Path] = None) -> dict[str, Any]:
     """Return ``{source: {refreshed_at, count}}`` recorded by ``models discover``."""
     path = discovery_meta_path(registry_path)
@@ -941,6 +965,7 @@ def write_discovery_meta(
     catalog_hash: Optional[str] = None,
     mode: str = "apply",
     pending_diff: Optional[dict[str, Any]] = None,
+    origin: str = DISCOVERY_ORIGIN_LIVE,
 ) -> Path:
     """Record that ``source`` (e.g. ``cursor``/``openai``/``anthropic``) was
     just discovered, with how many models it returned and when.
@@ -948,15 +973,36 @@ def write_discovery_meta(
     ``model_ids`` is an optional membership snapshot. Keeping it beside the
     timestamp lets diagnostics distinguish an old catalog from a registry
     whose entries have drifted away from the last known live catalog.
+
+    ``origin`` records *how* the snapshot was obtained. ``"live"`` means the
+    platform was actually queried (Cursor's plan endpoint, ``/v1/models``).
+    ``"curated"`` means it came from :data:`puppetmaster.static_catalog.
+    CURATED_CATALOGS` -- a hand-maintained list compiled into the package,
+    because that platform has no queryable model API. Without this the two are
+    indistinguishable in the sidecar: a curated apply writes a fresh
+    ``refreshed_at`` that reads as a successful live refresh, so `doctor`
+    reports the catalog "fresh" and re-running ``models discover`` looks like
+    it should surface new models when it can only ever re-apply the same
+    compiled-in list. Legacy entries written before this field default to
+    ``"live"`` (see :func:`discovery_origin`).
     """
     from datetime import datetime, timezone
 
     if mode not in {"apply", "probe"}:
         raise ValueError("discovery metadata mode must be 'apply' or 'probe'")
+    if origin not in DISCOVERY_ORIGINS:
+        raise ValueError(
+            "discovery metadata origin must be one of "
+            f"{sorted(DISCOVERY_ORIGINS)}"
+        )
     path = discovery_meta_path(registry_path)
     meta = read_discovery_meta(registry_path)
     stamp = now_iso or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    entry: dict[str, Any] = {"refreshed_at": stamp, "count": count}
+    entry: dict[str, Any] = {
+        "refreshed_at": stamp,
+        "count": count,
+        "origin": origin,
+    }
     if model_ids is not None:
         normalized_ids = sorted(
             {str(model_id) for model_id in model_ids if str(model_id)}

--- a/puppetmaster/static_catalog.py
+++ b/puppetmaster/static_catalog.py
@@ -898,6 +898,7 @@ def ensure_subscription_plan_catalog(
         has_plan_frontier,
     )
     from puppetmaster.model_registry import (
+        DISCOVERY_ORIGIN_CURATED,
         load_registry,
         read_discovery_meta,
         save_registry,
@@ -936,6 +937,7 @@ def ensure_subscription_plan_catalog(
                 registry_path,
                 model_ids=[item["model"] for item in catalog if item.get("model")],
                 catalog_hash=catalog_content_hash(catalog),
+                origin=DISCOVERY_ORIGIN_CURATED,
             )
             return {
                 "action": "discovered",

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -18588,6 +18588,123 @@ class SubscriptionPlanCatalogTests(unittest.TestCase):
             self.assertTrue(meta.get("claude"))
             self.assertTrue(meta["claude"].get("model_ids"))
 
+    def test_curated_autodiscovery_records_curated_origin(self) -> None:
+        """`ensure_subscription_plan_catalog` applies CURATED_CATALOGS -- a list
+        compiled into the package -- but writes the same sidecar shape a live
+        `/v1/models` fetch does. Without an origin marker the two are
+        indistinguishable: the entry carries a fresh `refreshed_at` that reads
+        as a successful refresh, so `doctor` calls the catalog fresh and
+        re-running discovery looks like it could surface new models when it can
+        only ever re-apply the same compiled-in list."""
+        from puppetmaster.model_registry import (
+            DISCOVERY_ORIGIN_CURATED,
+            discovery_origin,
+            read_discovery_meta,
+        )
+        from puppetmaster.static_catalog import ensure_subscription_plan_catalog
+
+        with TemporaryDirectory() as tmp:
+            path = self._registry_path(tmp)
+            report = ensure_subscription_plan_catalog(
+                path,
+                billing_detector=lambda a: self._status(
+                    a,
+                    healthy=(a == "claude-code"),
+                    billing="plan" if a == "claude-code" else "unknown",
+                ),
+            )
+            self.assertEqual(report["action"], "discovered")
+            meta = read_discovery_meta(path)
+            self.assertEqual(meta["claude"]["origin"], DISCOVERY_ORIGIN_CURATED)
+            self.assertEqual(
+                discovery_origin(meta, "claude"), DISCOVERY_ORIGIN_CURATED
+            )
+
+    def test_discovery_origin_defaults_live_for_legacy_entries(self) -> None:
+        """Sidecars written before the field exists must stay readable."""
+        from puppetmaster.model_registry import (
+            DISCOVERY_ORIGIN_LIVE,
+            discovery_origin,
+            write_discovery_meta,
+        )
+
+        legacy = {"cursor": {"refreshed_at": "2026-01-01T00:00:00Z", "count": 3}}
+        self.assertEqual(discovery_origin(legacy, "cursor"), DISCOVERY_ORIGIN_LIVE)
+        self.assertEqual(discovery_origin(legacy, "absent"), DISCOVERY_ORIGIN_LIVE)
+        self.assertEqual(
+            discovery_origin({"x": {"origin": "nonsense"}}, "x"), DISCOVERY_ORIGIN_LIVE
+        )
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "models.json"
+            # Default stays live so every existing caller is unchanged.
+            write_discovery_meta("cursor", 2, path)
+            from puppetmaster.model_registry import read_discovery_meta
+
+            self.assertEqual(
+                read_discovery_meta(path)["cursor"]["origin"], DISCOVERY_ORIGIN_LIVE
+            )
+            with self.assertRaises(ValueError):
+                write_discovery_meta("cursor", 2, path, origin="bogus")
+
+    def test_doctor_labels_curated_catalog_instead_of_ageing_it(self) -> None:
+        """A curated catalog does not go stale with wall-clock time and cannot
+        be refreshed by re-running discovery, so `doctor` must neither nag
+        about its age nor claim a live check happened."""
+        from puppetmaster.diagnostics import _catalog_freshness_check
+        from puppetmaster.model_registry import DISCOVERY_ORIGIN_CURATED
+
+        old = "2020-01-01T00:00:00Z"
+        meta = {
+            "cursor": {"refreshed_at": old, "count": 3, "origin": "live"},
+            "claude": {
+                "refreshed_at": old,
+                "count": 8,
+                "origin": DISCOVERY_ORIGIN_CURATED,
+            },
+        }
+        with patch(
+            "puppetmaster.model_registry.read_discovery_meta", return_value=meta
+        ), patch(
+            "puppetmaster.model_registry.discovery_catalog_changed", return_value=False
+        ), patch(
+            "puppetmaster.model_registry.discovery_registry_drift",
+            return_value={"status": "match"},
+        ):
+            check = _catalog_freshness_check()
+        self.assertEqual(check.status, "warn")
+        # The live source is aged and named in the stale list...
+        self.assertIn("cursor", check.detail)
+        # ...the curated one is not dragged into it.
+        self.assertNotIn("claude", check.detail.split("registry")[0])
+
+    def test_doctor_reports_curated_catalog_as_curated_not_fresh(self) -> None:
+        from puppetmaster.diagnostics import _catalog_freshness_check
+        from puppetmaster.model_registry import DISCOVERY_ORIGIN_CURATED
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        meta = {
+            "claude": {
+                "refreshed_at": now,
+                "count": 8,
+                "origin": DISCOVERY_ORIGIN_CURATED,
+            }
+        }
+        with patch(
+            "puppetmaster.model_registry.read_discovery_meta", return_value=meta
+        ), patch(
+            "puppetmaster.model_registry.discovery_catalog_changed", return_value=False
+        ), patch(
+            "puppetmaster.model_registry.discovery_registry_drift",
+            return_value={"status": "match"},
+        ):
+            check = _catalog_freshness_check()
+        self.assertEqual(check.status, "ok")
+        self.assertIn("curated", check.detail)
+        self.assertIn("claude", check.detail)
+        self.assertNotIn("catalog fresh", check.detail)
+
     def test_skips_when_plan_frontier_present(self) -> None:
         from puppetmaster.model_registry import ModelSpec, save_registry
         from puppetmaster.static_catalog import ensure_subscription_plan_catalog


### PR DESCRIPTION
## The problem

`~/.puppetmaster/models.discovery.json` records the same shape for every source:

```json
"claude": {
  "refreshed_at": "2026-08-17T14:40:29Z",
  "count": 7,
  "mode": "apply",
  "catalog_hash": "sha256:...",
  "last_applied_hash": "sha256:..."
}
```

That reads as "the Claude catalog was successfully refreshed from the platform 20 minutes ago." It wasn't. `static_catalog.py` states it plainly in its own module docstring:

> The two **CLI agent loops** — Claude Code and Codex — do *not* offer a queryable model list, so historically their registry tiers had to be hand-maintained.

So for `claude`, `codex`, `hermes`, and `agentic`, "discovery" re-applies `CURATED_CATALOGS` — a list compiled into the installed package. Nothing is fetched. But the sidecar entry is byte-identical in shape to a live Cursor plan fetch or an `/v1/models` call, so nothing downstream can tell them apart:

- **`doctor` reports it as fresh** — `catalog-freshness: ok, catalog fresh (claude 0d)` — and then ages it toward `catalog stale (>7d): claude 9d. Run puppetmaster models discover --probe ... --write to apply`. That refresh cannot help. Re-running it re-emits the same compiled-in list.
- **Re-running `models discover --write` looks like it should surface a newly released model.** It can only ever produce what the installed version already ships; a genuinely new model needs a package upgrade or a hand-edited registry.

## The change — additive, backward compatible

`refreshed_at` keeps its name and meaning. `catalog_staleness_days` still reads it, so every persisted sidecar stays readable and no other consumer moves.

- **`write_discovery_meta(..., origin=...)`** accepts `"live"` (the default, so every existing call site is unchanged) or `"curated"`, and rejects anything else the way `mode` already does.
- **`discovery_origin(meta, source)`** reads it back, defaulting to `"live"` for sidecars written before the field existed *and* for an unrecognized value — no migration, nothing fails closed on a missing key.
- **`_discover_one_source`** stamps `report["origin"]`: `curated` for `hermes` / `agentic` / `claude` / `codex`, `live` for `cursor` / `openai` / `anthropic`. `models discover --write` threads it into the sidecar, and `ensure_subscription_plan_catalog` stamps `curated` on the first-run auto-merge path.
- **`doctor`** reports curated sources as `curated (compiled into this build, not queryable): claude` instead of ageing them, and stops counting them toward the staleness warning. Drift and catalog-changed detection are untouched — those are real signals whatever the origin.

## Tests

Four, covering the field, its default, and both rendering branches:

- curated auto-discovery writes `origin: curated`
- legacy entries (no field), unknown sources, and a garbage value all read back as `live`; the default write stays `live`; a bogus `origin` raises
- `doctor` does not drag a curated source into the stale list alongside a genuinely stale live one
- `doctor` reports a curated source as *curated*, not as *fresh*

## Left for a follow-up, deliberately

`preflight._cached_catalog_verdict` also keys off `catalog_staleness_days`. For a curated snapshot that means it is treated as an authoritative catalog for one hour and then reported `catalog unverified (cached Nd old)` forever after — both odd framings for a list that ages with the package version, not the clock. I left that path alone here because it gates dispatch and I didn't want a labelling PR to change routing behaviour. `discovery_origin` is now available to fix it separately if you want it.

## Verification

Fork CI (this repo's own `ci.yml`) at this branch's head commit `4066eb0`, since Actions don't run on a fork PR without maintainer approval — **all 4 legs green**: ubuntu 3.9, ubuntu 3.12, macOS 3.12, windows 3.12.

https://github.com/bsmi021/Puppetmaster/actions/runs/32195096999

## Note

No `docs/CHANGELOG.md` entry: sibling PRs from the same review are open concurrently and would all conflict on the same `## Unreleased` heading. Happy to add one on request.
