### PR TITLE
absorb #40: swarm timeout propagation and honest timeout records

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Absorb of [@bsmi021](https://github.com/bsmi021) PR
+[#40](https://github.com/professorpalmer/Puppetmaster/pull/40), plus
+stack edits.
+
 **Let a swarm actually use the timeout it was given, and make the
 timeout record say what happened.**
 
@@ -12,7 +16,8 @@ timeout record say what happened.**
   `swarm` now take `--timeout-seconds` / `--max-timeout-seconds`, `run`
   stamps them onto every role, and `start_swarm` forwards them on every
   branch (including a caller-supplied `--config`, where an explicit
-  argument outranks the config's per-worker values).
+  argument outranks the config's per-worker values). `start_cursor_swarm`
+  now forwards the same flags.
 - **BREAKING: explicit `max_timeout_seconds` is now used as given.**
   `_worker_hard_cap` was `max(base * 3, explicit)`, so an explicit
   ceiling could only ever *raise* it and there was no way to bound a run

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,43 @@
+## Unreleased
+
+**Let a swarm actually use the timeout it was given, and make the
+timeout record say what happened.**
+
+- **Propagation.** `timeout_seconds` is advertised on
+  `puppetmaster_start_swarm`'s schema, but only the `adapter` branch ever
+  consumed it. A plain `start_swarm(goal, timeout_seconds=600)` fell
+  through to `run <goal>`, which had no such flag, so nothing reached the
+  task payloads that `Orchestrator._worker_wait_timeout` reads and the
+  run silently used `max([60]) + 30` = 90s base / 270s ceiling. `run` and
+  `swarm` now take `--timeout-seconds` / `--max-timeout-seconds`, `run`
+  stamps them onto every role, and `start_swarm` forwards them on every
+  branch (including a caller-supplied `--config`, where an explicit
+  argument outranks the config's per-worker values).
+- **BREAKING: explicit `max_timeout_seconds` is now used as given.**
+  `_worker_hard_cap` was `max(base * 3, explicit)`, so an explicit
+  ceiling could only ever *raise* it and there was no way to bound a run
+  more tightly than 3x. It is now the explicit value, floored at the base
+  timeout. **A config that already sets `max_timeout_seconds` below 3x
+  base gets a lower ceiling than before** — e.g. `timeout_seconds: 900`
+  with `max_timeout_seconds: 1200` drops from 2790s to 1200s. Remove the
+  key to keep the 3x default. A batch that mixes capped and uncapped
+  roles keeps the 3x floor, so one role's tight ceiling can't strip a
+  sibling's extension headroom.
+- **Honest reporting.** `_kill_and_report_timeout` was handed the *base*
+  timeout, so a run extended to the 3x ceiling still reported "killed
+  after 90s" — off by a factor of three, and silent about the extension.
+  The `worker.timed_out` event and the blocked VERIFICATION artifact now
+  carry `elapsed_seconds`, `base_timeout_seconds`, `hard_cap_seconds`,
+  `extended`, and `limit_hit` (`base_timeout` /
+  `went_quiet_after_extension` / `hard_cap`), and the message names the
+  limit that actually ended the run. The old `timeout_seconds` key is
+  kept.
+- **Docs.** `_job_progress_cursor` now states that the progress signal is
+  liveness, not productivity — `run.heartbeat` and `task.lease_renewed`
+  fire for any live worker, so the extension is granted to essentially
+  every one of them and the hard cap, not the base timeout, is the real
+  kill deadline. The CLI help and the MCP schema say so too.
+
 ## v1.22.11
 
 Absorb of [@bsmi021](https://github.com/bsmi021) PRs

--- a/puppetmaster/cli/_dispatch.py
+++ b/puppetmaster/cli/_dispatch.py
@@ -546,6 +546,29 @@ def _main(argv: Optional[list[str]] = None) -> int:
                 replace(spec, payload={**spec.payload, "disable_memory": True})
                 for spec in specs
             ]
+        # The orchestrator's watchdog reads `timeout_seconds` off each task
+        # payload (Orchestrator._worker_wait_timeout). Nothing in the default
+        # worker specs sets it, so an unstamped `run` silently falls back to
+        # the 60s floor + 30s grace = 90s base / 270s hard cap -- shorter than
+        # a single real agent turn. Stamp the caller's value onto every role.
+        #
+        # Applied on top of `--config` too, so an explicit flag outranks the
+        # per-worker values a config declares -- the usual precedence, and what
+        # MCP `start_swarm` relies on to honor its advertised `timeout_seconds`
+        # when the caller supplied their own config. Skipped entirely when the
+        # flags are absent, so a config-only run is untouched.
+        timeout_seconds = getattr(args, "timeout_seconds", None)
+        max_timeout_seconds = getattr(args, "max_timeout_seconds", None)
+        if timeout_seconds is not None or max_timeout_seconds is not None:
+            overrides: dict = {}
+            if timeout_seconds is not None:
+                overrides["timeout_seconds"] = int(timeout_seconds)
+            if max_timeout_seconds is not None:
+                overrides["max_timeout_seconds"] = int(max_timeout_seconds)
+            specs = [
+                replace(spec, payload={**spec.payload, **overrides})
+                for spec in specs
+            ]
         result = cli.Orchestrator(store).run(
             args.goal,
             specs=specs,
@@ -969,6 +992,7 @@ def _main(argv: Optional[list[str]] = None) -> int:
                 adapter=adapter,
                 cwd=args.cwd,
                 timeout_seconds=int(args.timeout_seconds),
+                max_timeout_seconds=getattr(args, "max_timeout_seconds", None),
                 model=args.model,
                 auto_route=auto_route,
                 routing_policy=getattr(args, "routing_policy", None),
@@ -997,6 +1021,7 @@ def _main(argv: Optional[list[str]] = None) -> int:
                 state_dir=state_dir,
                 cwd=args.cwd,
                 timeout_seconds=int(args.timeout_seconds),
+                max_timeout_seconds=getattr(args, "max_timeout_seconds", None),
                 model=args.model,
                 auto_route=auto_route,
                 routing_policy=getattr(args, "routing_policy", None),

--- a/puppetmaster/cli/_parser.py
+++ b/puppetmaster/cli/_parser.py
@@ -71,6 +71,28 @@ from puppetmaster.worker_runtime import WorkerDaemon
 from puppetmaster.workers import WorkerSpec
 
 
+def _positive_seconds(value: str) -> int:
+    """argparse type for a timeout: a positive whole number of seconds.
+
+    Worker payload timeouts are handed straight to ``subprocess.wait(timeout=)``
+    by the adapters, so ``--timeout-seconds 0`` or a negative kills every worker
+    the instant it starts. Fail at parse time with a readable message instead of
+    stamping the value onto every role. Mirrors ``_positive_int_arg`` on the MCP
+    side.
+    """
+    import argparse as _argparse
+
+    try:
+        seconds = int(value)
+    except (TypeError, ValueError):
+        raise _argparse.ArgumentTypeError(f"expected a whole number of seconds, got {value!r}")
+    if seconds <= 0:
+        raise _argparse.ArgumentTypeError(
+            f"must be a positive number of seconds, got {seconds}"
+        )
+    return seconds
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="puppetmaster",
@@ -489,6 +511,29 @@ def build_parser() -> argparse.ArgumentParser:
         choices=["subprocess", "inline", "daemon"],
         default="subprocess",
         help="Use subprocess workers, inline workers, or wait for warm daemon workers.",
+    )
+    run.add_argument(
+        "--timeout-seconds",
+        type=_positive_seconds,
+        default=None,
+        help=(
+            "Base per-worker timeout, stamped onto every role's payload. A "
+            "worker still alive past this point is extended rather than killed, "
+            "so the actual kill deadline is --max-timeout-seconds (default 3x "
+            "the base, where base = this value + 30s grace). Without this flag "
+            "the orchestrator falls back to a 90s base / 270s ceiling, far "
+            "shorter than a real agent turn."
+        ),
+    )
+    run.add_argument(
+        "--max-timeout-seconds",
+        type=_positive_seconds,
+        default=None,
+        help=(
+            "Absolute ceiling a worker may reach while still showing progress. "
+            "Used as given (floored at the base timeout). Defaults to 3x the "
+            "base timeout, which is --timeout-seconds plus a 30s grace."
+        ),
     )
     run.add_argument(
         "--disable-memory",
@@ -1587,9 +1632,24 @@ def build_parser() -> argparse.ArgumentParser:
     swarm.add_argument("--model", help="Optional model pin (disables auto-route unless --auto-route).")
     swarm.add_argument(
         "--timeout-seconds",
-        type=int,
+        type=_positive_seconds,
         default=900,
-        help="Per-worker timeout (default 900).",
+        help=(
+            "Base per-worker timeout (default 900). A worker still alive past "
+            "this point is extended, so the actual kill deadline is "
+            "--max-timeout-seconds."
+        ),
+    )
+    swarm.add_argument(
+        "--max-timeout-seconds",
+        type=_positive_seconds,
+        default=None,
+        help=(
+            "Absolute ceiling a worker may reach while still showing progress, "
+            "and the value it is actually killed at. Used as given (floored at "
+            "the base timeout). Defaults to 3x the base timeout, where base = "
+            "--timeout-seconds plus a 30s grace."
+        ),
     )
     swarm.add_argument(
         "--worker-mode",

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -2735,9 +2735,54 @@ def start_swarm(args: JsonObject) -> JsonObject:
     worker_mode = args.get("worker_mode")
     if worker_mode:
         command.extend(["--worker-mode", str(worker_mode)])
+    # `timeout_seconds` is advertised on this tool's schema (goal_schema), and
+    # every sibling start verb forwards it. Only the adapter branch above
+    # consumed it -- via write_generated_swarm_config -- so a plain
+    # `start_swarm(goal, timeout_seconds=600)` dropped the value on the floor
+    # and the run silently used the orchestrator's 90s base / 270s hard cap.
+    _append_swarm_timeout_flags(command, args)
     _append_swarm_memory_flags(command, args)
     _append_label_flag(command, args)
     return start_cli(command, args)
+
+
+def _append_swarm_timeout_flags(command: list[str], args: JsonObject) -> None:
+    """Forward the advertised worker timeouts to the ``run`` verb.
+
+    Forwarded on every branch, including ``--config``. The generated-config
+    branch already stamps the same value into each worker payload, so the flag
+    is redundant there but never contradictory -- both come from this same
+    argument. A **caller-supplied** config stamps nothing, so skipping it there
+    would drop the advertised value exactly as the bare ``run`` branch did; the
+    CLI applies the flag on top of whatever the config declares, which is the
+    precedence an explicit argument should have.
+
+    No-op when the caller passed nothing.
+    """
+    for key, flag in (
+        ("timeout_seconds", "--timeout-seconds"),
+        ("max_timeout_seconds", "--max-timeout-seconds"),
+    ):
+        seconds = _positive_int_arg(args.get(key))
+        if seconds is None:
+            continue
+        command.extend([flag, str(seconds)])
+
+
+def _positive_int_arg(value: Any) -> Optional[int]:
+    """Coerce an MCP argument to a positive int, or None when unusable.
+
+    Tolerates the numeric strings JSON-RPC clients sometimes send, and rejects
+    bools (which are ints in Python) so ``timeout_seconds: true`` can never
+    become ``--timeout-seconds 1``.
+    """
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        seconds = int(value)
+    except (TypeError, ValueError):
+        return None
+    return seconds if seconds > 0 else None
 
 
 def start_cursor_swarm(args: JsonObject) -> JsonObject:
@@ -2828,7 +2873,12 @@ def write_generated_swarm_config(args: JsonObject, roles: list[str], adapter: st
         adapter=adapter,
         state_dir=mcp_state_dir(args),
         cwd=cwd(args),
-        timeout_seconds=int(args.get("timeout_seconds") or 900),
+        # Same guard as the flag path: a bare int() would turn
+        # `timeout_seconds: true` into 1 and stamp a 1-second timeout onto every
+        # generated worker payload, and would pass a negative straight through
+        # to subprocess.wait().
+        timeout_seconds=_positive_int_arg(args.get("timeout_seconds")) or 900,
+        max_timeout_seconds=_positive_int_arg(args.get("max_timeout_seconds")),
         model=str(args["model"]) if args.get("model") else None,
         auto_route=auto_route,
         routing_policy=str(args["routing_policy"])
@@ -4017,6 +4067,16 @@ def swarm_schema() -> JsonObject:
                 "description": "Optional local worker roles to run.",
             },
             "config": {"type": "string", "description": "Optional workflow config path."},
+            "max_timeout_seconds": {
+                "type": "integer",
+                "description": (
+                    "Absolute ceiling a worker may reach while still showing "
+                    "progress, and the value a worker is actually killed at. "
+                    "Used as given, floored at the base timeout. Defaults to 3x "
+                    "the base timeout, where base = timeout_seconds + 30s grace "
+                    "(so timeout_seconds=600 defaults to a 1890s ceiling)."
+                ),
+            },
             "adapter": {
                 "type": "string",
                 "enum": ["cursor", "local"],

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -2806,6 +2806,7 @@ def start_cursor_swarm(args: JsonObject) -> JsonObject:
     worker_mode = args.get("worker_mode")
     if worker_mode:
         command.extend(["--worker-mode", str(worker_mode)])
+    _append_swarm_timeout_flags(command, args)
     _append_label_flag(command, args)
     return start_cli(command, args)
 

--- a/puppetmaster/orchestrator.py
+++ b/puppetmaster/orchestrator.py
@@ -2470,7 +2470,10 @@ class Orchestrator:
             process.wait(timeout=5)
         except subprocess.TimeoutExpired:
             process.kill()
-            process.wait(timeout=5)
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
         self.store.emit(
             job.id,
             "worker.timed_out",

--- a/puppetmaster/orchestrator.py
+++ b/puppetmaster/orchestrator.py
@@ -2314,19 +2314,45 @@ class Orchestrator:
         A4: a worker actively making progress past its base timeout (e.g. a long
         but legitimate e2e verify phase) is extended rather than SIGKILL'd, but
         only up to this cap so a wedged-yet-heartbeating worker can't run forever.
-        Honors an explicit ``payload.max_timeout_seconds``; otherwise 3× base.
+        Honors an explicit ``payload.max_timeout_seconds``; otherwise 3x base.
+
+        "Honors" used to mean ``max(base * 3, explicit)``, so an explicit cap
+        could only ever *raise* the ceiling: asking for 1800s on a 630s base
+        silently got you 1890s, and there was no way to bound a run more tightly
+        than 3x. An explicit ceiling is now used as given, floored at
+        ``base_timeout`` because a cap below the base would kill the worker
+        before its own timeout and make ``timeout_seconds`` meaningless.
         """
         explicit = [
-            int(task.payload.get("max_timeout_seconds", 0))
+            int(task.payload["max_timeout_seconds"])
             for task in tasks
-            if isinstance(task.payload.get("max_timeout_seconds", 0), int)
+            if isinstance(task.payload.get("max_timeout_seconds"), int)
+            and not isinstance(task.payload.get("max_timeout_seconds"), bool)
+            and int(task.payload["max_timeout_seconds"]) > 0
         ]
-        return max([base_timeout * 3, *explicit])
+        if not explicit:
+            return base_timeout * 3
+        if len(explicit) < len(tasks):
+            # A batch mixes roles. Any task without its own ceiling still keeps
+            # the 3x default, so one role's tight cap can't silently strip the
+            # extension headroom from a sibling that never asked for one.
+            return max(base_timeout * 3, max(explicit))
+        return max(base_timeout, max(explicit))
 
     def _job_progress_cursor(self, job_id: str) -> int:
         """Monotonic event cursor for a job — the cheap, backend-agnostic
         progress signal. A growing cursor between polls means the worker is
         still doing work (heartbeats, lease renewals, saved tasks/artifacts).
+
+        Read this as **liveness, not productivity**. ``worker_runtime`` emits
+        ``run.heartbeat`` + ``task.lease_renewed`` every couple of seconds for a
+        worker's whole life, so any process that is still up advances the
+        cursor. That is deliberate: a single agent turn can spend minutes inside
+        one provider call and legitimately produce nothing else, so demanding
+        artifacts here would SIGKILL exactly the long-but-healthy runs the
+        extension exists to protect. The consequence is that the extension is
+        granted to essentially every live worker, which makes ``hard_cap`` -- not
+        ``base_timeout`` -- the number that decides when a run dies.
 
         Uses ``event_cursor`` (SQLite ``MAX(id)``, file backend's size-keyed
         cache) rather than ``len(read_events())`` so a long-running worker's
@@ -2376,18 +2402,69 @@ class Orchestrator:
                                 "base_timeout_seconds": base_timeout,
                                 "hard_cap_seconds": hard_cap,
                                 "elapsed_seconds": int(elapsed),
-                                "reason": "worker still emitting progress events",
+                                "reason": (
+                                    "worker process still alive and emitting "
+                                    "events; will be killed at hard_cap_seconds"
+                                ),
                             },
                         )
                         extended = True
                     continue
-                raise self._kill_and_report_timeout(process, job, tasks, base_timeout)
+                # Which limit ended it, decided here where the real (float)
+                # elapsed and the branch taken are both known. Deriving it later
+                # from int(elapsed) vs hard_cap misclassifies a cap kill at
+                # 269.7s as "went quiet".
+                if hard_cap > base_timeout and elapsed >= hard_cap:
+                    # The ceiling is what set this poll's wake deadline
+                    # (`wait_for` is clamped to `hard_cap - elapsed`), so
+                    # reaching it is a cap kill regardless of whether this
+                    # particular poll happened to catch a heartbeat. Checked
+                    # before `extended` because a ceiling within one poll of the
+                    # base is hit on the first post-base check, so no extension
+                    # is ever recorded -- and calling that "hit its base timeout
+                    # without further progress" is exactly the misdescription
+                    # this record exists to remove. The `hard_cap > base_timeout`
+                    # guard keeps the degenerate equal case honest: with no
+                    # extension window at all, the base is what ended it.
+                    limit_hit = "hard_cap"
+                elif extended:
+                    limit_hit = "went_quiet_after_extension"
+                else:
+                    limit_hit = "base_timeout"
+                raise self._kill_and_report_timeout(
+                    process,
+                    job,
+                    tasks,
+                    base_timeout,
+                    elapsed_seconds=int(elapsed),
+                    hard_cap_seconds=hard_cap,
+                    extended=extended,
+                    limit_hit=limit_hit,
+                )
 
     def _kill_and_report_timeout(
-        self, process: subprocess.Popen, job: Job, tasks: list[Task], timeout_seconds: int
+        self,
+        process: subprocess.Popen,
+        job: Job,
+        tasks: list[Task],
+        timeout_seconds: int,
+        *,
+        elapsed_seconds: Optional[int] = None,
+        hard_cap_seconds: Optional[int] = None,
+        extended: bool = False,
+        limit_hit: Optional[str] = None,
     ) -> RuntimeError:
         """Terminate a timed-out worker, emit the timeout event + blocked
-        artifact, and return the error for the caller to raise."""
+        artifact, and return the error for the caller to raise.
+
+        ``timeout_seconds`` is the *base* timeout. It used to be the only number
+        reported, so an extended run that survived to the 3x hard cap still said
+        "killed after 90s" -- off by a factor of three, and it hid the fact that
+        an extension had been granted at all. ``elapsed_seconds`` is what
+        actually happened; the base and the cap are reported alongside it so the
+        message explains which limit was hit. The keyword arguments are optional
+        so existing direct callers (and tests) keep working.
+        """
         process.terminate()
         try:
             process.wait(timeout=5)
@@ -2397,13 +2474,111 @@ class Orchestrator:
         self.store.emit(
             job.id,
             "worker.timed_out",
-            {"returncode": process.returncode, "timeout_seconds": timeout_seconds},
+            {
+                "returncode": process.returncode,
+                "timeout_seconds": timeout_seconds,
+                "base_timeout_seconds": timeout_seconds,
+                "elapsed_seconds": elapsed_seconds,
+                "hard_cap_seconds": hard_cap_seconds,
+                "extended": extended,
+                "limit_hit": limit_hit
+                or self._timeout_limit_hit(elapsed_seconds, hard_cap_seconds, extended),
+            },
         )
-        self._emit_timeout_artifact(job, tasks, timeout_seconds)
+        self._emit_timeout_artifact(
+            job,
+            tasks,
+            timeout_seconds,
+            elapsed_seconds=elapsed_seconds,
+            hard_cap_seconds=hard_cap_seconds,
+            extended=extended,
+            limit_hit=limit_hit,
+        )
         return RuntimeError("worker process timed out")
 
+    @staticmethod
+    def _timeout_limit_hit(
+        elapsed_seconds: Optional[int],
+        hard_cap_seconds: Optional[int],
+        extended: bool,
+    ) -> str:
+        """Which limit actually ended the run.
+
+        Deliberately derived from ``elapsed`` against the cap, not from
+        ``extended``. Because the progress signal is really a liveness signal
+        (see ``_job_progress_cursor``), nearly every worker gets extended, so
+        keying off that flag would report "hit the hard cap" for runs that went
+        quiet far below it -- the same misreporting this record exists to fix.
+        """
+        # The cap can only be what ended a run that was extended past its base
+        # timeout in the first place; an unextended kill is always the base.
+        if not extended:
+            return "base_timeout"
+        if elapsed_seconds is not None and hard_cap_seconds is not None:
+            # `elapsed_seconds` is int(float elapsed), so a kill at 269.7s
+            # against a 270s cap arrives here as 269. Allow one second of
+            # truncation rather than mislabelling a cap kill as "went quiet".
+            if elapsed_seconds >= hard_cap_seconds - 1:
+                return "hard_cap"
+        return "went_quiet_after_extension"
+
+    @staticmethod
+    def _timeout_message(
+        roles: list[str],
+        timeout_seconds: int,
+        elapsed_seconds: Optional[int],
+        hard_cap_seconds: Optional[int],
+        limit_hit: str,
+        extended: bool = False,
+    ) -> str:
+        """One line saying how long the worker actually ran and which limit ended it."""
+        ran = f"{elapsed_seconds}s" if elapsed_seconds is not None else f"{timeout_seconds}s"
+        if limit_hit == "hard_cap":
+            # `extended` is False when the ceiling sits within one poll of the
+            # base: it is reached on the first post-base check, before any
+            # extension is recorded. Saying "was extended" there would
+            # contradict `extended: false` in the same payload.
+            passed = (
+                "was extended past its"
+                if extended
+                else "passed its"
+            )
+            limit = (
+                f"it {passed} {timeout_seconds}s base timeout while still alive "
+                f"and hit the {hard_cap_seconds}s hard cap"
+            )
+        elif limit_hit == "went_quiet_after_extension":
+            limit = (
+                f"it passed its {timeout_seconds}s base timeout while still alive "
+                f"and was extended, then stopped emitting events before the "
+                f"{hard_cap_seconds}s hard cap"
+            )
+        else:
+            limit = f"it hit its {timeout_seconds}s base timeout without further progress"
+        # Point at the knob that actually moves the deadline that was hit.
+        # Raising timeout_seconds does nothing to a cap kill until it is pushed
+        # past the ceiling.
+        knob = (
+            "raising the task's max_timeout_seconds, and timeout_seconds with it"
+            if limit_hit == "hard_cap"
+            else "raising the task's timeout_seconds"
+        )
+        return (
+            f"Worker for roles {roles} was killed after {ran}: {limit}. "
+            f"Results are partial and must not be trusted; re-run after {knob}, "
+            f"or split the work."
+        )
+
     def _emit_timeout_artifact(
-        self, job: Job, tasks: list[Task], timeout_seconds: int
+        self,
+        job: Job,
+        tasks: list[Task],
+        timeout_seconds: int,
+        *,
+        elapsed_seconds: Optional[int] = None,
+        hard_cap_seconds: Optional[int] = None,
+        extended: bool = False,
+        limit_hit: Optional[str] = None,
     ) -> None:
         """Record an explicit *blocked* VERIFICATION artifact when a worker is
         killed on timeout.
@@ -2419,13 +2594,20 @@ class Orchestrator:
         if representative is None:
             return
         roles = sorted({task.role for task in tasks})
+        resolved_limit = limit_hit or self._timeout_limit_hit(
+            elapsed_seconds, hard_cap_seconds, extended
+        )
         artifact = Artifact(
             job_id=job.id,
             task_id=representative.id,
             type=ArtifactType.VERIFICATION,
             created_by="orchestrator",
             confidence=0.9,
-            evidence=["orchestrator:worker-timeout", f"timeout_seconds:{timeout_seconds}"],
+            evidence=[
+                "orchestrator:worker-timeout",
+                f"timeout_seconds:{timeout_seconds}",
+                f"elapsed_seconds:{elapsed_seconds if elapsed_seconds is not None else timeout_seconds}",
+            ],
             payload={
                 "adapter": "orchestrator",
                 "check": "worker.timeout",
@@ -2433,10 +2615,18 @@ class Orchestrator:
                 "failure": "worker_timeout",
                 "roles": roles,
                 "timeout_seconds": timeout_seconds,
-                "message": (
-                    f"Worker for roles {roles} was killed after {timeout_seconds}s. "
-                    "Results are partial and must not be trusted; re-run with a longer "
-                    "timeout (raise the task's timeout_seconds) or split the work."
+                "base_timeout_seconds": timeout_seconds,
+                "elapsed_seconds": elapsed_seconds,
+                "hard_cap_seconds": hard_cap_seconds,
+                "extended": extended,
+                "limit_hit": resolved_limit,
+                "message": self._timeout_message(
+                    roles,
+                    timeout_seconds,
+                    elapsed_seconds,
+                    hard_cap_seconds,
+                    resolved_limit,
+                    extended,
                 ),
             },
         )

--- a/puppetmaster/swarm_launch.py
+++ b/puppetmaster/swarm_launch.py
@@ -69,6 +69,7 @@ def build_analysis_swarm_specs(
     adapter: str = "cursor",
     cwd: str = "",
     timeout_seconds: int = 900,
+    max_timeout_seconds: Optional[int] = None,
     model: Optional[str] = None,
     auto_route: Optional[bool] = None,
     routing_policy: Optional[str] = None,
@@ -102,6 +103,10 @@ def build_analysis_swarm_specs(
             "timeout_seconds": int(timeout_seconds),
             **ANALYSIS_NO_EDIT_PAYLOAD,
         }
+        if max_timeout_seconds is not None:
+            # Orchestrator._worker_hard_cap honors this; without it the ceiling
+            # is 3x the base timeout.
+            payload["max_timeout_seconds"] = int(max_timeout_seconds)
         try:
             from puppetmaster.acceptance_criteria import parse_acceptance_criteria_block
 
@@ -166,6 +171,7 @@ def write_analysis_swarm_config(
     state_dir: Path,
     cwd: str = "",
     timeout_seconds: int = 900,
+    max_timeout_seconds: Optional[int] = None,
     model: Optional[str] = None,
     auto_route: Optional[bool] = None,
     routing_policy: Optional[str] = None,
@@ -183,6 +189,7 @@ def write_analysis_swarm_config(
         adapter=adapter,
         cwd=cwd,
         timeout_seconds=timeout_seconds,
+        max_timeout_seconds=max_timeout_seconds,
         model=model,
         auto_route=auto_route,
         routing_policy=routing_policy,
@@ -264,6 +271,7 @@ def detach_analysis_swarm(
     state_dir: Path,
     cwd: str,
     timeout_seconds: int = 900,
+    max_timeout_seconds: Optional[int] = None,
     model: Optional[str] = None,
     auto_route: Optional[bool] = None,
     routing_policy: Optional[str] = None,
@@ -285,6 +293,7 @@ def detach_analysis_swarm(
         state_dir=state_dir,
         cwd=cwd,
         timeout_seconds=timeout_seconds,
+        max_timeout_seconds=max_timeout_seconds,
         model=model,
         auto_route=auto_route,
         routing_policy=routing_policy,

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -11493,6 +11493,37 @@ class ModelRouterTests(unittest.TestCase):
         self.assertIn("--max-timeout-seconds", command)
         self.assertEqual(command[command.index("--max-timeout-seconds") + 1], "1800")
 
+    def test_start_cursor_swarm_forwards_the_timeout_it_advertises(self) -> None:
+        """`timeout_seconds` / `max_timeout_seconds` are on this verb's schema
+        (via goal_schema) and `start_swarm` already forwards them, but
+        `start_cursor_swarm` only stamped generated-config payloads and never
+        appended the CLI flags the advertised schema must forward."""
+        from puppetmaster import mcp_server
+
+        captured = {}
+
+        def fake_start_cli(command, args):
+            captured["command"] = command
+            return {"ok": True}
+
+        with patch.object(mcp_server, "start_cli", side_effect=fake_start_cli), patch.object(
+            mcp_server, "write_generated_swarm_config", return_value=Path("generated.json")
+        ), patch.object(mcp_server, "_platform_lock_preflight", return_value=None):
+            mcp_server.start_cursor_swarm(
+                {
+                    "goal": "long audit",
+                    "cwd": ".",
+                    "timeout_seconds": 600,
+                    "max_timeout_seconds": 1800,
+                }
+            )
+
+        command = captured["command"]
+        self.assertIn("--timeout-seconds", command)
+        self.assertEqual(command[command.index("--timeout-seconds") + 1], "600")
+        self.assertIn("--max-timeout-seconds", command)
+        self.assertEqual(command[command.index("--max-timeout-seconds") + 1], "1800")
+
     def test_start_swarm_omits_timeout_flags_when_not_asked(self) -> None:
         from puppetmaster import mcp_server
 
@@ -11536,6 +11567,15 @@ class ModelRouterTests(unittest.TestCase):
             _append_swarm_timeout_flags(command, {"timeout_seconds": value})
             self.assertEqual(command[2:], expected, msg=f"value={value!r}")
 
+        for value in (True, -30, 0, "soon"):
+            command = ["run", "goal"]
+            _append_swarm_timeout_flags(command, {"max_timeout_seconds": value})
+            self.assertEqual(
+                command[2:],
+                [],
+                msg=f"max_timeout_seconds={value!r} must be omitted",
+            )
+
     def test_generated_config_timeout_survives_a_junk_argument(self) -> None:
         """The generated-config branch used a bare `int(... or 900)`, so
         `timeout_seconds: true` became **1** -- a 1-second timeout stamped onto
@@ -11564,6 +11604,31 @@ class ModelRouterTests(unittest.TestCase):
                 [900],
                 msg=f"timeout_seconds={junk!r} must fall back, not be coerced",
             )
+
+        for junk in (True, -30, 0, "soon"):
+            with TemporaryDirectory() as tmp:
+                path = write_generated_swarm_config(
+                    {
+                        "goal": "audit",
+                        "cwd": tmp,
+                        "state_dir": tmp,
+                        "timeout_seconds": 600,
+                        "max_timeout_seconds": junk,
+                    },
+                    ["explore"],
+                    "cursor",
+                )
+                workers = json.loads(Path(path).read_text("utf-8"))["workers"]
+            for worker in workers:
+                self.assertEqual(worker["payload"]["timeout_seconds"], 600)
+                self.assertNotIn(
+                    "max_timeout_seconds",
+                    worker["payload"],
+                    msg=(
+                        f"max_timeout_seconds={junk!r} must be omitted, "
+                        "not stamped as 1 / negative"
+                    ),
+                )
 
         # ...and a usable value still reaches every generated payload.
         with TemporaryDirectory() as tmp:

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -11361,6 +11361,285 @@ class ModelRouterTests(unittest.TestCase):
             routed = Orchestrator(store)._with_retrieved_memory(specs, goal)
             self.assertIn("retrieved_memory", routed[0].payload)
 
+    def test_run_verb_timeout_reaches_the_orchestrator_watchdog(self) -> None:
+        """End to end through the real dispatch path: `--timeout-seconds` on
+        `run` must land in every role's payload, because that payload is the
+        *only* thing `Orchestrator._worker_wait_timeout` reads. Unstamped, the
+        default workers give `max([60]) + 30` = 90s base and a 270s ceiling --
+        shorter than one real agent turn, and the reason a 600s request was
+        killed at the ceiling."""
+        from puppetmaster import cli
+        from puppetmaster.cli._dispatch import _main
+        from puppetmaster.models import Task
+        from puppetmaster.orchestrator import Orchestrator
+
+        class _Stop(Exception):
+            pass
+
+        def watchdog_bounds(argv: list) -> tuple:
+            captured = {}
+
+            def fake_run(self, goal, *, specs, **kwargs):
+                captured["specs"] = specs
+                raise _Stop()
+
+            with TemporaryDirectory() as tmp:
+                with patch.object(cli.Orchestrator, "run", fake_run):
+                    with self.assertRaises(_Stop):
+                        _main(["--state-dir", tmp, *argv])
+
+            specs = captured["specs"]
+            self.assertEqual(
+                [spec.role for spec in specs],
+                ["explore", "architect", "implement", "redteam", "test"],
+                msg="every role must be stamped, or the chain stalls later",
+            )
+            tasks = [
+                Task(
+                    job_id="j",
+                    role=spec.role,
+                    instruction=spec.instruction,
+                    payload=dict(spec.payload),
+                )
+                for spec in specs
+            ]
+            base = Orchestrator._worker_wait_timeout(tasks[:1])
+            return base, Orchestrator._worker_hard_cap(tasks[:1], base)
+
+        # Unchanged when the flag is absent, so existing runs and configs move.
+        self.assertEqual(watchdog_bounds(["run", "goal"]), (90, 270))
+        self.assertEqual(
+            watchdog_bounds(["run", "goal", "--timeout-seconds", "600"]),
+            (630, 1890),
+        )
+        self.assertEqual(
+            watchdog_bounds(
+                [
+                    "run",
+                    "goal",
+                    "--timeout-seconds",
+                    "600",
+                    "--max-timeout-seconds",
+                    "1800",
+                ]
+            ),
+            (630, 1800),
+        )
+
+    def test_run_verb_stamps_timeout_on_every_role(self) -> None:
+        from puppetmaster.cli._parser import build_parser
+        from puppetmaster.workers import specs_for_roles
+
+        args = build_parser().parse_args(["run", "goal", "--timeout-seconds", "600"])
+        self.assertEqual(args.timeout_seconds, 600)
+        self.assertIsNone(args.max_timeout_seconds)
+        # Every default role, not just the first, or the chain stalls later.
+        self.assertEqual(
+            [spec.role for spec in specs_for_roles(args.workers)],
+            ["explore", "architect", "implement", "redteam", "test"],
+        )
+
+    def test_analysis_swarm_specs_carry_the_explicit_hard_cap(self) -> None:
+        """The generated-config branch is the other way a swarm is launched;
+        it stamped `timeout_seconds` but had no way to set the ceiling."""
+        from puppetmaster.swarm_launch import build_analysis_swarm_specs
+
+        specs = build_analysis_swarm_specs(
+            "goal",
+            ["explore", "test"],
+            adapter="cursor",
+            timeout_seconds=600,
+            max_timeout_seconds=1800,
+        )
+        for spec in specs:
+            self.assertEqual(spec.payload["timeout_seconds"], 600)
+            self.assertEqual(spec.payload["max_timeout_seconds"], 1800)
+
+        # Absent by default, so the 3x-base ceiling still applies.
+        default = build_analysis_swarm_specs(
+            "goal", ["explore"], adapter="cursor", timeout_seconds=600
+        )
+        self.assertNotIn("max_timeout_seconds", default[0].payload)
+
+    def test_start_swarm_forwards_the_timeout_it_advertises(self) -> None:
+        """`timeout_seconds` is on this tool's schema (via goal_schema) and every
+        sibling start verb forwards it, but `start_swarm` consumed it only on the
+        `adapter` branch. A plain `start_swarm(goal, timeout_seconds=600)` fell
+        through to `["run", goal]`, which had no such flag, so the value was
+        dropped and the orchestrator used its 90s floor instead."""
+        from puppetmaster import mcp_server
+
+        captured = {}
+
+        def fake_start_cli(command, args):
+            captured["command"] = command
+            return {"ok": True}
+
+        with patch.object(mcp_server, "start_cli", side_effect=fake_start_cli):
+            mcp_server.start_swarm(
+                {
+                    "goal": "long audit",
+                    "cwd": ".",
+                    "roles": ["explore"],
+                    "allow_local_demo": True,
+                    "timeout_seconds": 600,
+                    "max_timeout_seconds": 1800,
+                }
+            )
+
+        command = captured["command"]
+        self.assertIn("--timeout-seconds", command)
+        self.assertEqual(command[command.index("--timeout-seconds") + 1], "600")
+        self.assertIn("--max-timeout-seconds", command)
+        self.assertEqual(command[command.index("--max-timeout-seconds") + 1], "1800")
+
+    def test_start_swarm_omits_timeout_flags_when_not_asked(self) -> None:
+        from puppetmaster import mcp_server
+
+        captured = {}
+
+        def fake_start_cli(command, args):
+            captured["command"] = command
+            return {"ok": True}
+
+        with patch.object(mcp_server, "start_cli", side_effect=fake_start_cli):
+            mcp_server.start_swarm(
+                {
+                    "goal": "quick audit",
+                    "cwd": ".",
+                    "roles": ["explore"],
+                    "allow_local_demo": True,
+                }
+            )
+
+        self.assertNotIn("--timeout-seconds", captured["command"])
+        self.assertNotIn("--max-timeout-seconds", captured["command"])
+
+    def test_swarm_timeout_arg_coercion_rejects_nonsense(self) -> None:
+        """Numeric strings are tolerated (JSON-RPC clients send them); bools,
+        zero, negatives, and unparseable values never become a flag -- a
+        `timeout_seconds: true` must not turn into `--timeout-seconds 1`."""
+        from puppetmaster.mcp_server import _append_swarm_timeout_flags
+
+        for value, expected in (
+            (600, ["--timeout-seconds", "600"]),
+            ("600", ["--timeout-seconds", "600"]),
+            (600.0, ["--timeout-seconds", "600"]),
+            (True, []),
+            (False, []),
+            (0, []),
+            (-5, []),
+            ("soon", []),
+            (None, []),
+        ):
+            command = ["run", "goal"]
+            _append_swarm_timeout_flags(command, {"timeout_seconds": value})
+            self.assertEqual(command[2:], expected, msg=f"value={value!r}")
+
+    def test_generated_config_timeout_survives_a_junk_argument(self) -> None:
+        """The generated-config branch used a bare `int(... or 900)`, so
+        `timeout_seconds: true` became **1** -- a 1-second timeout stamped onto
+        every worker payload, killing each worker immediately -- and a negative
+        went straight through to `subprocess.wait()`. The flag path already
+        rejected both, so nothing downstream corrected it."""
+        import json
+
+        from puppetmaster.mcp_server import write_generated_swarm_config
+
+        for junk in (True, -30, 0, "soon", None):
+            with TemporaryDirectory() as tmp:
+                path = write_generated_swarm_config(
+                    {
+                        "goal": "audit",
+                        "cwd": tmp,
+                        "state_dir": tmp,
+                        "timeout_seconds": junk,
+                    },
+                    ["explore"],
+                    "cursor",
+                )
+                workers = json.loads(Path(path).read_text("utf-8"))["workers"]
+            self.assertEqual(
+                [w["payload"]["timeout_seconds"] for w in workers],
+                [900],
+                msg=f"timeout_seconds={junk!r} must fall back, not be coerced",
+            )
+
+        # ...and a usable value still reaches every generated payload.
+        with TemporaryDirectory() as tmp:
+            path = write_generated_swarm_config(
+                {
+                    "goal": "audit",
+                    "cwd": tmp,
+                    "state_dir": tmp,
+                    "timeout_seconds": 600,
+                    "max_timeout_seconds": 1800,
+                },
+                ["explore", "test"],
+                "cursor",
+            )
+            workers = json.loads(Path(path).read_text("utf-8"))["workers"]
+        for worker in workers:
+            self.assertEqual(worker["payload"]["timeout_seconds"], 600)
+            self.assertEqual(worker["payload"]["max_timeout_seconds"], 1800)
+
+    def test_start_swarm_forwards_timeout_with_a_caller_supplied_config(self) -> None:
+        """A caller-supplied `config=` stamps nothing into worker payloads, so
+        the advertised `timeout_seconds` would be dropped there just as it was
+        on the bare `run` branch. The CLI applies the flag on top of whatever
+        the config declares, which is the precedence an explicit argument
+        should have."""
+        from puppetmaster import mcp_server
+
+        captured = {}
+
+        def fake_start_cli(command, args):
+            captured["command"] = command
+            return {"ok": True}
+
+        with patch.object(mcp_server, "start_cli", side_effect=fake_start_cli):
+            mcp_server.start_swarm(
+                {
+                    "goal": "team audit",
+                    "cwd": ".",
+                    "config": "team.json",
+                    "timeout_seconds": 3600,
+                }
+            )
+
+        command = captured["command"]
+        self.assertIn("--config", command)
+        self.assertIn("--timeout-seconds", command)
+        self.assertEqual(command[command.index("--timeout-seconds") + 1], "3600")
+
+    def test_start_swarm_generated_config_also_carries_the_flag(self) -> None:
+        """Redundant on this branch (write_analysis_swarm_config stamps the same
+        value into every payload) but never contradictory -- both come from the
+        same argument."""
+        from puppetmaster import mcp_server
+
+        captured = {}
+
+        def fake_start_cli(command, args):
+            captured["command"] = command
+            return {"ok": True}
+
+        with patch.object(mcp_server, "start_cli", side_effect=fake_start_cli), patch.object(
+            mcp_server, "write_generated_swarm_config", return_value=Path("generated.json")
+        ), patch.object(mcp_server, "_platform_lock_preflight", return_value=None):
+            mcp_server.start_swarm(
+                {
+                    "goal": "cursor audit",
+                    "cwd": ".",
+                    "adapter": "cursor",
+                    "timeout_seconds": 600,
+                }
+            )
+
+        command = captured["command"]
+        self.assertIn("--config", command)
+        self.assertEqual(command[command.index("--timeout-seconds") + 1], "600")
+
     def test_start_swarm_passes_disable_memory_flag_by_default(self) -> None:
         from puppetmaster import mcp_server
 
@@ -21849,6 +22128,399 @@ class PuppetmasterLoudFailureTests(unittest.TestCase):
             verdict = assess_run_quality(artifacts)
             self.assertEqual(verdict["quality"], "blocked")
             self.assertIn("worker_timeout", verdict["blocking_failures"])
+
+    def test_timeout_artifact_reports_elapsed_not_base_timeout(self) -> None:
+        """The bug that cost the most debugging time: `_kill_and_report_timeout`
+        was handed `base_timeout`, so a run extended all the way to the 3x hard
+        cap still reported "killed after 90s". Observed on a real job that ran
+        269s and reported 90. The record must say how long it actually ran, and
+        that an extension happened."""
+        from puppetmaster.models import Task
+
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("long audit")
+            task = Task(job_id=job.id, role="explore", instruction="audit")
+            store.save_task(task)
+
+            Orchestrator(store)._emit_timeout_artifact(
+                job,
+                [task],
+                90,
+                elapsed_seconds=269,
+                hard_cap_seconds=270,
+                extended=True,
+            )
+
+            payload = store.list_artifacts(job.id)[0].payload
+            self.assertEqual(payload["elapsed_seconds"], 269)
+            self.assertEqual(payload["base_timeout_seconds"], 90)
+            self.assertEqual(payload["hard_cap_seconds"], 270)
+            self.assertTrue(payload["extended"])
+            self.assertEqual(payload["limit_hit"], "hard_cap")
+            self.assertIn("killed after 269s", payload["message"])
+            self.assertIn("hard cap", payload["message"])
+            self.assertNotIn("killed after 90s", payload["message"])
+
+    def test_timeout_artifact_without_extension_names_the_base_timeout(self) -> None:
+        from puppetmaster.models import Task
+
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("wedged")
+            task = Task(job_id=job.id, role="explore", instruction="audit")
+            store.save_task(task)
+
+            Orchestrator(store)._emit_timeout_artifact(
+                job, [task], 600, elapsed_seconds=601, hard_cap_seconds=1800
+            )
+
+            payload = store.list_artifacts(job.id)[0].payload
+            self.assertFalse(payload["extended"])
+            self.assertEqual(payload["limit_hit"], "base_timeout")
+            self.assertIn("killed after 601s", payload["message"])
+            self.assertIn("600s base timeout", payload["message"])
+
+    def test_extended_but_quiet_run_is_not_reported_as_hitting_the_cap(self) -> None:
+        """Because the progress signal is really liveness, nearly every worker
+        gets extended -- so `extended` must not be read as "reached the
+        ceiling". A run extended at 110s and killed at 150s under a 270s cap
+        stopped emitting events; saying it "hit the 270s hard cap" would be the
+        same class of misreporting this change exists to remove."""
+        from puppetmaster.models import Task
+
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("quiet after extension")
+            task = Task(job_id=job.id, role="explore", instruction="audit")
+            store.save_task(task)
+
+            Orchestrator(store)._emit_timeout_artifact(
+                job,
+                [task],
+                90,
+                elapsed_seconds=150,
+                hard_cap_seconds=270,
+                extended=True,
+            )
+
+            payload = store.list_artifacts(job.id)[0].payload
+            self.assertTrue(payload["extended"])
+            self.assertEqual(payload["limit_hit"], "went_quiet_after_extension")
+            self.assertIn("killed after 150s", payload["message"])
+            self.assertIn("stopped emitting events", payload["message"])
+            self.assertNotIn("hit the 270s hard cap", payload["message"])
+
+    def test_limit_hit_tolerates_elapsed_truncation_at_the_cap(self) -> None:
+        """`elapsed_seconds` is int(float), so a kill at 269.7s against a 270s
+        cap arrives as 269 -- the real job this came from reported exactly that.
+        The fallback classifier must still call it a cap kill."""
+        self.assertEqual(Orchestrator._timeout_limit_hit(269, 270, True), "hard_cap")
+        self.assertEqual(Orchestrator._timeout_limit_hit(270, 270, True), "hard_cap")
+        self.assertEqual(
+            Orchestrator._timeout_limit_hit(150, 270, True),
+            "went_quiet_after_extension",
+        )
+        self.assertEqual(Orchestrator._timeout_limit_hit(91, 270, False), "base_timeout")
+        self.assertEqual(Orchestrator._timeout_limit_hit(None, None, False), "base_timeout")
+
+    def test_cap_near_the_base_is_still_reported_as_a_cap_kill(self) -> None:
+        """A ceiling within one poll of the base timeout is reached on the first
+        post-base check, so no extension is ever recorded. Keying the label off
+        `extended` would then describe a worker that was actively emitting
+        events as having "hit its base timeout without further progress" --
+        newly reachable now that an explicit cap is used as given."""
+        import subprocess as sp
+        import time
+
+        from puppetmaster.models import Task
+
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("tight ceiling")
+            task = Task(job_id=job.id, role="cursor", instruction="e2e")
+
+            class BusyProc:
+                """Alive and emitting, but one poll already overruns the tight
+                ceiling -- so the kill happens before any extension is recorded."""
+
+                def __init__(self) -> None:
+                    self.returncode = -15
+                    self.calls = 0
+                    self.killed = False
+
+                def wait(self, timeout=None):
+                    if self.killed:
+                        return -15
+                    self.calls += 1
+                    store.emit(job.id, "run.heartbeat", {"n": self.calls})
+                    time.sleep(0.15)
+                    raise sp.TimeoutExpired(cmd="x", timeout=timeout)
+
+                def terminate(self):
+                    self.killed = True
+
+                def kill(self):
+                    self.killed = True
+
+            orch = Orchestrator(store)
+            # A real ceiling just above the base: reached on the first post-base
+            # check, so `extended` is never recorded.
+            with patch.object(
+                Orchestrator, "_worker_wait_timeout", staticmethod(lambda tasks: 0)
+            ), patch.object(
+                Orchestrator, "_worker_hard_cap", staticmethod(lambda tasks, base: 0.1)
+            ):
+                with self.assertRaises(RuntimeError):
+                    orch._wait_for_worker(BusyProc(), job, [task])
+
+            events = [e["event"] for e in store.read_events(job.id)]
+            self.assertNotIn("worker.timeout_extended", events)
+            payload = [
+                e for e in store.read_events(job.id) if e["event"] == "worker.timed_out"
+            ][0]["payload"]
+            self.assertEqual(payload["limit_hit"], "hard_cap")
+            self.assertFalse(payload["extended"])
+
+            # The message must not claim an extension the payload denies.
+            message = [
+                a
+                for a in store.list_artifacts(job.id)
+                if a.payload.get("check") == "worker.timeout"
+            ][0].payload["message"]
+            self.assertIn("hard cap", message)
+            self.assertNotIn("was extended", message)
+            # A cap kill points at the knob that moves the ceiling.
+            self.assertIn("max_timeout_seconds", message)
+
+    def test_timeout_artifact_keeps_working_without_the_new_details(self) -> None:
+        """The keyword arguments are optional, so older/direct callers still get
+        a blocked artifact rather than a TypeError."""
+        from puppetmaster.models import Task
+        from puppetmaster.quality import assess_run_quality
+
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("legacy call")
+            task = Task(job_id=job.id, role="implement", instruction="e2e")
+            store.save_task(task)
+
+            Orchestrator(store)._emit_timeout_artifact(job, [task], timeout_seconds=600)
+
+            artifacts = store.list_artifacts(job.id)
+            self.assertEqual(assess_run_quality(artifacts)["quality"], "blocked")
+            self.assertIn("killed after 600s", artifacts[0].payload["message"])
+
+    def test_explicit_hard_cap_is_used_as_given(self) -> None:
+        """`max_timeout_seconds` was folded in with `max(base * 3, explicit)`, so
+        an explicit ceiling could only ever raise it: asking for 1800s on a 630s
+        base silently produced 1890s and there was no way to bound a run more
+        tightly than 3x."""
+        from puppetmaster.models import Task
+
+        def bounds(payload: dict) -> tuple:
+            tasks = [
+                Task(job_id="j", role="explore", instruction="i", payload=payload)
+            ]
+            base = Orchestrator._worker_wait_timeout(tasks)
+            return base, Orchestrator._worker_hard_cap(tasks, base)
+
+        self.assertEqual(bounds({"timeout_seconds": 600}), (630, 1890))
+        self.assertEqual(
+            bounds({"timeout_seconds": 600, "max_timeout_seconds": 1800}), (630, 1800)
+        )
+        self.assertEqual(
+            bounds({"timeout_seconds": 600, "max_timeout_seconds": 3600}), (630, 3600)
+        )
+        # A cap under the base would kill the worker before its own timeout and
+        # make timeout_seconds meaningless, so it floors at the base.
+        self.assertEqual(
+            bounds({"timeout_seconds": 600, "max_timeout_seconds": 60}), (630, 630)
+        )
+        # Junk falls back to 3x rather than producing a nonsense ceiling.
+        for junk in (True, 0, -5):
+            self.assertEqual(
+                bounds({"timeout_seconds": 600, "max_timeout_seconds": junk}),
+                (630, 1890),
+                msg=f"max_timeout_seconds={junk!r}",
+            )
+
+    def test_cli_rejects_a_non_positive_timeout_at_parse_time(self) -> None:
+        """Worker payload timeouts go straight to `subprocess.wait(timeout=)`,
+        so `--timeout-seconds 0` or a negative would kill every worker the
+        instant it started. The MCP path already guarded this; the CLI must
+        too, and loudly rather than by silently falling back."""
+        from puppetmaster.cli._parser import build_parser
+
+        for verb in ("run", "swarm"):
+            for flag in ("--timeout-seconds", "--max-timeout-seconds"):
+                for bad in ("0", "-5", "abc"):
+                    with self.assertRaises(SystemExit, msg=f"{verb} {flag} {bad}"):
+                        with contextlib.redirect_stderr(io.StringIO()):
+                            build_parser().parse_args([verb, "goal", flag, bad])
+        # ...and a usable value still parses.
+        args = build_parser().parse_args(
+            ["run", "goal", "--timeout-seconds", "600", "--max-timeout-seconds", "1800"]
+        )
+        self.assertEqual((args.timeout_seconds, args.max_timeout_seconds), (600, 1800))
+
+    def test_extended_kill_at_the_ceiling_says_it_was_extended(self) -> None:
+        self.assertIn(
+            "was extended past its",
+            Orchestrator._timeout_message(["explore"], 90, 269, 270, "hard_cap", True),
+        )
+        self.assertNotIn(
+            "was extended",
+            Orchestrator._timeout_message(["explore"], 600, 601, 630, "hard_cap", False),
+        )
+
+    def test_one_roles_tight_cap_does_not_starve_an_uncapped_sibling(self) -> None:
+        """`_wait_for_worker` is handed every task in the batch, not one role.
+        Using the explicit ceiling as given would let a short-capped role set the
+        ceiling for a long-running sibling that never asked for one -- with
+        `{timeout_seconds: 3600}` beside `{timeout_seconds: 600,
+        max_timeout_seconds: 900}` the batch base is 3630, so a naive
+        `max(base, explicit)` collapses the ceiling onto the base and the long
+        role gets no extension at all."""
+        from puppetmaster.models import Task
+
+        def cap(payloads: list) -> tuple:
+            tasks = [
+                Task(job_id="j", role=f"r{i}", instruction="i", payload=p)
+                for i, p in enumerate(payloads)
+            ]
+            base = Orchestrator._worker_wait_timeout(tasks)
+            return base, Orchestrator._worker_hard_cap(tasks, base)
+
+        self.assertEqual(
+            cap(
+                [
+                    {"timeout_seconds": 3600},
+                    {"timeout_seconds": 600, "max_timeout_seconds": 900},
+                ]
+            ),
+            (3630, 10890),
+        )
+        # When every task carries a ceiling, the largest is used as given.
+        self.assertEqual(
+            cap(
+                [
+                    {"timeout_seconds": 600, "max_timeout_seconds": 900},
+                    {"timeout_seconds": 600, "max_timeout_seconds": 1200},
+                ]
+            ),
+            (630, 1200),
+        )
+
+    def test_timed_out_event_carries_the_full_picture(self) -> None:
+        import subprocess as sp
+
+        from puppetmaster.models import Task
+
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("wedged")
+            task = Task(job_id=job.id, role="cursor", instruction="e2e")
+
+            class WedgedProc:
+                def __init__(self) -> None:
+                    self.returncode = -15
+                    self.killed = False
+
+                def wait(self, timeout=None):
+                    if self.killed:
+                        return -15
+                    raise sp.TimeoutExpired(cmd="x", timeout=timeout)
+
+                def terminate(self):
+                    self.killed = True
+
+                def kill(self):
+                    self.killed = True
+
+            orch = Orchestrator(store)
+            with patch.object(
+                Orchestrator, "_worker_wait_timeout", staticmethod(lambda tasks: 0)
+            ), patch.object(
+                Orchestrator, "_worker_hard_cap", staticmethod(lambda tasks, base: 0)
+            ):
+                with self.assertRaises(RuntimeError):
+                    orch._wait_for_worker(WedgedProc(), job, [task])
+
+            timed_out = [
+                e for e in store.read_events(job.id) if e["event"] == "worker.timed_out"
+            ]
+            self.assertEqual(len(timed_out), 1)
+            payload = timed_out[0]["payload"]
+            self.assertIsNotNone(payload["elapsed_seconds"])
+            self.assertEqual(payload["hard_cap_seconds"], 0)
+            self.assertFalse(payload["extended"])
+            self.assertEqual(payload["limit_hit"], "base_timeout")
+            # Kept for anything already reading the old key.
+            self.assertIn("timeout_seconds", payload)
+
+    def test_wait_loop_labels_a_cap_kill_as_hard_cap(self) -> None:
+        """`_wait_for_worker` decides `limit_hit` where the real float elapsed
+        and the branch taken are both known, instead of re-deriving it from a
+        truncated int downstream."""
+        import subprocess as sp
+        import time
+
+        from puppetmaster.models import Task
+
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("busy but capped")
+            task = Task(job_id=job.id, role="cursor", instruction="e2e")
+
+            class BusyProc:
+                """Always alive, always emitting -- only the cap can stop it.
+
+                Burns a little real time per poll so `elapsed` actually walks
+                past the cap; the extension is granted on the way there.
+                """
+
+                def __init__(self) -> None:
+                    self.returncode = -15
+                    self.calls = 0
+                    self.killed = False
+
+                def wait(self, timeout=None):
+                    if self.killed:
+                        return -15
+                    self.calls += 1
+                    store.emit(job.id, "run.heartbeat", {"n": self.calls})
+                    time.sleep(0.4)
+                    raise sp.TimeoutExpired(cmd="x", timeout=timeout)
+
+                def terminate(self):
+                    self.killed = True
+
+                def kill(self):
+                    self.killed = True
+
+            orch = Orchestrator(store)
+            with patch.object(
+                Orchestrator, "_worker_wait_timeout", staticmethod(lambda tasks: 0)
+            ), patch.object(
+                Orchestrator, "_worker_hard_cap", staticmethod(lambda tasks, base: 1)
+            ):
+                with self.assertRaises(RuntimeError):
+                    orch._wait_for_worker(BusyProc(), job, [task])
+
+            events = [e["event"] for e in store.read_events(job.id)]
+            self.assertIn("worker.timeout_extended", events)
+
+            timed_out = [
+                e for e in store.read_events(job.id) if e["event"] == "worker.timed_out"
+            ][0]["payload"]
+            self.assertEqual(timed_out["limit_hit"], "hard_cap")
+            artifact = [
+                a
+                for a in store.list_artifacts(job.id)
+                if a.payload.get("check") == "worker.timeout"
+            ][0]
+            self.assertEqual(artifact.payload["limit_hit"], "hard_cap")
 
     def test_worker_wait_extends_while_progressing(self) -> None:
         """A4: a worker still emitting events past base timeout is extended, not killed."""


### PR DESCRIPTION
## Summary
- Absorb [@bsmi021](https://github.com/bsmi021) fork PR [#40](https://github.com/professorpalmer/Puppetmaster/pull/40) onto dest with stack-wide edits (not a rubber-stamp of the main-targeted fork).
- Honor advertised swarm timeouts on the CLI `run`/`swarm` path and report the limit that actually killed the worker.
- BREAKING: explicit `max_timeout_seconds` is used as given (floored at base), not only as a 3x raise.
- Stack edits: `start_cursor_swarm` now forwards the same timeout flags; junk `max_timeout_seconds` stays omitted; a hung post-kill wait can no longer swallow the timeout record.

## Test plan
- [x] Focused pytest slice for timeout propagation, coercion, generated-config junk caps, hard-cap semantics, and timeout reporting
- [ ] CI on this PR
