### PR TITLE
absorb #35 #36 #37: catalog origin and prompt orientation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,22 @@
+## Unreleased
+
+Absorb of [@bsmi021](https://github.com/bsmi021) PRs
+[#35](https://github.com/professorpalmer/Puppetmaster/pull/35),
+[#36](https://github.com/professorpalmer/Puppetmaster/pull/36), and
+[#37](https://github.com/professorpalmer/Puppetmaster/pull/37), plus
+stack edits. No version bump on this landing.
+
+- **claude-sonnet-5.** Curated `claude-code` / `agentic` / `hermes`
+  catalogs gain Sonnet 5 (cap 87, $3/$15, 1M, `long-context`) so the
+  router can select it. Agentic and Hermes keep `provider=anthropic`.
+- **Discovery origin.** `models.discovery.json` records `live` vs
+  `curated`. Doctor no longer ages compiled-in Claude/Codex/Hermes/
+  agentic catalogs. `--probe` and `--write` both stamp origin.
+  Preflight skips the clock TTL only for an explicit `origin=curated`.
+- **Analysis prompt orientation.** Structured prompts open by locating
+  `Your task` and label the artifact contract as output format so
+  gpt-5.6 / Codex stop treating the contract as the subject.
+
 ## v1.22.10
 
 **Fix: spawned Codex / Claude Code / Cursor workers read the delegate-first

--- a/puppetmaster/adapters/_prompts.py
+++ b/puppetmaster/adapters/_prompts.py
@@ -28,8 +28,25 @@ _IMPLEMENT_REPORT_CONTRACT = (
 )
 
 
+# Opening line of every analysis prompt. gpt-5.6 models read the first noun
+# phrase they see as the subject of the request, so a prompt that opened on
+# "Puppetmaster artifact contract:" got answered *about the contract*. Naming
+# where the assignment actually lives, before anything else, is what fixes it.
+# Static, so it stays inside the shared cacheable prefix.
+# NB: do not write the literal "Your task:" (with the colon) here --
+# split_prompt_messages() splits the system/user seam on the first bare
+# occurrence of TASK_INSTRUCTION_HEADER, so an inline mention would move the
+# seam to this line and collapse the shared system prefix.
+_PROMPT_ORIENTATION = (
+    "Read this entire prompt before acting. Your assignment is the final "
+    'section, the one headed "Your task". Everything above it -- output '
+    "format, contract, repository context -- tells you HOW to answer and is "
+    "never itself the thing to analyze, define, or ask about."
+)
+
+
 _PUPPETMASTER_ARTIFACT_CONTRACT_LINES = (
-    "Puppetmaster artifact contract:",
+    "OUTPUT FORMAT (the Puppetmaster artifact contract for your reply):",
     "Return only JSON, with no markdown wrapper, in this shape:",
     '{"artifacts":[{"type":"finding","claim":"...","evidence":["path or symbol"],"confidence":0.8}]}',
     "Allowed artifact types:",
@@ -142,7 +159,7 @@ def build_structured_prompt(
         else (prompt or "")
     )
 
-    lines: list[str] = []
+    lines: list[str] = [_PROMPT_ORIENTATION, ""]
     if final_message_note:
         # Primary contract: finish by CALLING the submit_findings tool. The
         # provider constrains the tool's arguments, so structure is reliable even

--- a/puppetmaster/cli/commands_models.py
+++ b/puppetmaster/cli/commands_models.py
@@ -728,6 +728,7 @@ def _run_models_discover(args, path: Path) -> int:
     import json as _json
 
     from puppetmaster.model_registry import (
+        DISCOVERY_ORIGIN_LIVE,
         catalog_content_hash,
         discovery_registry_diff,
         load_registry,
@@ -816,6 +817,7 @@ def _run_models_discover(args, path: Path) -> int:
                 model_ids=[item["id"] for item in catalogs.get(src, []) if item.get("id")],
                 catalog_hash=catalog_content_hash(catalogs.get(src, [])),
                 mode="apply",
+                origin=report.get("origin", DISCOVERY_ORIGIN_LIVE),
             )
         if not args.json:
             print(f"Wrote merged registry to {path}")
@@ -879,6 +881,7 @@ def _run_models_discover(args, path: Path) -> int:
                 pending_diff=discovery_registry_diff(
                     original_registry, src, model_ids
                 ),
+                origin=report.get("origin", DISCOVERY_ORIGIN_LIVE),
             )
         if not args.json:
             print(
@@ -911,7 +914,18 @@ class _DiscoverSourceError(RuntimeError):
     pass
 
 def _discover_one_source(source: str, registry: list, *, prune: bool = False):
-    """Fetch + merge one catalog source; returns (registry, report, catalog)."""
+    """Fetch + merge one catalog source; returns (registry, report, catalog).
+
+    ``report["origin"]`` records whether the catalog was actually fetched from
+    the platform (``live``) or read out of the compiled-in curated list
+    (``curated``) -- Claude Code, Codex, Hermes, and the agentic providers
+    expose no queryable model API, so their "discovery" is a re-apply.
+    """
+    from puppetmaster.model_registry import (
+        DISCOVERY_ORIGIN_CURATED,
+        DISCOVERY_ORIGIN_LIVE,
+    )
+
     if source == "cursor":
         from puppetmaster.cursor_discovery import (
             CursorDiscoveryError,
@@ -927,6 +941,7 @@ def _discover_one_source(source: str, registry: list, *, prune: bool = False):
             registry, catalog, prune=prune
         )
         report["source"] = "cursor"
+        report["origin"] = DISCOVERY_ORIGIN_LIVE
         return merged, report, catalog
 
     if source == "hermes":
@@ -945,6 +960,7 @@ def _discover_one_source(source: str, registry: list, *, prune: bool = False):
             "hermes", "api", registry, allowed_providers=allowed
         )
         report["source"] = "hermes"
+        report["origin"] = DISCOVERY_ORIGIN_CURATED
         report["available_providers"] = sorted(allowed)
         catalog = [
             {"id": item["model"]}
@@ -980,6 +996,7 @@ def _discover_one_source(source: str, registry: list, *, prune: bool = False):
             except Exception as exc:
                 report["bedrock"] = {"error": repr(exc)}
         report["source"] = "agentic"
+        report["origin"] = DISCOVERY_ORIGIN_CURATED
         report["available_providers"] = sorted(allowed)
         if bedrock_present and "bedrock" not in allowed:
             report.setdefault("bedrock", {})
@@ -1029,6 +1046,7 @@ def _discover_one_source(source: str, registry: list, *, prune: bool = False):
         merged, report = merge_curated_into_registry(adapter, billing, registry)
         catalog = [{"id": item["model"]} for item in curated_catalog(adapter)]
         report["source"] = source
+        report["origin"] = DISCOVERY_ORIGIN_CURATED
         return merged, report, catalog
 
     from puppetmaster.api_discovery import (
@@ -1054,4 +1072,5 @@ def _discover_one_source(source: str, registry: list, *, prune: bool = False):
     except ApiDiscoveryError as exc:
         raise _DiscoverSourceError(str(exc)) from exc
     report["source"] = source
+    report["origin"] = DISCOVERY_ORIGIN_LIVE
     return merged, report, catalog

--- a/puppetmaster/diagnostics.py
+++ b/puppetmaster/diagnostics.py
@@ -121,8 +121,10 @@ def _catalog_freshness_check() -> Check:
     records when each source was last enumerated and its model membership;
     this surfaces a reminder before routing quietly uses an out-of-date view."""
     from puppetmaster.model_registry import (
+        DISCOVERY_ORIGIN_CURATED,
         catalog_staleness_days,
         discovery_catalog_changed,
+        discovery_origin,
         discovery_registry_drift,
         read_discovery_meta,
     )
@@ -141,6 +143,7 @@ def _catalog_freshness_check() -> Check:
         stale_threshold = 7.0
     stale: list[str] = []
     fresh: list[str] = []
+    curated: list[str] = []
     drift: list[str] = []
     changed: list[str] = []
     for source in meta:
@@ -148,7 +151,15 @@ def _catalog_freshness_check() -> Check:
         if age is None:
             continue
         label = f"{source} {age:.0f}d"
-        (stale if age > stale_threshold else fresh).append(label)
+        if discovery_origin(meta, source) == DISCOVERY_ORIGIN_CURATED:
+            # A curated catalog is compiled into the package: it does not go
+            # stale with wall-clock time and re-running discovery can never
+            # surface a model the installed version does not already list.
+            # Ageing it would nag the user toward a refresh that cannot help;
+            # calling it "fresh" would claim a live check that never happened.
+            curated.append(source)
+        else:
+            (stale if age > stale_threshold else fresh).append(label)
         if discovery_catalog_changed(meta, source):
             changed.append(source)
         membership = discovery_registry_drift(source=source)
@@ -175,10 +186,17 @@ def _catalog_freshness_check() -> Check:
             + ". Run `puppetmaster models discover --probe` to review, then "
             "`puppetmaster models discover --write` to apply.",
         )
+    details = []
+    if fresh:
+        details.append(f"catalog fresh ({', '.join(fresh)})")
+    if curated:
+        details.append(
+            f"curated (compiled into this build, not queryable): {', '.join(sorted(curated))}"
+        )
     return Check(
         "catalog-freshness",
         "ok",
-        f"catalog fresh ({', '.join(fresh) or 'recently discovered'})",
+        ". ".join(details) or "catalog fresh (recently discovered)",
     )
 
 

--- a/puppetmaster/model_registry.py
+++ b/puppetmaster/model_registry.py
@@ -919,6 +919,37 @@ def discovery_meta_path(registry_path: Optional[Path] = None) -> Path:
     return resolved.with_name(resolved.stem + ".discovery.json")
 
 
+DISCOVERY_ORIGIN_LIVE = "live"
+DISCOVERY_ORIGIN_CURATED = "curated"
+DISCOVERY_ORIGINS = frozenset({DISCOVERY_ORIGIN_LIVE, DISCOVERY_ORIGIN_CURATED})
+
+# Sources whose "discovery" re-applies CURATED_CATALOGS. A pre-field sidecar
+# for these was never a live fetch; cursor/openai/anthropic stay live.
+_CURATED_DISCOVERY_SOURCES = frozenset({"claude", "codex", "hermes", "agentic"})
+
+
+def discovery_origin(meta: dict[str, Any], source: str) -> str:
+    """How ``source``'s recorded snapshot was obtained.
+
+    Explicit garbage (an unrecognized ``origin`` value) defaults to ``"live"``
+    so a typo cannot silently flip a live fetch into curated treatment.
+
+    When the entry exists and ``origin`` is missing or empty — not garbage —
+    claude/codex/hermes/agentic read as ``"curated"``: those platforms have
+    never had a queryable catalog. cursor/openai/anthropic missing origin
+    stay ``"live"``.
+    """
+    entry = meta.get(source)
+    if not isinstance(entry, dict):
+        return DISCOVERY_ORIGIN_LIVE
+    if "origin" not in entry or entry.get("origin") in (None, ""):
+        if source in _CURATED_DISCOVERY_SOURCES:
+            return DISCOVERY_ORIGIN_CURATED
+        return DISCOVERY_ORIGIN_LIVE
+    value = str(entry.get("origin"))
+    return value if value in DISCOVERY_ORIGINS else DISCOVERY_ORIGIN_LIVE
+
+
 def read_discovery_meta(registry_path: Optional[Path] = None) -> dict[str, Any]:
     """Return ``{source: {refreshed_at, count}}`` recorded by ``models discover``."""
     path = discovery_meta_path(registry_path)
@@ -941,6 +972,7 @@ def write_discovery_meta(
     catalog_hash: Optional[str] = None,
     mode: str = "apply",
     pending_diff: Optional[dict[str, Any]] = None,
+    origin: str = DISCOVERY_ORIGIN_LIVE,
 ) -> Path:
     """Record that ``source`` (e.g. ``cursor``/``openai``/``anthropic``) was
     just discovered, with how many models it returned and when.
@@ -948,15 +980,36 @@ def write_discovery_meta(
     ``model_ids`` is an optional membership snapshot. Keeping it beside the
     timestamp lets diagnostics distinguish an old catalog from a registry
     whose entries have drifted away from the last known live catalog.
+
+    ``origin`` records *how* the snapshot was obtained. ``"live"`` means the
+    platform was actually queried (Cursor's plan endpoint, ``/v1/models``).
+    ``"curated"`` means it came from :data:`puppetmaster.static_catalog.
+    CURATED_CATALOGS` -- a hand-maintained list compiled into the package,
+    because that platform has no queryable model API. Without this the two are
+    indistinguishable in the sidecar: a curated apply writes a fresh
+    ``refreshed_at`` that reads as a successful live refresh, so `doctor`
+    reports the catalog "fresh" and re-running ``models discover`` looks like
+    it should surface new models when it can only ever re-apply the same
+    compiled-in list. Legacy entries written before this field are read by
+    :func:`discovery_origin`.
     """
     from datetime import datetime, timezone
 
     if mode not in {"apply", "probe"}:
         raise ValueError("discovery metadata mode must be 'apply' or 'probe'")
+    if origin not in DISCOVERY_ORIGINS:
+        raise ValueError(
+            "discovery metadata origin must be one of "
+            f"{sorted(DISCOVERY_ORIGINS)}"
+        )
     path = discovery_meta_path(registry_path)
     meta = read_discovery_meta(registry_path)
     stamp = now_iso or datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    entry: dict[str, Any] = {"refreshed_at": stamp, "count": count}
+    entry: dict[str, Any] = {
+        "refreshed_at": stamp,
+        "count": count,
+        "origin": origin,
+    }
     if model_ids is not None:
         normalized_ids = sorted(
             {str(model_id) for model_id in model_ids if str(model_id)}

--- a/puppetmaster/preflight.py
+++ b/puppetmaster/preflight.py
@@ -116,6 +116,7 @@ def _cached_catalog_membership(
     authoritative and block absent models.
     """
     from puppetmaster.model_registry import (
+        DISCOVERY_ORIGIN_CURATED,
         DISCOVERY_SOURCE_TO_ADAPTER,
         catalog_staleness_days,
         default_registry_path,
@@ -148,20 +149,27 @@ def _cached_catalog_membership(
     age = catalog_staleness_days(meta, source)
     if age is None:
         return None
-    if ttl_seconds is None:
-        try:
-            ttl_seconds = float(
-                os.environ.get("PUPPETMASTER_CATALOG_CACHE_TTL_SECONDS", "3600")
+    # Fail-closed: only an explicit sidecar origin skips the TTL. Missing
+    # origin keeps today's 1h gate so legacy sidecars do not suddenly block.
+    explicit_curated = entry.get("origin") == DISCOVERY_ORIGIN_CURATED
+    if not explicit_curated:
+        if ttl_seconds is None:
+            try:
+                ttl_seconds = float(
+                    os.environ.get("PUPPETMASTER_CATALOG_CACHE_TTL_SECONDS", "3600")
+                )
+            except ValueError:
+                ttl_seconds = 3600.0
+        if age * 86400.0 > max(0.0, ttl_seconds):
+            return (
+                True,
+                f"catalog unverified (cached {age:.1f}d old)",
+                ["preflight:cached_catalog_stale"],
             )
-        except ValueError:
-            ttl_seconds = 3600.0
-    if age * 86400.0 > max(0.0, ttl_seconds):
-        return (
-            True,
-            f"catalog unverified (cached {age:.1f}d old)",
-            ["preflight:cached_catalog_stale"],
-        )
     available = {str(model_id) for model_id in entry["model_ids"]}
+    catalog_label = (
+        f"curated {source} catalog" if explicit_curated else f"recent {source} catalog"
+    )
     if not available:
         if source == "agentic":
             return (
@@ -171,18 +179,18 @@ def _cached_catalog_membership(
             )
         return (
             False,
-            f"model {model!r} is absent from the recent {source} catalog",
+            f"model {model!r} is absent from the {catalog_label}",
             ["preflight:cached_model_not_in_catalog"],
         )
     if model not in available:
         return (
             False,
-            f"model {model!r} is absent from the recent {source} catalog",
+            f"model {model!r} is absent from the {catalog_label}",
             ["preflight:cached_model_not_in_catalog"],
         )
     return (
         True,
-        f"model {model!r} present in recent {source} catalog",
+        f"model {model!r} present in {catalog_label}",
         ["preflight:cached_catalog_match"],
     )
 

--- a/puppetmaster/static_catalog.py
+++ b/puppetmaster/static_catalog.py
@@ -57,6 +57,14 @@ CURATED_CATALOGS: dict[str, list[dict]] = {
             "tags": ["tools", "claude", "balanced", "vision", "code", "reasoning"],
         },
         {
+            "model": "claude-sonnet-5",
+            "capability": 87,
+            "input": 3.0,
+            "output": 15.0,
+            "context": 1_000_000,
+            "tags": ["tools", "claude", "balanced", "vision", "code", "reasoning", "long-context"],
+        },
+        {
             "model": "claude-opus-4-6",
             "capability": 88,
             "input": 5.0,
@@ -244,6 +252,15 @@ CURATED_CATALOGS: dict[str, list[dict]] = {
             "output": 15.0,
             "context": 200_000,
             "tags": ["tools", "agentic", "anthropic", "balanced", "vision", "code", "reasoning"],
+            "payload_defaults": {"provider": "anthropic"},
+        },
+        {
+            "model": "claude-sonnet-5",
+            "capability": 87,
+            "input": 3.0,
+            "output": 15.0,
+            "context": 1_000_000,
+            "tags": ["tools", "agentic", "anthropic", "balanced", "vision", "code", "reasoning", "long-context"],
             "payload_defaults": {"provider": "anthropic"},
         },
         {
@@ -584,6 +601,15 @@ CURATED_CATALOGS: dict[str, list[dict]] = {
             "payload_defaults": {"provider": "anthropic"},
         },
         {
+            "model": "claude-sonnet-5",
+            "capability": 87,
+            "input": 3.0,
+            "output": 15.0,
+            "context": 1_000_000,
+            "tags": ["tools", "hermes", "anthropic", "balanced", "vision", "code", "reasoning", "long-context"],
+            "payload_defaults": {"provider": "anthropic"},
+        },
+        {
             "model": "gpt-5",
             "capability": 90,
             "input": 1.25,
@@ -898,6 +924,7 @@ def ensure_subscription_plan_catalog(
         has_plan_frontier,
     )
     from puppetmaster.model_registry import (
+        DISCOVERY_ORIGIN_CURATED,
         load_registry,
         read_discovery_meta,
         save_registry,
@@ -936,6 +963,7 @@ def ensure_subscription_plan_catalog(
                 registry_path,
                 model_ids=[item["model"] for item in catalog if item.get("model")],
                 catalog_hash=catalog_content_hash(catalog),
+                origin=DISCOVERY_ORIGIN_CURATED,
             )
             return {
                 "action": "discovered",

--- a/tests/test_prompt_prefix.py
+++ b/tests/test_prompt_prefix.py
@@ -51,16 +51,65 @@ class BuildPromptOrderTests(unittest.TestCase):
     def test_build_structured_prompt_puts_contract_before_instruction(self) -> None:
         instruction = "Review the payment module"
         prompt = build_structured_prompt(instruction)
-        self.assertTrue(prompt.startswith("Puppetmaster artifact contract:"))
+        # The contract still precedes the instruction (static-first, so sibling
+        # workers share a cacheable prefix) -- it is just no longer the first
+        # thing the model reads. See the orientation test below.
         self.assertTrue(prompt.rstrip().endswith(instruction))
         self.assertLess(
-            prompt.index("Puppetmaster artifact contract:"),
+            prompt.index("Puppetmaster artifact contract"),
             prompt.index(TASK_INSTRUCTION_HEADER),
         )
         note = build_structured_prompt(instruction, final_message_note=True)
         self.assertTrue(note.rstrip().endswith(instruction))
         self.assertIn("submit_findings", note)
         self.assertLess(note.index("submit_findings"), note.index(TASK_INSTRUCTION_HEADER))
+
+    def test_structured_prompt_opens_by_locating_the_task(self) -> None:
+        """gpt-5.6 models answer *about* the first noun phrase they read.
+
+        Opening on "Puppetmaster artifact contract:" made them treat the
+        contract as the subject: one asked what to do with the contract,
+        another spent 51k input tokens explaining what it is. Four of four
+        Codex analysis runs degraded that way, across two models. So the
+        prompt must open by saying where the assignment lives and that nothing
+        above it is the subject, and must label the contract as output format.
+        """
+        for prompt in (
+            build_structured_prompt("Review the payment module"),
+            build_structured_prompt("Review the payment module", final_message_note=True),
+        ):
+            first_line = prompt.splitlines()[0]
+            self.assertIn("Read this entire prompt before acting", first_line)
+            self.assertIn("Your task", first_line)
+            # The orientation must NOT contain the bare TASK_INSTRUCTION_HEADER:
+            # split_prompt_messages() cuts the system/user seam at its first
+            # occurrence, so an inline mention would collapse the shared prefix.
+            self.assertNotIn(TASK_INSTRUCTION_HEADER, first_line)
+            self.assertEqual(prompt.count(TASK_INSTRUCTION_HEADER), 1)
+            self.assertLess(
+                prompt.index("Read this entire prompt"),
+                prompt.index("Puppetmaster artifact contract"),
+            )
+            self.assertIn("OUTPUT FORMAT", prompt)
+            # `with_report_contract` keys off this literal to avoid stacking a
+            # second contract; the relabel must not break that detection.
+            self.assertIn("Puppetmaster artifact contract", prompt)
+
+    def test_report_contract_still_detects_the_relabelled_contract(self) -> None:
+        from puppetmaster.adapters._prompts import with_report_contract
+
+        structured = build_structured_prompt("Review the payment module")
+        self.assertEqual(with_report_contract(structured), structured)
+
+    def test_split_prompt_messages_keeps_orientation_in_system_prefix(self) -> None:
+        from puppetmaster.adapters._prompts import _PROMPT_ORIENTATION
+
+        system_prefix, user_suffix = split_prompt_messages(
+            build_structured_prompt("Review the payment module")
+        )
+        self.assertTrue(system_prefix.startswith(_PROMPT_ORIENTATION))
+        self.assertTrue(user_suffix.startswith(TASK_INSTRUCTION_HEADER))
+        self.assertNotIn(_PROMPT_ORIENTATION, user_suffix)
 
 class JobStableSectionOrderTests(unittest.TestCase):
     def test_memory_skills_census_appear_before_instruction(self) -> None:

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -12130,6 +12130,57 @@ class OpenAIAdapterTests(unittest.TestCase):
         self.assertIn("cheap", nano.tags)
         self.assertLess(nano.capability_score, 60)
 
+    def test_curated_catalogs_include_claude_sonnet_5(self) -> None:
+        """Claude Code and Codex cannot enumerate their own models, so
+        CURATED_CATALOGS is the only place a Claude model can enter routing.
+        The Claude 5 family shipped with opus-5 and fable-5 but the newest
+        Sonnet stayed at 4.5 (capability 82 / 200K), so the router could
+        neither select Sonnet 5 nor rank it against its real 1M context."""
+        from puppetmaster.model_registry import starter_registry
+        from puppetmaster.static_catalog import (
+            CURATED_CATALOGS,
+            merge_curated_into_registry,
+        )
+
+        for catalog_name in ("claude-code", "agentic", "hermes"):
+            entries = {entry["model"]: entry for entry in CURATED_CATALOGS[catalog_name]}
+            self.assertIn(
+                "claude-sonnet-5", entries, f"{catalog_name} missing claude-sonnet-5"
+            )
+            sonnet5 = entries["claude-sonnet-5"]
+            sonnet45 = entries["claude-sonnet-4-5"]
+            self.assertEqual(sonnet5["context"], 1_000_000)
+            self.assertEqual(sonnet5["input"], 3.0)
+            self.assertEqual(sonnet5["output"], 15.0)
+            self.assertIn("long-context", sonnet5["tags"])
+            self.assertGreater(sonnet5["capability"], sonnet45["capability"])
+            if catalog_name == "claude-code":
+                self.assertNotIn("payload_defaults", sonnet5)
+            else:
+                self.assertEqual(sonnet5["payload_defaults"]["provider"], "anthropic")
+
+        # A curated entry is only useful if it survives the merge into a real
+        # registry as a routable, plan-billed spec.
+        merged, report = merge_curated_into_registry(
+            "claude-code", "plan", starter_registry()
+        )
+        self.assertIn("claude-sonnet-5", report["added"])
+        spec = next(
+            s
+            for s in merged
+            if s.adapter == "claude-code" and s.adapter_model_name == "claude-sonnet-5"
+        )
+        self.assertEqual(spec.context_window, 1_000_000)
+        self.assertEqual(spec.billing, "plan")
+        self.assertIn("plan-billed", spec.tags)
+        # Sonnet stays under every Opus tier so quality routing is unchanged.
+        opus_caps = [
+            s.capability_score
+            for s in merged
+            if s.adapter == "claude-code" and "opus" in s.adapter_model_name
+        ]
+        self.assertTrue(all(spec.capability_score < cap for cap in opus_caps))
+
     def test_starter_registry_includes_gpt_5_6_family(self) -> None:
         from puppetmaster.model_registry import starter_registry
         from puppetmaster.static_catalog import CURATED_CATALOGS
@@ -16225,6 +16276,127 @@ class PreflightTests(unittest.TestCase):
             self.assertIn("preflight:cached_catalog_stale", result.evidence)
             self.assertNotIn("preflight:cached_model_not_in_catalog", result.evidence)
 
+    def test_explicit_curated_old_catalog_still_consults_model_ids(self) -> None:
+        """An explicit curated snapshot ages with the package, not the clock."""
+        from puppetmaster.model_registry import (
+            DISCOVERY_ORIGIN_CURATED,
+            ModelSpec,
+            save_registry,
+            write_discovery_meta,
+        )
+        from puppetmaster.platform_billing import BillingStatus
+        from puppetmaster.preflight import preflight_check
+
+        with TemporaryDirectory() as tmp:
+            registry_path = Path(tmp) / "models.json"
+            save_registry(
+                [
+                    ModelSpec(
+                        id="agentic/gpt-5",
+                        adapter="agentic",
+                        adapter_model_name="gpt-5",
+                        capability_score=90,
+                        billing="api",
+                    )
+                ],
+                registry_path,
+            )
+            write_discovery_meta(
+                "agentic",
+                1,
+                registry_path,
+                model_ids=["other-model"],
+                now_iso="2020-01-01T00:00:00Z",
+                origin=DISCOVERY_ORIGIN_CURATED,
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "PUPPETMASTER_MODELS_PATH": str(registry_path),
+                    "PUPPETMASTER_CATALOG_CACHE_TTL_SECONDS": "3600",
+                },
+                clear=False,
+            ):
+                result = preflight_check(
+                    "agentic",
+                    "gpt-5",
+                    billing_status=BillingStatus(
+                        adapter="agentic",
+                        billing="api",
+                        healthy=True,
+                        detail="openai key",
+                        evidence=[],
+                    ),
+                )
+
+            self.assertFalse(result.ok)
+            self.assertIn("curated agentic catalog", result.reason)
+            self.assertNotIn("recent", result.reason)
+            self.assertIn("preflight:cached_model_not_in_catalog", result.evidence)
+            self.assertNotIn("preflight:cached_catalog_stale", result.evidence)
+
+    def test_missing_origin_old_catalog_still_fails_open_stale(self) -> None:
+        """Legacy sidecars without origin keep the 1h TTL / fail-open path."""
+        from puppetmaster.model_registry import (
+            ModelSpec,
+            discovery_meta_path,
+            save_registry,
+        )
+        from puppetmaster.platform_billing import BillingStatus
+        from puppetmaster.preflight import preflight_check
+
+        with TemporaryDirectory() as tmp:
+            registry_path = Path(tmp) / "models.json"
+            save_registry(
+                [
+                    ModelSpec(
+                        id="agentic/gpt-5",
+                        adapter="agentic",
+                        adapter_model_name="gpt-5",
+                        capability_score=90,
+                        billing="api",
+                    )
+                ],
+                registry_path,
+            )
+            discovery_meta_path(registry_path).write_text(
+                json.dumps(
+                    {
+                        "agentic": {
+                            "refreshed_at": "2020-01-01T00:00:00Z",
+                            "count": 1,
+                            "model_ids": ["other-model"],
+                        }
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "PUPPETMASTER_MODELS_PATH": str(registry_path),
+                    "PUPPETMASTER_CATALOG_CACHE_TTL_SECONDS": "3600",
+                },
+                clear=False,
+            ):
+                result = preflight_check(
+                    "agentic",
+                    "gpt-5",
+                    billing_status=BillingStatus(
+                        adapter="agentic",
+                        billing="api",
+                        healthy=True,
+                        detail="openai key",
+                        evidence=[],
+                    ),
+                )
+
+            self.assertTrue(result.ok)
+            self.assertIn("catalog unverified", result.reason)
+            self.assertIn("preflight:cached_catalog_stale", result.evidence)
+            self.assertNotIn("preflight:cached_model_not_in_catalog", result.evidence)
+
 class AdapterCliPresenceTests(unittest.TestCase):
     """`adapter_cli_present` closes the gap billing detection can't see: an
     adapter that reads billing-healthy off a stale auth file but whose CLI
@@ -18634,6 +18806,227 @@ class SubscriptionPlanCatalogTests(unittest.TestCase):
             meta = read_discovery_meta(path)
             self.assertTrue(meta.get("claude"))
             self.assertTrue(meta["claude"].get("model_ids"))
+
+    def test_curated_autodiscovery_records_curated_origin(self) -> None:
+        """`ensure_subscription_plan_catalog` applies CURATED_CATALOGS -- a list
+        compiled into the package -- but writes the same sidecar shape a live
+        `/v1/models` fetch does. Without an origin marker the two are
+        indistinguishable: the entry carries a fresh `refreshed_at` that reads
+        as a successful refresh, so `doctor` calls the catalog fresh and
+        re-running discovery looks like it could surface new models when it can
+        only ever re-apply the same compiled-in list."""
+        from puppetmaster.model_registry import (
+            DISCOVERY_ORIGIN_CURATED,
+            discovery_origin,
+            read_discovery_meta,
+        )
+        from puppetmaster.static_catalog import ensure_subscription_plan_catalog
+
+        with TemporaryDirectory() as tmp:
+            path = self._registry_path(tmp)
+            report = ensure_subscription_plan_catalog(
+                path,
+                billing_detector=lambda a: self._status(
+                    a,
+                    healthy=(a == "claude-code"),
+                    billing="plan" if a == "claude-code" else "unknown",
+                ),
+            )
+            self.assertEqual(report["action"], "discovered")
+            meta = read_discovery_meta(path)
+            self.assertEqual(meta["claude"]["origin"], DISCOVERY_ORIGIN_CURATED)
+            self.assertEqual(
+                discovery_origin(meta, "claude"), DISCOVERY_ORIGIN_CURATED
+            )
+
+    def test_discovery_origin_defaults_live_for_legacy_entries(self) -> None:
+        """Sidecars written before the field exists must stay readable."""
+        from puppetmaster.model_registry import (
+            DISCOVERY_ORIGIN_LIVE,
+            discovery_origin,
+            write_discovery_meta,
+        )
+
+        legacy = {"cursor": {"refreshed_at": "2026-01-01T00:00:00Z", "count": 3}}
+        self.assertEqual(discovery_origin(legacy, "cursor"), DISCOVERY_ORIGIN_LIVE)
+        self.assertEqual(discovery_origin(legacy, "absent"), DISCOVERY_ORIGIN_LIVE)
+        self.assertEqual(
+            discovery_origin({"x": {"origin": "nonsense"}}, "x"), DISCOVERY_ORIGIN_LIVE
+        )
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "models.json"
+            # Default stays live so every existing caller is unchanged.
+            write_discovery_meta("cursor", 2, path)
+            from puppetmaster.model_registry import read_discovery_meta
+
+            self.assertEqual(
+                read_discovery_meta(path)["cursor"]["origin"], DISCOVERY_ORIGIN_LIVE
+            )
+            with self.assertRaises(ValueError):
+                write_discovery_meta("cursor", 2, path, origin="bogus")
+
+    def test_legacy_claude_sidecar_without_origin_reads_curated(self) -> None:
+        """Pre-field claude sidecars were curated applies, not live fetches."""
+        from puppetmaster.diagnostics import _catalog_freshness_check
+        from puppetmaster.model_registry import (
+            DISCOVERY_ORIGIN_CURATED,
+            DISCOVERY_ORIGIN_LIVE,
+            discovery_origin,
+        )
+
+        legacy = {"claude": {"refreshed_at": "2020-01-01T00:00:00Z", "count": 7}}
+        self.assertEqual(discovery_origin(legacy, "claude"), DISCOVERY_ORIGIN_CURATED)
+        self.assertEqual(
+            discovery_origin(
+                {"hermes": {"origin": "", "refreshed_at": "2020-01-01T00:00:00Z"}},
+                "hermes",
+            ),
+            DISCOVERY_ORIGIN_CURATED,
+        )
+        self.assertEqual(
+            discovery_origin(
+                {"claude": {"origin": "nonsense", "refreshed_at": "x"}},
+                "claude",
+            ),
+            DISCOVERY_ORIGIN_LIVE,
+        )
+
+        with patch(
+            "puppetmaster.model_registry.read_discovery_meta", return_value=legacy
+        ), patch(
+            "puppetmaster.model_registry.discovery_catalog_changed", return_value=False
+        ), patch(
+            "puppetmaster.model_registry.discovery_registry_drift",
+            return_value={"status": "match"},
+        ):
+            check = _catalog_freshness_check()
+        self.assertEqual(check.status, "ok")
+        self.assertIn("curated", check.detail)
+        self.assertIn("claude", check.detail)
+        self.assertNotIn("catalog stale", check.detail)
+        self.assertNotIn("catalog fresh", check.detail)
+
+    def test_doctor_labels_curated_catalog_instead_of_ageing_it(self) -> None:
+        """A curated catalog does not go stale with wall-clock time and cannot
+        be refreshed by re-running discovery, so `doctor` must neither nag
+        about its age nor claim a live check happened."""
+        from puppetmaster.diagnostics import _catalog_freshness_check
+        from puppetmaster.model_registry import DISCOVERY_ORIGIN_CURATED
+
+        old = "2020-01-01T00:00:00Z"
+        meta = {
+            "cursor": {"refreshed_at": old, "count": 3, "origin": "live"},
+            "claude": {
+                "refreshed_at": old,
+                "count": 8,
+                "origin": DISCOVERY_ORIGIN_CURATED,
+            },
+        }
+        with patch(
+            "puppetmaster.model_registry.read_discovery_meta", return_value=meta
+        ), patch(
+            "puppetmaster.model_registry.discovery_catalog_changed", return_value=False
+        ), patch(
+            "puppetmaster.model_registry.discovery_registry_drift",
+            return_value={"status": "match"},
+        ):
+            check = _catalog_freshness_check()
+        self.assertEqual(check.status, "warn")
+        # The live source is aged and named in the stale list...
+        self.assertIn("cursor", check.detail)
+        # ...the curated one is not dragged into it.
+        self.assertNotIn("claude", check.detail.split("registry")[0])
+
+    def test_doctor_reports_curated_catalog_as_curated_not_fresh(self) -> None:
+        from puppetmaster.diagnostics import _catalog_freshness_check
+        from puppetmaster.model_registry import DISCOVERY_ORIGIN_CURATED
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        meta = {
+            "claude": {
+                "refreshed_at": now,
+                "count": 8,
+                "origin": DISCOVERY_ORIGIN_CURATED,
+            }
+        }
+        with patch(
+            "puppetmaster.model_registry.read_discovery_meta", return_value=meta
+        ), patch(
+            "puppetmaster.model_registry.discovery_catalog_changed", return_value=False
+        ), patch(
+            "puppetmaster.model_registry.discovery_registry_drift",
+            return_value={"status": "match"},
+        ):
+            check = _catalog_freshness_check()
+        self.assertEqual(check.status, "ok")
+        self.assertIn("curated", check.detail)
+        self.assertIn("claude", check.detail)
+        self.assertNotIn("catalog fresh", check.detail)
+
+    def test_discover_probe_persists_curated_origin_for_claude_and_hermes(self) -> None:
+        """`--probe` and `--write` both stamp the report origin onto the sidecar."""
+        from types import SimpleNamespace
+
+        from puppetmaster import cli
+        from puppetmaster.cli.commands_models import _discover_one_source
+        from puppetmaster.model_registry import (
+            DISCOVERY_ORIGIN_CURATED,
+            read_discovery_meta,
+        )
+        from puppetmaster.platform_billing import BillingStatus
+
+        with patch(
+            "puppetmaster.platform_billing.detect_adapter_billing",
+            return_value=BillingStatus(
+                adapter="claude-code",
+                billing="plan",
+                healthy=True,
+                detail="t",
+                evidence=[],
+            ),
+        ):
+            _, claude_report, _ = _discover_one_source("claude", [])
+        self.assertEqual(claude_report["origin"], DISCOVERY_ORIGIN_CURATED)
+
+        with patch(
+            "puppetmaster.adapters.available_hermes_providers", return_value=set()
+        ):
+            _, hermes_report, _ = _discover_one_source("hermes", [])
+        self.assertEqual(hermes_report["origin"], DISCOVERY_ORIGIN_CURATED)
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "models.json"
+            for source, persist_write in (("claude", False), ("hermes", True)):
+                args = SimpleNamespace(
+                    source=source,
+                    json=False,
+                    write=persist_write,
+                    probe=not persist_write,
+                    registry_path=None,
+                    prune=False,
+                )
+                with patch.object(
+                    cli,
+                    "_discover_one_source",
+                    return_value=(
+                        [],
+                        {
+                            "source": source,
+                            "discovered_count": 2,
+                            "added": [],
+                            "origin": DISCOVERY_ORIGIN_CURATED,
+                        },
+                        [{"id": "m1"}, {"id": "m2"}],
+                    ),
+                ):
+                    rc = cli._run_models_discover(args, path)
+                self.assertEqual(rc, 0)
+                self.assertEqual(
+                    read_discovery_meta(path)[source]["origin"],
+                    DISCOVERY_ORIGIN_CURATED,
+                )
 
     def test_skips_when_plan_frontier_present(self) -> None:
         from puppetmaster.model_registry import ModelSpec, save_registry


### PR DESCRIPTION
## Summary
- Absorb [@bsmi021](https://github.com/bsmi021) fork PRs [#35](https://github.com/professorpalmer/Puppetmaster/pull/35), [#36](https://github.com/professorpalmer/Puppetmaster/pull/36), and [#37](https://github.com/professorpalmer/Puppetmaster/pull/37) onto the daily branch with stack-wide edits (not a rubber-stamp of the main-targeted forks).
- #35: add claude-sonnet-5 (cap 87, 1M, long-context) to curated claude-code / agentic / hermes. Drop the unrelated @cursor/sdk pin. Assert Anthropic provider stamps on agentic/hermes.
- #36: record discovery origin live|curated. Stamp both --write and --probe. Infer curated for legacy claude/codex/hermes/agentic sidecars missing the field. Doctor no longer ages those sources. Preflight skips the clock TTL only for an explicit origin=curated.
- #37: analysis prompts open with orientation and label the artifact contract as output format so gpt-5.6 / Codex stop treating the contract as the subject. with_report_contract still matches.

## Test plan
- [x] Focused pytest slice for sonnet-5, discovery origin, doctor labels, probe stamp, preflight TTL, and prompt orientation — 13 passed
- [ ] CI on this PR
