### PR TITLE
Stop analysis prompts from reading as questions about the contract

### DIFF
--- a/puppetmaster/adapters/_prompts.py
+++ b/puppetmaster/adapters/_prompts.py
@@ -28,8 +28,25 @@ _IMPLEMENT_REPORT_CONTRACT = (
 )
 
 
+# Opening line of every analysis prompt. gpt-5.6 models read the first noun
+# phrase they see as the subject of the request, so a prompt that opened on
+# "Puppetmaster artifact contract:" got answered *about the contract*. Naming
+# where the assignment actually lives, before anything else, is what fixes it.
+# Static, so it stays inside the shared cacheable prefix.
+# NB: do not write the literal "Your task:" (with the colon) here --
+# split_prompt_messages() splits the system/user seam on the first bare
+# occurrence of TASK_INSTRUCTION_HEADER, so an inline mention would move the
+# seam to this line and collapse the shared system prefix.
+_PROMPT_ORIENTATION = (
+    "Read this entire prompt before acting. Your assignment is the final "
+    'section, the one headed "Your task". Everything above it -- output '
+    "format, contract, repository context -- tells you HOW to answer and is "
+    "never itself the thing to analyze, define, or ask about."
+)
+
+
 _PUPPETMASTER_ARTIFACT_CONTRACT_LINES = (
-    "Puppetmaster artifact contract:",
+    "OUTPUT FORMAT (the Puppetmaster artifact contract for your reply):",
     "Return only JSON, with no markdown wrapper, in this shape:",
     '{"artifacts":[{"type":"finding","claim":"...","evidence":["path or symbol"],"confidence":0.8}]}',
     "Allowed artifact types:",
@@ -142,7 +159,7 @@ def build_structured_prompt(
         else (prompt or "")
     )
 
-    lines: list[str] = []
+    lines: list[str] = [_PROMPT_ORIENTATION, ""]
     if final_message_note:
         # Primary contract: finish by CALLING the submit_findings tool. The
         # provider constrains the tool's arguments, so structure is reliable even

--- a/tests/test_prompt_prefix.py
+++ b/tests/test_prompt_prefix.py
@@ -51,16 +51,55 @@ class BuildPromptOrderTests(unittest.TestCase):
     def test_build_structured_prompt_puts_contract_before_instruction(self) -> None:
         instruction = "Review the payment module"
         prompt = build_structured_prompt(instruction)
-        self.assertTrue(prompt.startswith("Puppetmaster artifact contract:"))
+        # The contract still precedes the instruction (static-first, so sibling
+        # workers share a cacheable prefix) -- it is just no longer the first
+        # thing the model reads. See the orientation test below.
         self.assertTrue(prompt.rstrip().endswith(instruction))
         self.assertLess(
-            prompt.index("Puppetmaster artifact contract:"),
+            prompt.index("Puppetmaster artifact contract"),
             prompt.index(TASK_INSTRUCTION_HEADER),
         )
         note = build_structured_prompt(instruction, final_message_note=True)
         self.assertTrue(note.rstrip().endswith(instruction))
         self.assertIn("submit_findings", note)
         self.assertLess(note.index("submit_findings"), note.index(TASK_INSTRUCTION_HEADER))
+
+    def test_structured_prompt_opens_by_locating_the_task(self) -> None:
+        """gpt-5.6 models answer *about* the first noun phrase they read.
+
+        Opening on "Puppetmaster artifact contract:" made them treat the
+        contract as the subject: one asked what to do with the contract,
+        another spent 51k input tokens explaining what it is. Four of four
+        Codex analysis runs degraded that way, across two models. So the
+        prompt must open by saying where the assignment lives and that nothing
+        above it is the subject, and must label the contract as output format.
+        """
+        for prompt in (
+            build_structured_prompt("Review the payment module"),
+            build_structured_prompt("Review the payment module", final_message_note=True),
+        ):
+            first_line = prompt.splitlines()[0]
+            self.assertIn("Read this entire prompt before acting", first_line)
+            self.assertIn("Your task", first_line)
+            # The orientation must NOT contain the bare TASK_INSTRUCTION_HEADER:
+            # split_prompt_messages() cuts the system/user seam at its first
+            # occurrence, so an inline mention would collapse the shared prefix.
+            self.assertNotIn(TASK_INSTRUCTION_HEADER, first_line)
+            self.assertEqual(prompt.count(TASK_INSTRUCTION_HEADER), 1)
+            self.assertLess(
+                prompt.index("Read this entire prompt"),
+                prompt.index("Puppetmaster artifact contract"),
+            )
+            self.assertIn("OUTPUT FORMAT", prompt)
+            # `with_report_contract` keys off this literal to avoid stacking a
+            # second contract; the relabel must not break that detection.
+            self.assertIn("Puppetmaster artifact contract", prompt)
+
+    def test_report_contract_still_detects_the_relabelled_contract(self) -> None:
+        from puppetmaster.adapters._prompts import with_report_contract
+
+        structured = build_structured_prompt("Review the payment module")
+        self.assertEqual(with_report_contract(structured), structured)
 
 class JobStableSectionOrderTests(unittest.TestCase):
     def test_memory_skills_census_appear_before_instruction(self) -> None:


### PR DESCRIPTION
## The problem

Every analysis prompt `build_structured_prompt` produces opened on this line:

```
Puppetmaster artifact contract:
```

gpt-5.6 models take the first noun phrase they see as the subject of the request. So they answered *about the contract* instead of about the repository:

- **gpt-5.6-luna** returned: *"What would you like me to do with the Puppetmaster artifact contract — define it, review an existing contract, implement it, or diagnose a failing artifact?"*
- **gpt-5.6-terra** spent **51,351 input tokens** researching and explaining what the artifact contract is.

**4 of 4 Codex analysis runs degraded that way** (`result: degraded`, `empty-or-unstructured`), across two models and two prompt variants — including one variant that explicitly neutralised the unrelated AGENTS.md self-delegation problem (#33). Removing the preamble and holding everything else constant produced real analysis from the same models on the same repo. Claude models on the identical contract are unaffected.

`ArtifactContractGroundingTests` already documents this failure class — a redteam role emitting a nonsense risk about the contract text — and `_ARTIFACT_GROUNDING` was added to fix it. That prose helps, but it sits *below* the header, and by the time it is read gpt-5.6 has already fixed on the opening line.

## The change — relabel, not reorder

The contract has to stay ahead of the task. `TASK_INSTRUCTION_HEADER` is a deliberate static-first seam so sibling workers share a cacheable prefix (`SharedPrefixPropertyTests` pins it, and `split_prompt_messages` cuts the agentic system/user boundary there). Putting the task first would defeat that design. So instead:

1. **Open on `_PROMPT_ORIENTATION`**, which names where the assignment actually lives and says everything above it is *how* to answer, never the thing to analyse. It is static, so the shared prefix is preserved and the cache seam does not move.
2. **Relabel the contract header** to `OUTPUT FORMAT (the Puppetmaster artifact contract for your reply):`. The literal substring `Puppetmaster artifact contract` is kept on purpose — `with_report_contract` keys on it to avoid stacking a second contract onto an implement prompt. A test now pins that detection.

One subtlety worth flagging: the orientation deliberately writes `"Your task"` **without** the colon. `split_prompt_messages` cuts the system/user seam at the first bare occurrence of `TASK_INSTRUCTION_HEADER`, so an inline mention with the colon would move the seam onto that first line and collapse the entire shared system prefix. My first draft did exactly that and the existing ordering test caught it; there is now a test asserting the header appears exactly once and never in the orientation.

## Tests

- `test_structured_prompt_opens_by_locating_the_task` — the first line orients before the contract, the contract is labelled `OUTPUT FORMAT`, the detection literal survives, and `TASK_INSTRUCTION_HEADER` appears exactly once
- `test_report_contract_still_detects_the_relabelled_contract` — `with_report_contract` is still a no-op on a structured prompt
- the existing ordering test is retained, loosened only from `startswith` to "contract precedes the instruction"

## Verification — and one honest gap

Fork CI at this branch's head commit `46d0048`, **all 4 legs green**: https://github.com/bsmi021/Puppetmaster/actions/runs/32195103678

**The controlled A/B I ran on this specific wording did not reproduce the original failure, so it neither confirms nor refutes the fix.** I ran gpt-5.6-luna twice against this repo — once with the old header, once with the new — holding model, task, and repo constant. Both arms returned six well-grounded artifacts with `file:line` evidence; neither asked about the contract. The likely reason is prompt size: I fed the bare `build_structured_prompt` output (~1 KB), while the four degraded runs went through the full production path — contract, then job brief, repo census, CodeGraph context and memory — where the leading line dominates a much larger prompt.

So the motivating evidence is the original 4/4 degradation through the production path, not a fresh controlled run of this exact wording. I'd rather say that plainly than imply a validation I don't have. If you'd prefer this held until it's reproduced end-to-end through a real swarm, that's a reasonable call.

(A side effect worth reporting: with the Codex sandbox bypassed, the run against unpatched `AGENTS.md` spawned two Puppetmaster swarm jobs of its own rather than analysing directly — a live reproduction of #33's self-delegation loop.)

## Note

No `docs/CHANGELOG.md` entry: sibling PRs from the same review are open concurrently and would all conflict on the same `## Unreleased` heading. Happy to add one on request.
