### PR TITLE
absorb #43: dashboard Ctrl-C on Windows

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,28 @@
+## Unreleased
+
+**Fix: `puppetmaster dashboard` never exited on Ctrl-C on Windows, and its
+listening socket was never released either.**
+
+`serve()` ran `ThreadingHTTPServer.serve_forever` on a daemon thread and
+parked the main thread in an untimed `Thread.join()`. On Windows an untimed
+lock acquire is uninterruptible, so the eval breaker set by `CTRL_C_EVENT`
+was never checked, `KeyboardInterrupt` was never raised, and
+`except KeyboardInterrupt: httpd.shutdown()` never ran. Ctrl-C did nothing;
+the only way out was Ctrl-Break, closing the terminal, or `taskkill`.
+
+- **Main-thread `serve_forever`.** `serve()` now calls
+  `httpd.serve_forever(poll_interval=0.5)` directly on the main thread — the
+  same shape stdlib's `python -m http.server` uses — instead of a daemon
+  thread plus an untimed join. Ctrl-C now interrupts the loop and is
+  swallowed with `"Dashboard stopped."`, exiting 0 (`dashboard.py` already
+  advertises Ctrl-C as the normal way to stop).
+- **Socket release.** `httpd.server_close()` now runs in a `finally` on the
+  blocking path, so the port is actually freed on exit — it previously
+  appeared nowhere in `dashboard.py`. The two existing dashboard HTTP tests
+  that drive `serve(..., serve_forever=False)` against a manually-started
+  thread now call `server_close()` too, so they stop leaking a bound
+  listener on every run.
+
 ## v1.22.12
 
 Absorb of [@bsmi021](https://github.com/bsmi021) PR

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,14 @@ the only way out was Ctrl-Break, closing the terminal, or `taskkill`.
   that drive `serve(..., serve_forever=False)` against a manually-started
   thread now call `server_close()` too, so they stop leaking a bound
   listener on every run.
+- **Behaviour change: a crash inside the serve loop now surfaces.**
+  Previously an exception other than `KeyboardInterrupt` escaping
+  `serve_forever` was raised on the daemon thread, where the thread excepthook
+  printed it and `join()` returned normally — `puppetmaster dashboard` exited
+  **0** with a dead server. On the main thread the exception now propagates,
+  so the command fails loudly instead of silently. `main()` only pretty-prints
+  `FileNotFoundError`, `ValueError` and `RuntimeError`, so an unexpected
+  `OSError` here reaches the user as a traceback rather than an `error:` line.
 
 ## v1.22.12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Absorb of [@bsmi021](https://github.com/bsmi021) PR
+[#43](https://github.com/professorpalmer/Puppetmaster/pull/43), plus
+stack edits.
+
 **Fix: `puppetmaster dashboard` never exited on Ctrl-C on Windows, and its
 listening socket was never released either.**
 

--- a/puppetmaster/dashboard.py
+++ b/puppetmaster/dashboard.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import threading
 from pathlib import Path
 from typing import Any, Callable, Optional, Union
 
@@ -2619,11 +2618,20 @@ def serve(
         except Exception:
             pass
     if not serve_forever:
+        # Caller owns the socket: return it bound and OPEN (tests drive a
+        # request, then shutdown()/server_close() themselves).
         return httpd
-    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
-    thread.start()
+    # serve_forever() must run on the MAIN thread. Parking the main thread in an
+    # untimed Thread.join() instead makes Ctrl-C undeliverable on Windows: an
+    # untimed lock acquire is uninterruptible there, so the eval breaker set by
+    # the console CTRL_C_EVENT is never checked and KeyboardInterrupt is never
+    # raised. The 0.5s poll keeps the main thread returning to the eval loop.
     try:
-        thread.join()
+        httpd.serve_forever(poll_interval=0.5)
     except KeyboardInterrupt:
-        httpd.shutdown()
+        print("\nDashboard stopped.")
+    finally:
+        # Release the listening socket. Without this the port stays bound for
+        # the life of the process and, on Windows, briefly after it.
+        httpd.server_close()
     return httpd

--- a/puppetmaster/dashboard.py
+++ b/puppetmaster/dashboard.py
@@ -2569,10 +2569,12 @@ def serve(
     allow_external: bool = False,
     all_projects: bool = False,
 ):
-    """Start the dashboard HTTP server. Returns the server (already bound).
+    """Start the dashboard HTTP server. Returns the server.
 
-    ``serve_forever=False`` binds and returns without blocking — used by tests
-    to drive a single request, then ``server.shutdown()``.
+    ``serve_forever=False`` binds and returns without blocking, with the socket
+    still **open** — used by tests to drive a single request, then
+    ``server.shutdown()`` / ``server.server_close()`` themselves. Otherwise this
+    blocks until Ctrl-C and returns an already-closed server.
 
     The dashboard serves durable job state with no authentication, so binding
     to a non-loopback interface would expose it to the local network. That is
@@ -2631,7 +2633,7 @@ def serve(
     except KeyboardInterrupt:
         print("\nDashboard stopped.")
     finally:
-        # Release the listening socket. Without this the port stays bound for
-        # the life of the process and, on Windows, briefly after it.
+        # Release the listening socket rather than leaving it to process exit,
+        # so an in-process caller (and the tests) can rebind immediately.
         httpd.server_close()
     return httpd

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -17797,7 +17797,7 @@ class DashboardTests(unittest.TestCase):
         needs a genuine console-attach dance (FreeConsole/AttachConsole/
         GenerateConsoleCtrlEvent) that is fragile under hosts that inherit
         the console's "ignore Ctrl+C" flag (see the helper spawned below,
-        and the SetConsoleCtrlHandler(NULL, FALSE) call right before it).
+        and the SetConsoleCtrlHandler(NULL, FALSE) the child does to itself).
         The portable regression guard is
         test_dashboard_serve_runs_loop_on_main_thread above; this test is
         the belt-and-suspenders end-to-end check.
@@ -17807,17 +17807,18 @@ class DashboardTests(unittest.TestCase):
                 "set PUPPETMASTER_RUN_CONSOLE_TESTS=1 to run console Ctrl-C e2e tests"
             )
 
-        import ctypes
+        import socket
         import urllib.request
 
         repo_root = Path(__file__).resolve().parent.parent
-        port = 18920
         CREATE_NO_WINDOW = 0x08000000
 
-        # The "ignore Ctrl+C" flag is inherited by child processes, and an
-        # agent/CI shell commonly has it set — clear it here so children
-        # inherit "Ctrl+C enabled".
-        ctypes.WinDLL("kernel32", use_last_error=True).SetConsoleCtrlHandler(None, False)
+        # Ask the OS for a free port rather than hardcoding one: a fixed port
+        # collides with whatever else the machine (or a parallel CI job) is
+        # running, and the failure would look exactly like the bug.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("127.0.0.1", 0))
+            port = probe.getsockname()[1]
 
         # The AttachConsole()/GenerateConsoleCtrlEvent() dance must run in its
         # OWN process — doing it in this process would detach the test
@@ -17857,11 +17858,20 @@ class DashboardTests(unittest.TestCase):
             helper_path = Path(tmp) / "send_ctrlc_helper.py"
             helper_path.write_text(helper_src, encoding="utf-8")
 
-            cmd = [
-                sys.executable, "-m", "puppetmaster",
-                "--state-dir", str(state_dir),
-                "dashboard", "--port", str(port), "--no-open",
-            ]
+            # The "ignore Ctrl+C" flag is inherited by child processes and an
+            # agent/CI shell commonly has it set — with it set the child would
+            # ignore the CTRL_C_EVENT below and the test would fail exactly the
+            # way the bug does. The child clears it for *itself* here, so the
+            # unittest runner's own console behaviour is never modified.
+            bootstrap = (
+                "import ctypes, runpy, sys\n"
+                "ctypes.WinDLL('kernel32', use_last_error=True)"
+                ".SetConsoleCtrlHandler(None, False)\n"
+                "sys.argv = ['puppetmaster', '--state-dir', sys.argv[1],\n"
+                "            'dashboard', '--port', sys.argv[2], '--no-open']\n"
+                "runpy.run_module('puppetmaster', run_name='__main__')\n"
+            )
+            cmd = [sys.executable, "-c", bootstrap, str(state_dir), str(port)]
             proc = subprocess.Popen(
                 cmd,
                 stdout=subprocess.DEVNULL,
@@ -17891,13 +17901,20 @@ class DashboardTests(unittest.TestCase):
                     [sys.executable, str(helper_path), str(proc.pid)],
                     capture_output=True, text=True, creationflags=CREATE_NO_WINDOW,
                 )
-                self.assertIn(
-                    "'target_on_console': True",
-                    helper.stdout,
+                # Both halves matter: attaching to the child's console proves we
+                # aimed at the right target, and generate_ok proves the event was
+                # actually raised. Without the second assertion a delivery failure
+                # would fall through to "did not exit within 5s" — the exact
+                # message the real bug produces.
+                delivery_context = (
                     "CTRL_C_EVENT delivery to the child console could not be "
-                    f"verified, so a hang here would be indistinguishable from "
-                    f"the bug: stdout={helper.stdout!r} stderr={helper.stderr!r}",
+                    "verified, so a hang here would be indistinguishable from "
+                    f"the bug: rc={helper.returncode} "
+                    f"stdout={helper.stdout!r} stderr={helper.stderr!r}"
                 )
+                self.assertIn("'target_on_console': True", helper.stdout, delivery_context)
+                self.assertIn("'generate_ok': True", helper.stdout, delivery_context)
+                self.assertEqual(0, helper.returncode, delivery_context)
 
                 sent_at = time.time()
                 died_at = None

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -17796,9 +17796,11 @@ class DashboardTests(unittest.TestCase):
         Off by default (opt in with PUPPETMASTER_RUN_CONSOLE_TESTS=1): this
         needs a genuine console-attach dance (FreeConsole/AttachConsole/
         GenerateConsoleCtrlEvent) that is fragile under hosts that inherit
-        the "ignore Ctrl+C" flag — see plan-dashboard-ctrlc.md §2. The
-        portable regression guard is test_dashboard_serve_runs_loop_on_main_thread
-        above; this test is the belt-and-suspenders end-to-end check.
+        the console's "ignore Ctrl+C" flag (see the helper spawned below,
+        and the SetConsoleCtrlHandler(NULL, FALSE) call right before it).
+        The portable regression guard is
+        test_dashboard_serve_runs_loop_on_main_thread above; this test is
+        the belt-and-suspenders end-to-end check.
         """
         if os.environ.get("PUPPETMASTER_RUN_CONSOLE_TESTS") != "1":
             self.skipTest(

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -17669,6 +17669,7 @@ class DashboardTests(unittest.TestCase):
                     self.assertTrue(any(j["id"] == job.id for j in jobs))
             finally:
                 httpd.shutdown()
+                httpd.server_close()
 
     def test_dashboard_rejects_traversal_job_id(self) -> None:
         """/api/job must reject ids that aren't plain job ids before they reach
@@ -17699,6 +17700,230 @@ class DashboardTests(unittest.TestCase):
                     self.assertIn(b"invalid id", exc.read())
             finally:
                 httpd.shutdown()
+                httpd.server_close()
+
+    def test_dashboard_serve_returns_open_socket_when_not_serving_forever(self) -> None:
+        """serve_forever=False must keep returning a bound, OPEN server —
+        callers (tests) drive a request against it and shut it down
+        themselves. Regression guard: server_close() must not creep into
+        this branch (it belongs only to the blocking path)."""
+        import urllib.request
+
+        from puppetmaster.dashboard import serve
+
+        with TemporaryDirectory() as tmp:
+            httpd = serve(
+                Path(tmp) / ".puppetmaster",
+                backend="file",
+                host="127.0.0.1",
+                port=0,
+                open_browser=False,
+                serve_forever=False,
+            )
+            self.assertNotEqual(httpd.socket.fileno(), -1)
+            port = httpd.server_address[1]
+            t = threading.Thread(target=httpd.serve_forever, daemon=True)
+            t.start()
+            try:
+                with urllib.request.urlopen(f"http://127.0.0.1:{port}/") as r:
+                    self.assertEqual(r.status, 200)
+            finally:
+                httpd.shutdown()
+                httpd.server_close()
+
+    def test_dashboard_serve_closes_socket_on_interrupt(self) -> None:
+        """The blocking serve_forever() branch must release the listening
+        socket when interrupted. Before the fix, server_close() never ran
+        anywhere in dashboard.py, so the port stayed bound after Ctrl-C."""
+        from http.server import ThreadingHTTPServer
+
+        from puppetmaster.dashboard import serve
+
+        def fake_serve_forever(self, poll_interval=0.5):
+            raise KeyboardInterrupt
+
+        with TemporaryDirectory() as tmp:
+            with patch.object(ThreadingHTTPServer, "serve_forever", fake_serve_forever):
+                httpd = serve(
+                    Path(tmp) / ".puppetmaster",
+                    backend="file",
+                    host="127.0.0.1",
+                    port=0,
+                    open_browser=False,
+                    serve_forever=True,
+                )
+            self.assertEqual(httpd.socket.fileno(), -1)
+
+    def test_dashboard_serve_runs_loop_on_main_thread(self) -> None:
+        """serve_forever() must run on the MAIN thread, not a spawned daemon
+        thread. This is the direct regression guard: the original code parked
+        the main thread in an untimed Thread.join() on a daemon thread running
+        serve_forever, which made Ctrl-C undeliverable on Windows (an untimed
+        lock acquire there is uninterruptible, so KeyboardInterrupt was never
+        raised). Also asserts poll_interval is passed and short enough that
+        the main thread keeps returning to the eval loop."""
+        from http.server import ThreadingHTTPServer
+
+        from puppetmaster.dashboard import serve
+
+        calls = {}
+
+        def fake_serve_forever(self, poll_interval=None):
+            calls["on_main_thread"] = threading.current_thread() is threading.main_thread()
+            calls["poll_interval"] = poll_interval
+            raise KeyboardInterrupt
+
+        with TemporaryDirectory() as tmp:
+            with patch.object(ThreadingHTTPServer, "serve_forever", fake_serve_forever):
+                serve(
+                    Path(tmp) / ".puppetmaster",
+                    backend="file",
+                    host="127.0.0.1",
+                    port=0,
+                    open_browser=False,
+                    serve_forever=True,
+                )
+        self.assertTrue(calls.get("on_main_thread"))
+        self.assertIsNotNone(calls.get("poll_interval"))
+        self.assertLessEqual(calls["poll_interval"], 0.5)
+
+    @unittest.skipUnless(os.name == "nt", "console Ctrl-C semantics are Windows-specific")
+    def test_dashboard_ctrlc_e2e_windows_console(self) -> None:
+        """The actual user report: a real CTRL_C_EVENT delivered to
+        `python -m puppetmaster dashboard` must make it exit (within 5s,
+        code 0) with its listening socket released.
+
+        Off by default (opt in with PUPPETMASTER_RUN_CONSOLE_TESTS=1): this
+        needs a genuine console-attach dance (FreeConsole/AttachConsole/
+        GenerateConsoleCtrlEvent) that is fragile under hosts that inherit
+        the "ignore Ctrl+C" flag — see plan-dashboard-ctrlc.md §2. The
+        portable regression guard is test_dashboard_serve_runs_loop_on_main_thread
+        above; this test is the belt-and-suspenders end-to-end check.
+        """
+        if os.environ.get("PUPPETMASTER_RUN_CONSOLE_TESTS") != "1":
+            self.skipTest(
+                "set PUPPETMASTER_RUN_CONSOLE_TESTS=1 to run console Ctrl-C e2e tests"
+            )
+
+        import ctypes
+        import urllib.request
+
+        repo_root = Path(__file__).resolve().parent.parent
+        port = 18920
+        CREATE_NO_WINDOW = 0x08000000
+
+        # The "ignore Ctrl+C" flag is inherited by child processes, and an
+        # agent/CI shell commonly has it set — clear it here so children
+        # inherit "Ctrl+C enabled".
+        ctypes.WinDLL("kernel32", use_last_error=True).SetConsoleCtrlHandler(None, False)
+
+        # The AttachConsole()/GenerateConsoleCtrlEvent() dance must run in its
+        # OWN process — doing it in this process would detach the test
+        # runner's own console. Write the helper to a temp file and spawn it.
+        helper_src = (
+            "import ctypes, sys\n"
+            "from ctypes import wintypes\n"
+            'kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)\n'
+            "kernel32.AttachConsole.argtypes = [wintypes.DWORD]\n"
+            "kernel32.AttachConsole.restype = wintypes.BOOL\n"
+            "kernel32.FreeConsole.restype = wintypes.BOOL\n"
+            "kernel32.SetConsoleCtrlHandler.argtypes = [wintypes.LPVOID, wintypes.BOOL]\n"
+            "kernel32.SetConsoleCtrlHandler.restype = wintypes.BOOL\n"
+            "kernel32.GenerateConsoleCtrlEvent.argtypes = [wintypes.DWORD, wintypes.DWORD]\n"
+            "kernel32.GenerateConsoleCtrlEvent.restype = wintypes.BOOL\n"
+            "pid = int(sys.argv[1])\n"
+            "out = {}\n"
+            "kernel32.FreeConsole()\n"
+            "ok = kernel32.AttachConsole(pid)\n"
+            'out["attach_ok"] = bool(ok)\n'
+            "if not ok:\n"
+            "    print(out, flush=True)\n"
+            "    raise SystemExit(2)\n"
+            "kernel32.SetConsoleCtrlHandler(None, True)\n"
+            "buf = (wintypes.DWORD * 64)()\n"
+            "n = kernel32.GetConsoleProcessList(buf, 64)\n"
+            'out["console_pids"] = list(buf[:n])\n'
+            'out["target_on_console"] = pid in out["console_pids"]\n'
+            "ok = kernel32.GenerateConsoleCtrlEvent(0, 0)\n"
+            'out["generate_ok"] = bool(ok)\n'
+            "print(out, flush=True)\n"
+            "raise SystemExit(0 if ok else 3)\n"
+        )
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            helper_path = Path(tmp) / "send_ctrlc_helper.py"
+            helper_path.write_text(helper_src, encoding="utf-8")
+
+            cmd = [
+                sys.executable, "-m", "puppetmaster",
+                "--state-dir", str(state_dir),
+                "dashboard", "--port", str(port), "--no-open",
+            ]
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                stdin=subprocess.DEVNULL,
+                cwd=str(repo_root),
+                creationflags=CREATE_NO_WINDOW,
+            )
+            try:
+                deadline = time.time() + 15
+                up = False
+                while time.time() < deadline:
+                    if proc.poll() is not None:
+                        break
+                    try:
+                        with urllib.request.urlopen(
+                            f"http://127.0.0.1:{port}/api/jobs", timeout=1
+                        ) as r:
+                            up = r.status == 200
+                            break
+                    except OSError:
+                        time.sleep(0.2)
+                self.assertIsNone(proc.poll(), "dashboard child exited before coming up")
+                self.assertTrue(up, "dashboard child never answered on its port")
+
+                helper = subprocess.run(
+                    [sys.executable, str(helper_path), str(proc.pid)],
+                    capture_output=True, text=True, creationflags=CREATE_NO_WINDOW,
+                )
+                self.assertIn(
+                    "'target_on_console': True",
+                    helper.stdout,
+                    "CTRL_C_EVENT delivery to the child console could not be "
+                    f"verified, so a hang here would be indistinguishable from "
+                    f"the bug: stdout={helper.stdout!r} stderr={helper.stderr!r}",
+                )
+
+                sent_at = time.time()
+                died_at = None
+                while time.time() - sent_at < 5.0:
+                    if proc.poll() is not None:
+                        died_at = time.time()
+                        break
+                    time.sleep(0.05)
+                self.assertIsNotNone(
+                    died_at, "dashboard did not exit within 5s of CTRL_C_EVENT"
+                )
+                self.assertEqual(proc.returncode, 0)
+
+                listeners = subprocess.run(
+                    [
+                        "powershell", "-NoProfile", "-Command",
+                        f"(Get-NetTCPConnection -LocalPort {port} -State Listen "
+                        f"-EA SilentlyContinue | Measure-Object).Count",
+                    ],
+                    capture_output=True, text=True, creationflags=CREATE_NO_WINDOW,
+                ).stdout.strip()
+                self.assertEqual(
+                    listeners, "0", "listening socket was not released after Ctrl-C"
+                )
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+                    proc.wait(timeout=10)
 
     def test_cost_rollup_tolerates_non_numeric_cost(self) -> None:
         """A ROUTING artifact with a non-numeric estimated_cost_usd must not


### PR DESCRIPTION
## Summary
- Absorb [@bsmi021](https://github.com/bsmi021) fork PR [#43](https://github.com/professorpalmer/Puppetmaster/pull/43) onto `dev` with stack-wide edits (not a rubber-stamp of the main-targeted fork).
- `serve()` now runs `ThreadingHTTPServer.serve_forever(poll_interval=0.5)` on the main thread so Windows Ctrl-C can interrupt, and `server_close()` runs on the blocking path so the listener is released.
- `serve_forever=False` still returns an open bound server (MCP/CLI `--background` stay on the detached Popen path). Portable regression tests cover main-thread loop + socket close; the Windows console e2e stays opt-in.
- Stack edit: Unreleased CHANGELOG now uses `dev` absorb credit for @bsmi021 / #43.

## Test plan
- [x] `DashboardTests` + `DashboardMobileTests` + `WinConsoleTests` (26 tests, 3 skipped including Windows console e2e on macOS)
- [x] Swarm `job_358b8678f600` (review/audit/redteam, cursor/grok-4-6 Extra High+Fast) — fix held; only required stack edit was absorb credit
- [x] CI on this PR (ubuntu 3.9/3.12, macos 3.12, windows 3.12)

