### PR TITLE
Fix: dashboard in a second project silently shadowed the first

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -60,10 +60,60 @@ write, the second project got no runfile at all, so its own `--status` and
   started; it previously compared the runfile against *this* invocation's
   `--all-projects` flag instead of the tracked record's own, so it wrongly
   reported "serving another project."
-- New `tests/test_dashboard_ports.py` and
-  `tests/test_dashboard_background_identity.py` cover the bind retry,
-  `/api/meta`, and identity-aware reuse (including both fixes above) end to
-  end.
+- New `tests/test_dashboard_ports.py` covers the bind retry and `/api/meta`
+  against real bound servers; `tests/test_dashboard_background_identity.py`
+  covers the CLI/MCP reuse wiring (mostly against a mocked identity check,
+  for speed) plus the `--port`/`auto_port` argv derivation, with a couple of
+  cases run against a real server to guard the wiring itself, not just the
+  identity functions.
+
+**Follow-up (adversarial review): the own-project-reuse pre-check had its own
+bugs.**
+
+- **Fix: an explicit `--port N` was silently discarded whenever this project
+  already had a live tracked dashboard.** The reuse pre-check (both CLI and
+  MCP) checked neither `auto_port` nor whether the tracked port matched the
+  one just asked for, so a tracked dashboard on a *different* port was
+  "reused" anyway — a regression against the `--port` semantics above:
+  moving a project's dashboard to a new port required `--stop` first, with
+  no error telling you so. Reuse of a tracked dashboard now requires either
+  `auto_port` (no explicit `--port`, or `--port-search`) or that the tracked
+  port equals the one requested.
+- **Fix: `--host localhost` piled up unstoppable servers.** The reuse
+  pre-check compared the requested host's *spelling* against the child's
+  recorded host, which is always the literal address it bound (e.g.
+  `127.0.0.1` — `--host` isn't forwarded for loopback names). `"localhost" !=
+  "127.0.0.1"` never matched, so every repeat `--background --host localhost`
+  spawned a brand-new server; only the last one was ever tracked, so the rest
+  leaked until reboot. Both sides of the comparison now fold through the same
+  loopback-alias table before comparing.
+- **Fix: a slow or hostile listener on the port could hang or balloon a
+  `dashboard` invocation.** `dashboard_identity`'s `timeout` bounded each
+  individual `recv`, not the call — a peer trickling one byte at a time kept
+  every `recv` under the timeout and could stall the caller far longer than
+  the declared budget (measured: 12s against 1.0s), and an unbounded `.read()`
+  would buffer an arbitrarily large body in full. It now enforces a real
+  wall-clock deadline across the whole read and caps the body size. Also
+  broadened its exception handling to cover `http.client`'s own exceptions
+  (a truncating server, a non-HTTP squatter) — these used to escape as a raw
+  traceback out of an ordinary `dashboard --background`, contradicting the
+  function's own "returns None" contract.
+- **Fix: `--status` called your own pre-upgrade dashboard "another
+  project."** A dashboard predating `/api/meta` 404s that route, which is
+  indistinguishable by liveness alone from a genuine foreign server — every
+  existing user with a background board hit this in the upgrade window.
+  `--status` now falls back to the runfile's own tracked pid: if nothing
+  identifies itself but that pid is still alive, it reports the board as
+  yours (noting identity couldn't be confirmed) rather than making the false
+  claim that it belongs to someone else. This only changes what `--status`
+  *reports* — the reuse path's identity requirement is unchanged.
+- A handful of nits: an invalid `--port` (e.g. `70000`) was reported as
+  "already in use," which was simply false — it's now reported as not a
+  valid port; `dashboard --background`'s failure message is no longer
+  generic (the detached child's stderr is now captured to a small log file
+  and quoted on failure, instead of being discarded to `DEVNULL`); the
+  literal-port reuse path no longer risks persisting a runfile with a null
+  pid from a redundant identity round-trip.
 
 ## v1.22.12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,9 +45,25 @@ write, the second project got no runfile at all, so its own `--status` and
   its own requested `--port`, which was simply wrong the moment the child
   bumped — this also fixes the `--mobile` banner/QR printing the
   pre-bump port before the bind even happened.
+- **Own-project reuse, host-gated.** `--background` and the MCP tool both
+  now check this project's own already-running dashboard — at whatever port
+  it actually bound to, which can be past the requested one from an earlier
+  bump — before probing the literal requested port, so a repeat call
+  doesn't spawn a redundant second server for the same project. Gated on
+  the tracked server's host matching the one requested: a loopback
+  dashboard from an earlier plain `--background` is never "reused" for a
+  later `--mobile` call, which needs an externally-reachable bind and would
+  otherwise get handed an unreachable `127.0.0.1` URL.
+- **`--status` compares against what it tracks, not what was just typed.**
+  `dashboard --status` (bare, so `--all-projects` defaults off) after
+  `dashboard --background --all-projects` now still reports the board it
+  started; it previously compared the runfile against *this* invocation's
+  `--all-projects` flag instead of the tracked record's own, so it wrongly
+  reported "serving another project."
 - New `tests/test_dashboard_ports.py` and
   `tests/test_dashboard_background_identity.py` cover the bind retry,
-  `/api/meta`, and identity-aware reuse end to end.
+  `/api/meta`, and identity-aware reuse (including both fixes above) end to
+  end.
 
 ## v1.22.12
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,54 @@
+## Unreleased
+
+**Fix: `puppetmaster dashboard` for a second project silently shadowed the
+first instead of starting its own server.**
+
+Two independent defects, both confirmed by direct repro. Foreground: a stock
+`ThreadingHTTPServer` sets `SO_REUSEADDR`, which has inverted semantics on
+Windows — a second dashboard's `bind()` succeeds *over* the first's live
+listener, so it prints a URL, opens a browser tab, and never receives a
+single request (the kernel routes everything to the first binder; killing
+the first silently hands the tab to the second, with no reload). Background/
+MCP: the reuse check was a bare liveness probe (`GET /api/jobs` returns 200)
+with no project identity, so a second project's `dashboard --background` (or
+the `puppetmaster_dashboard` MCP tool) was told "reusing it" and handed the
+*first* project's URL — and because the early return preceded the runfile
+write, the second project got no runfile at all, so its own `--status` and
+`--stop` had nothing to work with.
+
+- **BREAKING: an explicit `--port N` on a busy port now fails instead of
+  silently colliding.** Omit `--port` (the common case) and a busy port is
+  auto-bumped to the next free one (capped at 20 attempts, then a clear
+  error naming the range tried and suggesting `dashboard --stop`) — this is
+  the default fix for the reported bug. But a *named* port is a promise a
+  script/bookmark/reverse-proxy may depend on, so naming one that's taken now
+  errors instead of quietly serving somewhere else; pass the new
+  `--port-search` to opt back into bumping from an explicit `--port`.
+- **Bind retry, not a probe-then-bind.** New `bind_dashboard_server()` binds
+  on a dashboard-specific server class with `allow_reuse_address = 0` on
+  Windows only (POSIX keeps it, where it only reclaims a `TIME_WAIT` socket —
+  needed for an immediate restart after Ctrl-C) and retries on the *real*
+  `OSError`/`PermissionError` (matching Windows' `EADDRINUSE` **and**
+  `winerror == 10013`, not just `errno.EADDRINUSE`) — `ports.reserve_port()`
+  was considered and rejected as the primary mechanism because its
+  bind-probe-then-close has an inherent TOCTOU window.
+- **Project identity on the wire.** A new `GET /api/meta` returns a hashed
+  `state_dir_id` + pid (never the raw path — the board is unauthenticated
+  and reachable off-loopback under `--mobile`) so `--background`/MCP reuse
+  and `--status` can tell "this project's dashboard" from "something is
+  listening." A pre-upgrade dashboard 404s the new route and is correctly
+  treated as foreign — no coordinated upgrade needed. A project-scoped
+  request never reuses a running `--all-projects` board, or vice versa.
+- **Truthful port propagation.** The *child* now writes its own runfile
+  (`--write-runfile`, internal) after it knows its real, possibly-bumped
+  port; the parent only ever reads it back. Previously the parent recorded
+  its own requested `--port`, which was simply wrong the moment the child
+  bumped — this also fixes the `--mobile` banner/QR printing the
+  pre-bump port before the bind even happened.
+- New `tests/test_dashboard_ports.py` and
+  `tests/test_dashboard_background_identity.py` cover the bind retry,
+  `/api/meta`, and identity-aware reuse end to end.
+
 ## v1.22.12
 
 Absorb of [@bsmi021](https://github.com/bsmi021) PR

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -16,23 +16,33 @@ python -m puppetmaster dashboard            # jobs index for this workspace
 python -m puppetmaster dashboard <job_id>   # deep-link straight to one job
 ```
 
-From an agent, the MCP verb `puppetmaster_dashboard` starts the server (if one
-isn't already listening) and returns the URL to open — pass `job_id` to deep-link,
-`mobile: true` to get a phone URL + QR, and `stop: true` to tear it down. The
-server runs **detached**, so there's no terminal to keep open.
+From an agent, the MCP verb `puppetmaster_dashboard` starts the server (or reuses
+this project's own, if one is already running) and returns the URL to open — pass
+`job_id` to deep-link, `mobile: true` to get a phone URL + QR, and `stop: true` to
+tear it down. The server runs **detached**, so there's no terminal to keep open.
 
 | Flag | Default | Purpose |
 |---|---|---|
-| `--port` | `8787` | Port to serve on. |
+| `--port` | auto | Port to serve on. **Omit it** (the common case) to auto-pick the next free port starting at 8787 — a busy port (e.g. another project's dashboard) is never silently shared. **Pass it explicitly** and it's a strict promise: a busy port fails outright instead of quietly landing somewhere else, so a script/bookmark/reverse-proxy pinning a port can rely on it. Add `--port-search` to opt an explicit `--port` back into auto-bumping. |
+| `--port-search` | off | With an explicit `--port`, search upward from it instead of failing when it's busy. No effect without `--port` (bumping is already the default). |
 | `--host` | `127.0.0.1` | Bind host. Non-loopback is refused unless `--allow-external`. |
 | `--no-open` | off | Don't auto-open a browser tab. |
 | `--all-projects` | off | Aggregate jobs from every Puppetmaster project state dir on this machine. |
 | `--allow-external` | off | Allow binding to a non-loopback host. The board is **unauthenticated**, so this exposes job state to the network — only on a trusted one. |
 | `--mobile` | off | Serve on a phone-reachable address: auto-detect a Tailscale IP (falls back to LAN IP), bind it (implies `--allow-external`), and print the URL. See below. |
 | `--qr` | off | With `--mobile`, also print a scannable QR of the URL (needs the optional `qrcode` package). |
-| `--background` / `-b` | off | Run detached like a backend service and return to the prompt instead of holding the terminal. Prints the URL (and QR with `--qr`), then keeps serving until `--stop`. |
+| `--background` / `-b` | off | Run detached like a backend service and return to the prompt instead of holding the terminal. Prints the URL (and QR with `--qr`), then keeps serving until `--stop`. Reuses this project's own already-running background dashboard instead of spawning a redundant one. |
 | `--stop` | off | Stop the detached background dashboard for this state dir. |
 | `--status` | off | Report whether a background dashboard is running for this state dir. |
+
+**Project identity, not just liveness.** Every dashboard exposes `GET /api/meta`
+— a hashed id for its state dir, plus pid and `--all-projects` scope — so
+`--background`/the MCP tool can tell *this project's* dashboard apart from some
+other program (or another project's board) merely answering on the same
+host:port, and reuse only the former. A pre-upgrade dashboard without this route
+is never mistaken for a match — no coordinated upgrade needed, and `--status`
+still reports it as yours (noting it predates `/api/meta`) as long as the pid
+your own runfile tracked is still alive.
 
 ## Easiest setup: let the pilot run it (no second terminal)
 

--- a/puppetmaster/cli/_dispatch.py
+++ b/puppetmaster/cli/_dispatch.py
@@ -182,27 +182,79 @@ def _start_background_dashboard(
     state_dir: Path,
     host: str,
     *,
+    port: int,
+    auto_port: bool,
     source: str,
     allow_external: bool,
 ) -> int:
     """Spawn a detached dashboard, wait for it to answer, and return the link.
 
-    The detached child runs the ordinary foreground server in its own session,
-    so it survives this process exiting. We record its pid in the state dir so
-    ``--stop`` / ``--status`` can manage it without hunting for the port owner.
+    The detached child runs the ordinary foreground server in its own
+    session, so it survives this process exiting.
+
+    Reuse is identity-aware (``dashboard_serves``), not a bare liveness
+    probe: something merely *answering* on ``host:port`` used to be enough to
+    declare "reusing it" — even when it was a different project's dashboard,
+    which strands the caller with a URL for state it doesn't own and no
+    runfile of its own (``--status``/``--stop`` then fail on it). And because
+    the child may bump to a port other than the one requested (``auto_port``,
+    §3.1), *it* — not this parent — writes the runfile once it knows the real
+    port (``--write-runfile``); the parent only ever reads that back.
     """
     from puppetmaster.dashboard import (
-        dashboard_alive,
+        clear_dashboard_runfile,
+        dashboard_identity,
+        dashboard_serves,
+        pid_alive,
+        read_dashboard_runfile,
         write_dashboard_runfile,
     )
 
-    port = args.port
-    url = f"http://{host}:{port}/" + (f"?job={args.job_id}" if args.job_id else "")
+    all_projects = getattr(args, "all_projects", False)
 
-    if dashboard_alive(host, port):
+    def _reuse(existing_host: str, existing_port: int, existing_pid) -> int:
+        url = f"http://{existing_host}:{existing_port}/" + (
+            f"?job={args.job_id}" if args.job_id else ""
+        )
         print(f"Dashboard already serving at {url} — reusing it.")
-        _announce_background_dashboard(args, host, port, source)
+        # Closes the bonus defect where the old blind-reuse early return
+        # preceded the runfile write entirely: without this, the caller that
+        # "reused" the server had no runfile of its own, so its own
+        # --status/--stop had nothing to work with.
+        write_dashboard_runfile(
+            state_dir,
+            {
+                "pid": existing_pid,
+                "host": existing_host,
+                "port": existing_port,
+                "url": url,
+                "all_projects": all_projects,
+            },
+        )
+        _announce_background_dashboard(args, existing_host, existing_port, source)
         return 0
+
+    # This project's own background dashboard may already be running — at
+    # whatever port it actually bound to, which can be past `port` if it
+    # bumped on a previous run. Check the tracked address first so a repeat
+    # `--background` doesn't spawn a redundant second server for the same
+    # project (and clobber the runfile the first one is still using).
+    existing = read_dashboard_runfile(state_dir)
+    if existing and pid_alive(int(existing.get("pid") or 0)):
+        existing_host = existing.get("host", host)
+        existing_port = int(existing.get("port") or port)
+        if dashboard_serves(existing_host, existing_port, state_dir, all_projects=all_projects):
+            return _reuse(existing_host, existing_port, existing.get("pid"))
+
+    # Nothing tracked (or it's stale/foreign) — something may still identify
+    # itself as this project's dashboard on the requested port specifically.
+    if dashboard_serves(host, port, state_dir, all_projects=all_projects):
+        identity = dashboard_identity(host, port)
+        return _reuse(host, port, (identity or {}).get("pid"))
+
+    # Clear any stale/foreign runfile so the readiness poll below can't
+    # mistake it for the child we're about to spawn.
+    clear_dashboard_runfile(state_dir)
 
     command = [
         sys.executable,
@@ -216,12 +268,15 @@ def _start_background_dashboard(
         "--port",
         str(port),
         "--no-open",
+        "--write-runfile",
     ]
+    if auto_port:
+        command.append("--port-search")
     if host.strip().lower() not in {"127.0.0.1", "localhost", "::1"}:
         command += ["--host", host]
     if allow_external:
         command.append("--allow-external")
-    if getattr(args, "all_projects", False):
+    if all_projects:
         command.append("--all-projects")
     if args.job_id:
         command.append(args.job_id)
@@ -233,12 +288,28 @@ def _start_background_dashboard(
         stderr=subprocess.DEVNULL,
         start_new_session=True,
     )
+
+    # Poll the child's own runfile rather than re-probing `host:port` — the
+    # child may have bumped, so a liveness/identity probe pinned to the
+    # requested port can miss it entirely (or, worse, see a *different*
+    # project's dashboard on that port and declare success).
     deadline = time.time() + 10
-    while time.time() < deadline and not dashboard_alive(host, port):
+    child_info = None
+    while time.time() < deadline:
+        candidate = read_dashboard_runfile(state_dir)
+        if candidate and candidate.get("pid") == process.pid:
+            child_info = candidate
+            break
         if process.poll() is not None:
             break
         time.sleep(0.2)
-    if not dashboard_alive(host, port):
+
+    if child_info is None or not dashboard_serves(
+        child_info.get("host", host),
+        int(child_info.get("port") or port),
+        state_dir,
+        all_projects=all_projects,
+    ):
         print(
             "puppetmaster dashboard --background: server did not come up. Run "
             f"`python -m puppetmaster dashboard --port {port}` in the foreground "
@@ -247,19 +318,10 @@ def _start_background_dashboard(
         )
         return 1
 
-    write_dashboard_runfile(
-        state_dir,
-        {
-            "pid": process.pid,
-            "host": host,
-            "port": port,
-            "url": url,
-            "source": source,
-            "all_projects": getattr(args, "all_projects", False),
-        },
-    )
+    bound_host = child_info.get("host", host)
+    bound_port = int(child_info.get("port") or port)
     print(f"Dashboard running in the background (pid {process.pid}).")
-    _announce_background_dashboard(args, host, port, source)
+    _announce_background_dashboard(args, bound_host, bound_port, source)
     print("Stop it with: python -m puppetmaster dashboard --stop")
     return 0
 
@@ -282,12 +344,22 @@ def _announce_background_dashboard(
 def _run_dashboard_command(args: argparse.Namespace, state_dir: Path) -> int:
     from puppetmaster.dashboard import (
         dashboard_alive,
+        dashboard_serves,
         print_mobile_banner,
         read_dashboard_runfile,
         resolve_mobile_host,
         serve,
         stop_background_dashboard,
     )
+
+    # argparse's --port default is now a sentinel (None), not 8787: only that
+    # lets us tell "user typed --port 8787" apart from "user typed nothing"
+    # (§3.3/§3.7(a)), which is what makes an explicit --port strict-fail
+    # instead of silently landing on a different port than the one asked for.
+    explicit_port = args.port is not None
+    port = args.port if explicit_port else 8787
+    auto_port = (not explicit_port) or getattr(args, "port_search", False)
+    all_projects = getattr(args, "all_projects", False)
 
     if getattr(args, "stop", False):
         result = stop_background_dashboard(state_dir)
@@ -303,17 +375,29 @@ def _run_dashboard_command(args: argparse.Namespace, state_dir: Path) -> int:
 
     if getattr(args, "status", False):
         info = read_dashboard_runfile(state_dir)
-        if info and dashboard_alive(
-            info.get("host", "127.0.0.1"), int(info.get("port") or args.port)
-        ):
-            print(
-                f"Background dashboard running: {info.get('url')} (pid {info.get('pid')})."
-            )
-        elif info:
-            print(
-                "A background dashboard is tracked here but isn't answering "
-                "(stale). Clear it with `dashboard --stop`."
-            )
+        if info:
+            info_host = info.get("host", "127.0.0.1")
+            info_port = int(info.get("port") or port)
+            if dashboard_serves(info_host, info_port, state_dir, all_projects=all_projects):
+                print(
+                    f"Background dashboard running: {info.get('url')} (pid {info.get('pid')})."
+                )
+            elif dashboard_alive(info_host, info_port):
+                # Something answers at the tracked address, but it isn't
+                # provably *this* project (or --all-projects scope doesn't
+                # match) — the old bare-liveness check reported this as
+                # "running" even when it was a different project's board.
+                print(
+                    "A dashboard is running at the tracked address, but it is "
+                    "serving another project (or a different --all-projects "
+                    "scope) — not this state dir. Clear it with `dashboard "
+                    "--stop` and start a fresh one."
+                )
+            else:
+                print(
+                    "A background dashboard is tracked here but isn't answering "
+                    "(stale). Clear it with `dashboard --stop`."
+                )
         else:
             print("No background dashboard is running for this state dir.")
         return 0
@@ -338,28 +422,52 @@ def _run_dashboard_command(args: argparse.Namespace, state_dir: Path) -> int:
 
     if getattr(args, "background", False):
         return _start_background_dashboard(
-            args, state_dir, host, source=source, allow_external=allow_external
-        )
-
-    if getattr(args, "mobile", False):
-        print_mobile_banner(
+            args,
+            state_dir,
             host,
-            args.port,
-            source,
-            job_id=args.job_id,
-            qr=getattr(args, "qr", False),
+            port=port,
+            auto_port=auto_port,
+            source=source,
+            allow_external=allow_external,
         )
 
-    serve(
-        state_dir,
-        backend=args.backend,
-        job_id=args.job_id,
-        host=host,
-        port=args.port,
-        open_browser=open_browser,
-        allow_external=allow_external,
-        all_projects=getattr(args, "all_projects", False),
-    )
+    # The mobile banner used to print before serve() bound the socket, so its
+    # QR/URL named the *requested* port even when the bind later bumped past
+    # it (§3.4 step 7). Deferring it to serve()'s on_bound callback means it
+    # only ever prints the port that's actually listening.
+    on_bound = None
+    if getattr(args, "mobile", False):
+
+        def on_bound(bound_host: str, bound_port: int) -> None:
+            print_mobile_banner(
+                bound_host,
+                bound_port,
+                source,
+                job_id=args.job_id,
+                qr=getattr(args, "qr", False),
+            )
+
+    try:
+        serve(
+            state_dir,
+            backend=args.backend,
+            job_id=args.job_id,
+            host=host,
+            port=port,
+            open_browser=open_browser,
+            allow_external=allow_external,
+            all_projects=all_projects,
+            auto_port=auto_port,
+            on_bound=on_bound,
+            runfile_state_dir=state_dir if getattr(args, "write_runfile", False) else None,
+        )
+    except OSError as exc:
+        # bind_dashboard_server's strict-fail / cap-exhausted errors, e.g. an
+        # explicit --port that's busy. main() only catches FileNotFoundError/
+        # ValueError/RuntimeError (_dispatch.py:136-141), so an uncaught
+        # OSError here would otherwise print a raw traceback.
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/puppetmaster/cli/_dispatch.py
+++ b/puppetmaster/cli/_dispatch.py
@@ -177,6 +177,18 @@ def _resolve_store_for_job(
     return found, create_store(backend, found)
 
 
+def _read_child_stderr_tail(path: Path, *, max_bytes: int = 4000) -> str:
+    """Best-effort tail of a detached child's captured stderr, or "" if
+    there's nothing (file missing, empty, or unreadable)."""
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return ""
+    if not data:
+        return ""
+    return data[-max_bytes:].decode("utf-8", errors="replace").strip()
+
+
 def _start_background_dashboard(
     args: argparse.Namespace,
     state_dir: Path,
@@ -204,7 +216,9 @@ def _start_background_dashboard(
     from puppetmaster.dashboard import (
         clear_dashboard_runfile,
         dashboard_identity,
+        dashboard_runfile,
         dashboard_serves,
+        normalize_dashboard_host,
         pid_alive,
         read_dashboard_runfile,
         write_dashboard_runfile,
@@ -240,22 +254,52 @@ def _start_background_dashboard(
     # `--background` doesn't spawn a redundant second server for the same
     # project (and clobber the runfile the first one is still using).
     existing = read_dashboard_runfile(state_dir)
-    if existing and existing.get("host", host) == host and pid_alive(int(existing.get("pid") or 0)):
+    if (
+        existing
+        and normalize_dashboard_host(existing.get("host", host)) == normalize_dashboard_host(host)
+        and pid_alive(int(existing.get("pid") or 0))
+    ):
         # Host-gated: a loopback dashboard tracked from an earlier plain
         # --background must not be "reused" for a --mobile request that
         # needs an externally-reachable bind. Falling through to the
         # literal-port probe below on a host mismatch correctly fails (a
         # loopback server doesn't answer on the LAN/Tailscale IP) and a new,
-        # properly-bound server gets spawned instead.
+        # properly-bound server gets spawned instead. Both sides of the host
+        # comparison are normalized (§F2) — the child always records the
+        # literal address it bound (e.g. "127.0.0.1"), never a loopback
+        # alias like "localhost", so comparing raw strings never matched a
+        # repeat --host localhost and piled up an orphaned server per call.
         existing_port = int(existing.get("port") or port)
-        if dashboard_serves(host, existing_port, state_dir, all_projects=all_projects):
+        # Port-gated (§F1): an explicit --port names a promise the caller
+        # may depend on (a script, a bookmark, a reverse proxy) -- reusing a
+        # tracked dashboard on a *different* port would silently discard
+        # that port with exit 0 instead of honoring or strict-failing it,
+        # exactly the collision --port is supposed to prevent. Only skip
+        # this gate when the caller didn't pin a port (auto_port, which is
+        # also true for an explicit --port --port-search) or the tracked
+        # port already matches what was asked for.
+        if (auto_port or existing_port == port) and dashboard_serves(
+            host, existing_port, state_dir, all_projects=all_projects
+        ):
             return _reuse(host, existing_port, existing.get("pid"))
 
-    # Nothing tracked (or it's stale/foreign) — something may still identify
-    # itself as this project's dashboard on the requested port specifically.
+    # Nothing tracked (or it's stale/foreign/on the wrong port) — something
+    # may still identify itself as this project's dashboard on the
+    # requested port specifically. This probe is always against the literal
+    # requested `port`, so it needs no explicit-port gate of its own: a
+    # match here already satisfies "this is a dashboard on the exact port
+    # asked for".
     if dashboard_serves(host, port, state_dir, all_projects=all_projects):
         identity = dashboard_identity(host, port)
-        return _reuse(host, port, (identity or {}).get("pid"))
+        if identity is None:
+            # dashboard_serves() just confirmed this identity a moment ago;
+            # None here means the server went away in between. Don't
+            # persist a runfile with a null pid (--stop would then report
+            # "process was not running" while a real server was still
+            # up) -- fall through and spawn our own instead.
+            pass
+        else:
+            return _reuse(host, port, identity.get("pid"))
 
     # Clear any stale/foreign runfile so the readiness poll below can't
     # mistake it for the child we're about to spawn.
@@ -286,13 +330,28 @@ def _start_background_dashboard(
     if args.job_id:
         command.append(args.job_id)
 
-    process = subprocess.Popen(
-        command,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
-    )
+    # The child's stderr used to be DEVNULL'd outright, so a real failure
+    # (the bind error, an import failure, ...) left the caller with nothing
+    # but "server did not come up" -- capture it to a file (not a pipe: this
+    # child is meant to outlive this process, and an unread PIPE would
+    # eventually fill and block a long-running server's own stderr writes)
+    # so a failure can quote it.
+    child_log = dashboard_runfile(state_dir).with_name("dashboard.err.log")
+    try:
+        err_handle: Any = open(child_log, "w", encoding="utf-8")
+    except OSError:
+        err_handle = subprocess.DEVNULL
+    try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=err_handle,
+            start_new_session=True,
+        )
+    finally:
+        if err_handle is not subprocess.DEVNULL:
+            err_handle.close()
 
     # Poll the child's own runfile rather than re-probing `host:port` — the
     # child may have bumped, so a liveness/identity probe pinned to the
@@ -315,10 +374,12 @@ def _start_background_dashboard(
         state_dir,
         all_projects=all_projects,
     ):
+        hint = _read_child_stderr_tail(child_log)
+        detail = f"\n{hint}" if hint else ""
         print(
-            "puppetmaster dashboard --background: server did not come up. Run "
-            f"`python -m puppetmaster dashboard --port {port}` in the foreground "
-            "to see the error.",
+            "puppetmaster dashboard --background: server did not come up."
+            f"{detail}\nRun `python -m puppetmaster dashboard --port {port}` "
+            "in the foreground to see the error.",
             file=sys.stderr,
         )
         return 1
@@ -349,7 +410,9 @@ def _announce_background_dashboard(
 def _run_dashboard_command(args: argparse.Namespace, state_dir: Path) -> int:
     from puppetmaster.dashboard import (
         dashboard_alive,
+        dashboard_identity,
         dashboard_serves,
+        pid_alive,
         print_mobile_banner,
         read_dashboard_runfile,
         resolve_mobile_host,
@@ -397,16 +460,34 @@ def _run_dashboard_command(args: argparse.Namespace, state_dir: Path) -> int:
                     f"Background dashboard running: {info.get('url')} (pid {info.get('pid')})."
                 )
             elif dashboard_alive(info_host, info_port):
-                # Something answers at the tracked address, but it isn't
-                # provably *this* project (or --all-projects scope doesn't
-                # match) — the old bare-liveness check reported this as
-                # "running" even when it was a different project's board.
-                print(
-                    "A dashboard is running at the tracked address, but it is "
-                    "serving another project (or a different --all-projects "
-                    "scope) — not this state dir. Clear it with `dashboard "
-                    "--stop` and start a fresh one."
-                )
+                # Something answers at the tracked address, but it doesn't
+                # identify as this project (or --all-projects scope doesn't
+                # match) via /api/meta -- which is also what a *pre-upgrade*
+                # puppetmaster dashboard looks like: it 404s a route that
+                # didn't exist yet. Every existing user with a background
+                # board hits this in the upgrade window, and it would be a
+                # false statement to call their own older server "another
+                # project". Fall back to the runfile's own pid: if nothing
+                # identifies itself but the pid this project's own runfile
+                # tracked is still alive, it's far more likely that same
+                # process running old code than a coincidentally-arrived
+                # foreign dashboard. (This only changes what --status
+                # *reports* -- the reuse path above still requires a real
+                # identity match and is not weakened by this fallback.)
+                tracked_pid = int(info.get("pid") or 0)
+                if dashboard_identity(info_host, info_port) is None and pid_alive(tracked_pid):
+                    print(
+                        f"Background dashboard running: {info.get('url')} "
+                        f"(pid {info.get('pid')}) -- predates /api/meta, so "
+                        "identity could not be confirmed."
+                    )
+                else:
+                    print(
+                        "A dashboard is running at the tracked address, but it is "
+                        "serving another project (or a different --all-projects "
+                        "scope) — not this state dir. Clear it with `dashboard "
+                        "--stop` and start a fresh one."
+                    )
             else:
                 print(
                     "A background dashboard is tracked here but isn't answering "

--- a/puppetmaster/cli/_dispatch.py
+++ b/puppetmaster/cli/_dispatch.py
@@ -240,11 +240,16 @@ def _start_background_dashboard(
     # `--background` doesn't spawn a redundant second server for the same
     # project (and clobber the runfile the first one is still using).
     existing = read_dashboard_runfile(state_dir)
-    if existing and pid_alive(int(existing.get("pid") or 0)):
-        existing_host = existing.get("host", host)
+    if existing and existing.get("host", host) == host and pid_alive(int(existing.get("pid") or 0)):
+        # Host-gated: a loopback dashboard tracked from an earlier plain
+        # --background must not be "reused" for a --mobile request that
+        # needs an externally-reachable bind. Falling through to the
+        # literal-port probe below on a host mismatch correctly fails (a
+        # loopback server doesn't answer on the LAN/Tailscale IP) and a new,
+        # properly-bound server gets spawned instead.
         existing_port = int(existing.get("port") or port)
-        if dashboard_serves(existing_host, existing_port, state_dir, all_projects=all_projects):
-            return _reuse(existing_host, existing_port, existing.get("pid"))
+        if dashboard_serves(host, existing_port, state_dir, all_projects=all_projects):
+            return _reuse(host, existing_port, existing.get("pid"))
 
     # Nothing tracked (or it's stale/foreign) — something may still identify
     # itself as this project's dashboard on the requested port specifically.
@@ -378,7 +383,16 @@ def _run_dashboard_command(args: argparse.Namespace, state_dir: Path) -> int:
         if info:
             info_host = info.get("host", "127.0.0.1")
             info_port = int(info.get("port") or port)
-            if dashboard_serves(info_host, info_port, state_dir, all_projects=all_projects):
+            # Compare against the *tracked* record's own all_projects, not
+            # this invocation's flag: --status asks "is what my runfile
+            # points at still there", not "does it match what I'd request
+            # right now" -- `dashboard --status` (all_projects defaults
+            # False) after `dashboard --background --all-projects` must
+            # still report the board it started, not "another project".
+            if dashboard_serves(
+                info_host, info_port, state_dir,
+                all_projects=bool(info.get("all_projects")),
+            ):
                 print(
                     f"Background dashboard running: {info.get('url')} (pid {info.get('pid')})."
                 )

--- a/puppetmaster/cli/_parser.py
+++ b/puppetmaster/cli/_parser.py
@@ -899,7 +899,25 @@ def build_parser() -> argparse.ArgumentParser:
         nargs="?",
         help="Job to open. Omit to land on the job list.",
     )
-    dashboard_cmd.add_argument("--port", type=int, default=8787, help="Port (default 8787).")
+    dashboard_cmd.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help=(
+            "Port. Default: auto-picks the next free port starting at 8787 "
+            "(so a second project's dashboard never silently shadows the "
+            "first). An explicit --port is strict: it fails if busy unless "
+            "--port-search is also given."
+        ),
+    )
+    dashboard_cmd.add_argument(
+        "--port-search",
+        action="store_true",
+        help=(
+            "With an explicit --port, search upward from it instead of "
+            "failing when it is busy."
+        ),
+    )
     dashboard_cmd.add_argument("--host", default="127.0.0.1", help="Bind host (default 127.0.0.1).")
     dashboard_cmd.add_argument(
         "--no-open",
@@ -957,6 +975,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--status",
         action="store_true",
         help="Report whether a background dashboard is running for this state dir.",
+    )
+    dashboard_cmd.add_argument(
+        "--write-runfile",
+        action="store_true",
+        help=argparse.SUPPRESS,  # internal contract: set by the --background
+        # parent on the child it spawns, so the *serving* process is the one
+        # that records its own (possibly bumped) port. Not for direct use.
     )
 
     await_cmd = subcommands.add_parser(

--- a/puppetmaster/dashboard.py
+++ b/puppetmaster/dashboard.py
@@ -20,6 +20,8 @@ socket:
 """
 from __future__ import annotations
 
+import errno
+import hashlib
 import json
 import os
 import re
@@ -2215,7 +2217,13 @@ setInterval(tick, 1500);
 INDEX_HTML = _PAGE_HEAD + RENDERER_JS + _PAGE_APP_JS
 
 
-def make_handler(store_factory: Callable[[], SwarmStore], *, all_projects: bool = False, backend: str = "sqlite"):
+def make_handler(
+    store_factory: Callable[[], SwarmStore],
+    *,
+    all_projects: bool = False,
+    backend: str = "sqlite",
+    state_dir: Optional[Union[Path, str]] = None,
+):
     from http.server import BaseHTTPRequestHandler
     from urllib.parse import parse_qs, urlparse
 
@@ -2269,6 +2277,26 @@ def make_handler(store_factory: Callable[[], SwarmStore], *, all_projects: bool 
                     except (FileNotFoundError, KeyError):
                         self._json(404, {"error": "job not found", "id": job_id})
                     return
+                if path == "/api/meta":
+                    # Identity on the wire (§3.2): lets a caller ask "is this
+                    # server mine?" without guessing from liveness alone. The
+                    # id is hashed — see _state_dir_id — so an unauthenticated,
+                    # possibly non-loopback endpoint never leaks the absolute
+                    # state dir path. The human-readable basename is loopback
+                    # gated; a remote (--mobile) peer only gets the hash.
+                    is_loopback = self.client_address[0] in ("127.0.0.1", "::1")
+                    project = None
+                    if is_loopback and state_dir is not None:
+                        project = Path(state_dir).name
+                    self._json(200, {
+                        "service": "puppetmaster-dashboard",
+                        "state_dir_id": _state_dir_id(state_dir),
+                        "project": project,
+                        "pid": os.getpid(),
+                        "all_projects": all_projects,
+                        "backend": backend,
+                    })
+                    return
                 self._json(404, {"error": "not found"})
             except Exception:
                 # Never leak internals (paths, backend details) to the client;
@@ -2279,6 +2307,23 @@ def make_handler(store_factory: Callable[[], SwarmStore], *, all_projects: bool 
 
 
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", ""})
+
+
+def _state_dir_id(state_dir: Optional[Union[Path, str]]) -> Optional[str]:
+    """A stable, non-reversible id for ``state_dir``.
+
+    Used on both sides of the identity check (the server's /api/meta response
+    and every prober) so "same project" is a plain string comparison. Hashed
+    rather than the raw path because the endpoint is unauthenticated and can
+    be reachable off-loopback under --mobile — the id must be safe to hand to
+    an unauthenticated peer while the path itself (username, directory
+    layout) is not. ``normcase`` is a no-op on POSIX and folds Windows drive-
+    letter/case variance before hashing.
+    """
+    if state_dir is None:
+        return None
+    resolved = os.path.normcase(str(Path(state_dir).resolve()))
+    return hashlib.sha256(resolved.encode("utf-8")).hexdigest()[:12]
 
 
 def _tailscale_binary() -> Optional[str]:
@@ -2531,6 +2576,58 @@ def dashboard_alive(host: str = "127.0.0.1", port: int = 8787, *, timeout: float
         return False
 
 
+def dashboard_identity(
+    host: str = "127.0.0.1", port: int = 8787, *, timeout: float = 1.0
+) -> Optional[dict]:
+    """The ``/api/meta`` payload from the dashboard on ``host:port``, or None.
+
+    None covers every case that means "can't vouch for this server": no
+    response, non-200, a body that isn't JSON (a foreign, non-dashboard web
+    server could 200 anything on that port), or a JSON body missing the
+    ``service`` marker. A pre-upgrade puppetmaster dashboard 404s
+    ``/api/meta`` and also lands here — the conservative default is "not
+    mine, don't reuse it, bump past it" (§3.2 rollout note).
+    """
+    import urllib.request
+
+    try:
+        with urllib.request.urlopen(
+            f"http://{host}:{port}/api/meta", timeout=timeout
+        ) as response:
+            if response.status != 200:
+                return None
+            payload = json.loads(response.read().decode("utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, dict) or payload.get("service") != "puppetmaster-dashboard":
+        return None
+    return payload
+
+
+def dashboard_serves(
+    host: str,
+    port: int,
+    state_dir: Union[Path, str],
+    *,
+    all_projects: bool = False,
+    timeout: float = 1.0,
+) -> bool:
+    """True only when ``host:port`` is a dashboard serving *this* state dir.
+
+    Encodes decision (f) in one place: a project-scoped caller (``all_projects=
+    False``) must not treat a running ``--all-projects`` board as "this
+    project's dashboard" — it should bump and start its own project-scoped
+    one — and vice versa. Both sides of the comparison route through
+    :func:`_state_dir_id` so this never compares raw paths.
+    """
+    identity = dashboard_identity(host, port, timeout=timeout)
+    if identity is None:
+        return False
+    if identity.get("state_dir_id") != _state_dir_id(state_dir):
+        return False
+    return bool(identity.get("all_projects")) == bool(all_projects)
+
+
 def stop_background_dashboard(state_dir: Union[Path, str]) -> dict:
     """Stop the detached background dashboard recorded for ``state_dir``.
 
@@ -2558,6 +2655,81 @@ def stop_background_dashboard(state_dir: Union[Path, str]) -> dict:
     return result
 
 
+def _port_taken(exc: OSError) -> bool:
+    """True when a bind failure means "pick another port" rather than "give up"."""
+    if exc.errno == errno.EADDRINUSE:  # 10048 on Windows, 98 on Linux
+        return True
+    # Windows-only: WSAEACCES surfaces as PermissionError(errno=EACCES,
+    # winerror=10013) both when another socket holds the port with
+    # incompatible SO_REUSEADDR options and when the port sits in a range
+    # Windows reserves for Hyper-V/WSL/winnat. Either way: bump. Deliberately
+    # NOT generalised to a bare EACCES, which on POSIX means "privileged port
+    # (<1024)" — bumping there would retry against a permissions wall instead
+    # of surfacing the real problem.
+    return getattr(exc, "winerror", None) == 10013
+
+
+def _dashboard_server_class():
+    from http.server import ThreadingHTTPServer
+
+    class _DashboardServer(ThreadingHTTPServer):
+        # SO_REUSEADDR has inverted semantics on Windows: when both the
+        # incumbent and the newcomer set it, bind() succeeds *over a live
+        # listener* and the first binder silently keeps every connection — a
+        # second project's dashboard prints its URL, opens a browser tab, and
+        # never receives a request (it serves the first project's jobs
+        # instead). Disabling it on Windows turns the collision into a real,
+        # detectable EADDRINUSE/EACCES (mirrors puppetmaster/ports.py's
+        # _port_is_free, which guards the same inversion). On POSIX we keep
+        # it: there it only permits rebinding a TIME_WAIT socket, which is
+        # what makes an immediate restart after Ctrl-C work.
+        allow_reuse_address = 0 if os.name == "nt" else 1
+
+    return _DashboardServer
+
+
+def bind_dashboard_server(
+    host: str, port: int, handler, *, auto_port: bool = True, max_attempts: int = 20
+):
+    """Bind the dashboard, bumping past ports already in use when ``auto_port``.
+
+    Returns the bound server; read the real port from
+    ``server.server_address[1]`` — never assume it equals ``port``.
+    ``port=0`` (OS-assigned ephemeral port, used by tests) always succeeds on
+    the first attempt.
+
+    ``ports.reserve_port()`` is not used here: it binds a probe socket, closes
+    it, and returns — a TOCTOU window (documented on that function) that
+    another process can win before this call binds for real. The only sound
+    fix is retrying the bind on the real server socket, which is what this
+    does.
+    """
+    server_class = _dashboard_server_class()
+    last: Optional[OSError] = None
+    attempts = max_attempts if auto_port else 1
+    for offset in range(attempts):
+        candidate = port + offset
+        if candidate > 65535:
+            break
+        try:
+            return server_class((host, candidate), handler)
+        except OSError as exc:
+            if not _port_taken(exc):
+                raise
+            last = exc
+    if not auto_port:
+        raise OSError(
+            f"port {port} on {host} is already in use — another dashboard (or "
+            f"another program) owns it. Omit --port to auto-pick the next free "
+            f"port, or pass --port-search to start searching from {port}."
+        ) from last
+    raise OSError(
+        f"no free port for the dashboard in {port}-{port + attempts - 1} on {host}. "
+        f"Stop an old dashboard (`puppetmaster dashboard --stop`) or pass an "
+        f"explicit --port."
+    ) from last
+
+
 def serve(
     state_dir: Union[Path, str],
     *,
@@ -2569,6 +2741,10 @@ def serve(
     serve_forever: bool = True,
     allow_external: bool = False,
     all_projects: bool = False,
+    auto_port: bool = True,
+    max_port_attempts: int = 20,
+    on_bound: Optional[Callable[[str, int], None]] = None,
+    runfile_state_dir: Optional[Union[Path, str]] = None,
 ):
     """Start the dashboard HTTP server. Returns the server (already bound).
 
@@ -2580,9 +2756,18 @@ def serve(
     refused unless ``allow_external`` (or
     ``PUPPETMASTER_DASHBOARD_ALLOW_EXTERNAL=1``) is set, making the exposure an
     explicit, deliberate choice.
-    """
-    from http.server import ThreadingHTTPServer
 
+    Two dashboards started for different projects used to both silently
+    "succeed" in binding the same port (Windows' inverted SO_REUSEADDR
+    semantics — see :func:`_dashboard_server_class`), with only the first
+    binder ever receiving a request. ``auto_port`` (the default, matching a
+    bare ``--port``-less invocation) makes that collision a real, detectable
+    bind failure and bumps to the next free port instead; pass
+    ``auto_port=False`` for the strict "this exact port or fail" behaviour an
+    explicit ``--port`` gets. Callers that need the *actual* bound port
+    (which may differ from the requested one) should use ``on_bound`` rather
+    than assuming it equals ``port``.
+    """
     from puppetmaster.store_factory import create_store
 
     allow_external = allow_external or os.environ.get(
@@ -2603,21 +2788,59 @@ def serve(
         # avoids cross-thread cursor reuse under the threading server.
         return create_store(backend, resolved)
 
-    httpd = ThreadingHTTPServer((host, port), make_handler(store_factory, all_projects=all_projects, backend=backend))
-    url = f"http://{host}:{port}/" + (f"?job={job_id}" if job_id else "")
-    print(f"Puppetmaster dashboard: {url}")
-    if all_projects:
-        print("Serving all projects (--all-projects mode)")
-    else:
-        print("Reading durable state from:", resolved)
-    print("Press Ctrl-C to stop.")
-    if open_browser:
-        try:
-            import webbrowser
+    handler = make_handler(
+        store_factory, all_projects=all_projects, backend=backend, state_dir=resolved
+    )
+    httpd = bind_dashboard_server(
+        host, port, handler, auto_port=auto_port, max_attempts=max_port_attempts
+    )
+    # Everything from here down runs *after* the bind (runfile write,
+    # on_bound callback) and can fail for reasons unrelated to the socket —
+    # a failure here must not leak the now-listening socket behind it.
+    try:
+        bound_port = httpd.server_address[1]
+        if port != 0 and bound_port != port:
+            print(
+                f"Port {port} is busy (another project's dashboard?) — serving "
+                f"this project on {bound_port} instead."
+            )
+        # The single place the URL is derived — everything downstream (the
+        # browser tab, the runfile, on_bound, the mobile banner) must consume
+        # this variable, never the originally-requested `port`.
+        url = f"http://{host}:{bound_port}/" + (f"?job={job_id}" if job_id else "")
+        print(f"Puppetmaster dashboard: {url}")
+        if all_projects:
+            print("Serving all projects (--all-projects mode)")
+        else:
+            print("Reading durable state from:", resolved)
+        print("Press Ctrl-C to stop.")
+        if open_browser:
+            try:
+                import webbrowser
 
-            webbrowser.open(url)
-        except Exception:
-            pass
+                webbrowser.open(url)
+            except Exception:
+                pass
+        if runfile_state_dir is not None:
+            # The *serving* process writes its own runfile, post-bind, so the
+            # recorded port is never a guess (previously the parent guessed
+            # its own requested --port, which was wrong the moment the child
+            # bumped — see docs/CHANGELOG.md).
+            write_dashboard_runfile(
+                runfile_state_dir,
+                {
+                    "pid": os.getpid(),
+                    "host": host,
+                    "port": bound_port,
+                    "url": url,
+                    "all_projects": all_projects,
+                },
+            )
+        if on_bound is not None:
+            on_bound(host, bound_port)
+    except BaseException:
+        httpd.server_close()
+        raise
     if not serve_forever:
         return httpd
     thread = threading.Thread(target=httpd.serve_forever, daemon=True)

--- a/puppetmaster/dashboard.py
+++ b/puppetmaster/dashboard.py
@@ -2309,6 +2309,23 @@ def make_handler(
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", ""})
 
 
+def normalize_dashboard_host(host: str) -> str:
+    """Fold loopback spellings together for an own-runfile host comparison.
+
+    A tracked runfile always records the host the child actually *bound*
+    (``bind_dashboard_server`` never sees ``"localhost"`` — the CLI/MCP only
+    forward a non-loopback ``--host``, so a loopback request always binds as
+    literal ``127.0.0.1``). Comparing that against a fresh request's host
+    *spelling* — ``"localhost"`` vs. ``"127.0.0.1"`` — never matches, so a
+    repeated ``--host localhost`` used to spawn a brand-new server every
+    time instead of reusing the one already running (orphaning the rest,
+    since only the last spawn gets tracked). Route every such comparison
+    through this so both sides fold onto the same spelling.
+    """
+    normalized = host.strip().lower()
+    return "127.0.0.1" if normalized in _LOOPBACK_HOSTS else normalized
+
+
 def _state_dir_id(state_dir: Optional[Union[Path, str]]) -> Optional[str]:
     """A stable, non-reversible id for ``state_dir``.
 
@@ -2583,22 +2600,82 @@ def dashboard_identity(
 
     None covers every case that means "can't vouch for this server": no
     response, non-200, a body that isn't JSON (a foreign, non-dashboard web
-    server could 200 anything on that port), or a JSON body missing the
-    ``service`` marker. A pre-upgrade puppetmaster dashboard 404s
-    ``/api/meta`` and also lands here — the conservative default is "not
-    mine, don't reuse it, bump past it" (§3.2 rollout note).
-    """
-    import urllib.request
+    server could 200 anything on that port), a JSON body missing the
+    ``service`` marker, or any HTTP-protocol violation (``http.client``'s
+    exceptions, e.g. a server that sends a valid ``Content-Length`` header
+    then truncates, or a non-HTTP squatter whose first line isn't a status
+    line — neither is an ``OSError``/``ValueError``, so both used to escape
+    as a raw traceback out of an ordinary ``dashboard --background``). A
+    pre-upgrade puppetmaster dashboard 404s ``/api/meta`` and also lands
+    here — the conservative default is "not mine, don't reuse it, bump past
+    it" (§3.2 rollout note).
 
+    Bounded on two axes so a misbehaving (or hostile) listener on the port
+    can't stall or balloon this call: ``max_body`` caps how much of the
+    response we'll ever hold in memory (the real payload is one short JSON
+    object), and ``deadline`` is a wall-clock budget across every recv of
+    the *response body* -- unlike a bare socket ``timeout``, which only
+    bounds a single recv, so a peer trickling one byte at a time keeps each
+    individual recv under the timeout and can otherwise stall the caller
+    far longer than ``timeout`` (measured: 12s against a declared 1.0s).
+
+    The deadline clock starts only once connected, not before: ``"host"``
+    resolution can itself legitimately eat close to the full ``timeout``
+    (e.g. ``"localhost"`` resolving to ``::1`` first, which the OS doesn't
+    always refuse instantly, before falling back to ``127.0.0.1``) with no
+    misbehaving peer involved at all -- charging that against the same
+    budget as the body read left nothing for a perfectly fine connection to
+    read its (already fully buffered) response.
+    """
+    import http.client
+    import time as _time
+
+    max_body = 65536  # generous headroom for one small JSON object
+    conn = http.client.HTTPConnection(host, port, timeout=timeout)
     try:
-        with urllib.request.urlopen(
-            f"http://{host}:{port}/api/meta", timeout=timeout
-        ) as response:
-            if response.status != 200:
+        conn.request("GET", "/api/meta")
+        # Capture the socket now, before getresponse(): the dashboard's
+        # handler is HTTP/1.0 (no keep-alive), so a "will_close" response
+        # makes getresponse() call conn.close() internally, which sets
+        # conn.sock to None -- but it hands the live socket off to the
+        # response object first (its .fp keeps the real fd open via the
+        # same refcounting makefile() always uses), so this reference stays
+        # valid for the reads below even once conn.sock reads back None.
+        sock = conn.sock
+        response = conn.getresponse()
+        if response.status != 200:
+            return None
+        deadline = _time.monotonic() + timeout
+        chunks: list[bytes] = []
+        total = 0
+        while total < max_body and not response.isclosed():
+            remaining = deadline - _time.monotonic()
+            if remaining <= 0:
                 return None
-            payload = json.loads(response.read().decode("utf-8"))
-    except (OSError, ValueError):
+            if sock is not None:
+                sock.settimeout(remaining)
+            # read1(), not read(): read() loops internally until it fills
+            # the requested amount (or hits EOF/Content-Length), so a slow
+            # dribbler still keeps every individual recv under the timeout
+            # and the call as a whole can run far past ``deadline``. read1()
+            # returns after at most one underlying read, so the deadline
+            # check above actually gets a turn between reads. A read1() that
+            # exactly exhausts Content-Length closes the response (and,
+            # once nothing else references it, the socket itself) as a
+            # side effect -- checking isclosed() up front (rather than only
+            # `if not chunk: break` after the call) keeps this loop from
+            # calling settimeout() on that now-closed socket on its next
+            # spin.
+            chunk = response.read1(min(8192, max_body - total))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+        payload = json.loads(b"".join(chunks).decode("utf-8"))
+    except (OSError, ValueError, http.client.HTTPException):
         return None
+    finally:
+        conn.close()
     if not isinstance(payload, dict) or payload.get("service") != "puppetmaster-dashboard":
         return None
     return payload
@@ -2704,6 +2781,13 @@ def bind_dashboard_server(
     fix is retrying the bind on the real server socket, which is what this
     does.
     """
+    if not 0 <= port <= 65535:
+        # Caught before the bind loop below: an out-of-range port (e.g. a
+        # typo'd --port 70000) would otherwise report "already in use",
+        # which is simply false -- it was never attempted, since the loop's
+        # own `candidate > 65535` guard breaks out on the very first
+        # iteration without ever calling bind().
+        raise OSError(f"port {port} is not a valid TCP port (must be 0-65535).")
     server_class = _dashboard_server_class()
     last: Optional[OSError] = None
     attempts = max_attempts if auto_port else 1

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -8,7 +8,6 @@ import subprocess
 import sys
 import threading
 import time
-import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -3256,17 +3255,6 @@ def run_cli(command: list[str], args: JsonObject) -> JsonObject:
     }
 
 
-def _dashboard_alive(host: str = "127.0.0.1", port: int = 8787) -> bool:
-    """True when a dashboard already answers on ``host:port``."""
-    try:
-        with urllib.request.urlopen(
-            f"http://{host}:{port}/api/jobs", timeout=1.0
-        ) as response:
-            return response.status == 200
-    except OSError:
-        return False
-
-
 def _spawn_dashboard_server(command: list[str], args: JsonObject) -> subprocess.Popen:
     """Launch the dashboard CLI detached from this MCP process."""
     return subprocess.Popen(
@@ -3283,22 +3271,30 @@ def _spawn_dashboard_server(command: list[str], args: JsonObject) -> subprocess.
 def run_dashboard(args: JsonObject) -> JsonObject:
     """Ensure a dashboard server is running and return its URL (and QR for phones).
 
-    Idempotent: an already-listening dashboard on the host:port is reused rather
-    than spawning a duplicate. Defaults to loopback; ``mobile=true`` binds a
-    phone-reachable Tailscale/LAN address (still unauthenticated + read-only) and
-    returns a scannable QR so the pilot can hand off a link with zero setup.
-    ``stop=true`` shuts down the detached background server."""
+    Idempotent: an already-listening dashboard for *this project's* state dir
+    is reused rather than spawning a duplicate — checked by identity
+    (``/api/meta``), not bare liveness, so a different project's dashboard
+    (or a mismatched --all-projects scope) answering on the same host:port is
+    never mistaken for "ours". A busy port bumps to the next free one unless
+    an explicit ``port`` was given, in which case the child fails the same
+    way the CLI's strict ``--port`` does. Defaults to loopback; ``mobile=true``
+    binds a phone-reachable Tailscale/LAN address (still unauthenticated +
+    read-only) and returns a scannable QR so the pilot can hand off a link
+    with zero setup. ``stop=true`` shuts down the detached background server.
+    """
     from puppetmaster.dashboard import (
+        dashboard_serves,
         qr_ascii,
         read_dashboard_runfile,
         resolve_mobile_host,
         stop_background_dashboard,
-        write_dashboard_runfile,
         write_qr_png,
     )
 
     state_dir = str(mcp_state_dir(args))
-    port = int(args.get("port") or 8787)
+    explicit_port = args.get("port") is not None
+    port = int(args["port"]) if explicit_port else 8787
+    auto_port = not explicit_port
     job_id = args.get("job_id")
     job = job_id.strip() if isinstance(job_id, str) and job_id.strip() else None
     all_projects = bool(args.get("all_projects"))
@@ -3329,10 +3325,9 @@ def run_dashboard(args: JsonObject) -> JsonObject:
             }
         host = ip
 
-    url = f"http://{host}:{port}/" + (f"?job={job}" if job else "")
-
-    already_running = _dashboard_alive(host, port)
+    already_running = dashboard_serves(host, port, state_dir, all_projects=all_projects)
     pid: Optional[int] = None
+    bound_port = port
     if not already_running:
         command = [
             sys.executable,
@@ -3344,7 +3339,10 @@ def run_dashboard(args: JsonObject) -> JsonObject:
             "--port",
             str(port),
             "--no-open",
+            "--write-runfile",
         ]
+        if auto_port:
+            command.append("--port-search")
         if host != "127.0.0.1":
             command += ["--host", host, "--allow-external"]
         if all_projects:
@@ -3352,13 +3350,27 @@ def run_dashboard(args: JsonObject) -> JsonObject:
         if job:
             command.append(job)
         process = _spawn_dashboard_server(command, args)
-        pid = process.pid
+        # Poll the child's own runfile (written post-bind, --write-runfile)
+        # rather than re-probing host:port — the child may have bumped past
+        # `port`, so a probe pinned to the requested port can miss it, or
+        # worse, see a *different* project's dashboard there and declare
+        # success (the identity-blind bug this whole change fixes).
         deadline = time.time() + 10
-        while time.time() < deadline and not _dashboard_alive(host, port):
+        child_info = None
+        while time.time() < deadline:
+            candidate = read_dashboard_runfile(state_dir)
+            if candidate and candidate.get("pid") == process.pid:
+                child_info = candidate
+                break
             if process.poll() is not None:
                 break
             time.sleep(0.2)
-        if not _dashboard_alive(host, port):
+        if child_info is None or not dashboard_serves(
+            child_info.get("host", host),
+            int(child_info.get("port") or port),
+            state_dir,
+            all_projects=all_projects,
+        ):
             body = {
                 "error": "dashboard failed to start",
                 "host": host,
@@ -3371,27 +3383,29 @@ def run_dashboard(args: JsonObject) -> JsonObject:
                 "content": [{"type": "text", "text": json.dumps(body, indent=2)}],
                 "isError": True,
             }
-        write_dashboard_runfile(
-            state_dir,
-            {
-                "pid": pid,
-                "host": host,
-                "port": port,
-                "url": url,
-                "source": source,
-                "all_projects": all_projects,
-            },
-        )
+        pid = process.pid
+        host = child_info.get("host", host)
+        bound_port = int(child_info.get("port") or port)
     elif mobile:
-        # Keep the runfile pid current when reusing a server we can identify.
+        # Keep the runfile pid current when reusing a server we can
+        # identify — compared via dashboard_serves (state_dir_id), not the
+        # bare host+port equality this used to do, which a foreign
+        # dashboard sharing the same host:port would satisfy by accident.
         tracked = read_dashboard_runfile(state_dir)
-        if tracked and tracked.get("host") == host and int(tracked.get("port") or 0) == port:
+        if tracked and dashboard_serves(
+            tracked.get("host", host),
+            int(tracked.get("port") or port),
+            state_dir,
+            all_projects=all_projects,
+        ):
             pid = tracked.get("pid")
+
+    url = f"http://{host}:{bound_port}/" + (f"?job={job}" if job else "")
 
     body: JsonObject = {
         "url": url,
         "host": host,
-        "port": port,
+        "port": bound_port,
         "source": source,
         "state_dir": state_dir,
         "all_projects": all_projects,
@@ -3426,10 +3440,17 @@ def run_dashboard(args: JsonObject) -> JsonObject:
         )
     else:
         body["note"] = (
-            "Reused the dashboard already listening on this port — it may be "
-            "serving a different project's state dir or all-projects mode."
+            "Reused this project's own dashboard, already running."
             if already_running
-            else "Open the URL in a browser tab for the user."
+            else (
+                "Started a new dashboard for this project."
+                + (
+                    f" Port {port} was busy (another project's dashboard?), so "
+                    f"it's serving on {bound_port} instead."
+                    if bound_port != port
+                    else ""
+                )
+            )
         )
     return {"content": [{"type": "text", "text": json.dumps(body, indent=2)}]}
 
@@ -3792,8 +3813,12 @@ def dashboard_schema() -> JsonObject:
     )
     schema["properties"]["port"] = {
         "type": "integer",
-        "default": 8787,
-        "description": "Dashboard port (default 8787).",
+        "description": (
+            "Dashboard port. Omit to auto-pick the next free port starting "
+            "at 8787 (a busy port — e.g. another project's dashboard — is "
+            "never silently shared). An explicit port is strict: starting "
+            "the dashboard fails if it's busy."
+        ),
     }
     schema["properties"]["all_projects"] = {
         "type": "boolean",

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -3284,6 +3284,7 @@ def run_dashboard(args: JsonObject) -> JsonObject:
     """
     from puppetmaster.dashboard import (
         dashboard_serves,
+        normalize_dashboard_host,
         pid_alive,
         qr_ascii,
         read_dashboard_runfile,
@@ -3341,16 +3342,22 @@ def run_dashboard(args: JsonObject) -> JsonObject:
     already_running = False
     if (
         tracked
-        and tracked.get("host", host) == host
+        and normalize_dashboard_host(tracked.get("host", host)) == normalize_dashboard_host(host)
         and pid_alive(int(tracked.get("pid") or 0))
-        and dashboard_serves(
-            host, int(tracked.get("port") or port), state_dir, all_projects=all_projects
-        )
     ):
-        already_running = True
-        bound_port = int(tracked.get("port") or port)
-        pid = tracked.get("pid")
-    else:
+        tracked_port = int(tracked.get("port") or port)
+        # Port-gated (§F1): an explicit port is a promise this call may
+        # depend on -- reusing a tracked dashboard on a *different* port
+        # would silently hand back a URL for a port the caller never asked
+        # for, with no error. Only skip this gate when the caller didn't
+        # pin a port (auto_port) or the tracked port already matches.
+        if (auto_port or tracked_port == port) and dashboard_serves(
+            host, tracked_port, state_dir, all_projects=all_projects
+        ):
+            already_running = True
+            bound_port = tracked_port
+            pid = tracked.get("pid")
+    if not already_running:
         already_running = dashboard_serves(host, port, state_dir, all_projects=all_projects)
 
     if not already_running:

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -3284,6 +3284,7 @@ def run_dashboard(args: JsonObject) -> JsonObject:
     """
     from puppetmaster.dashboard import (
         dashboard_serves,
+        pid_alive,
         qr_ascii,
         read_dashboard_runfile,
         resolve_mobile_host,
@@ -3325,9 +3326,33 @@ def run_dashboard(args: JsonObject) -> JsonObject:
             }
         host = ip
 
-    already_running = dashboard_serves(host, port, state_dir, all_projects=all_projects)
     pid: Optional[int] = None
     bound_port = port
+
+    # This project's own dashboard may already be running at whatever port
+    # it actually bound to, which can be past `port` if an earlier call
+    # bumped — check the tracked runfile first so a repeat call doesn't
+    # spawn a redundant second server for the same project. Host-gated: a
+    # loopback dashboard tracked from an earlier non-mobile call must not be
+    # "reused" for a mobile=true request that needs an externally-reachable
+    # bind — falling through to the literal-port probe below on a host
+    # mismatch correctly fails and a new, properly-bound server gets spawned.
+    tracked = read_dashboard_runfile(state_dir)
+    already_running = False
+    if (
+        tracked
+        and tracked.get("host", host) == host
+        and pid_alive(int(tracked.get("pid") or 0))
+        and dashboard_serves(
+            host, int(tracked.get("port") or port), state_dir, all_projects=all_projects
+        )
+    ):
+        already_running = True
+        bound_port = int(tracked.get("port") or port)
+        pid = tracked.get("pid")
+    else:
+        already_running = dashboard_serves(host, port, state_dir, all_projects=all_projects)
+
     if not already_running:
         command = [
             sys.executable,
@@ -3386,19 +3411,22 @@ def run_dashboard(args: JsonObject) -> JsonObject:
         pid = process.pid
         host = child_info.get("host", host)
         bound_port = int(child_info.get("port") or port)
-    elif mobile:
-        # Keep the runfile pid current when reusing a server we can
-        # identify — compared via dashboard_serves (state_dir_id), not the
-        # bare host+port equality this used to do, which a foreign
-        # dashboard sharing the same host:port would satisfy by accident.
-        tracked = read_dashboard_runfile(state_dir)
-        if tracked and dashboard_serves(
-            tracked.get("host", host),
-            int(tracked.get("port") or port),
+    elif mobile and pid is None:
+        # The pre-check above already set pid when it found the match; this
+        # only covers reuse discovered via the literal-port probe instead
+        # (tracked runfile absent/host-mismatched but something still
+        # identifies as ours on host:port). Compared via dashboard_serves
+        # (state_dir_id), not the bare host+port equality this used to do,
+        # which a foreign dashboard sharing the same host:port would satisfy
+        # by accident.
+        refreshed = read_dashboard_runfile(state_dir)
+        if refreshed and dashboard_serves(
+            refreshed.get("host", host),
+            int(refreshed.get("port") or port),
             state_dir,
             all_projects=all_projects,
         ):
-            pid = tracked.get("pid")
+            pid = refreshed.get("pid")
 
     url = f"http://{host}:{bound_port}/" + (f"?job={job}" if job else "")
 

--- a/tests/test_dashboard_background_identity.py
+++ b/tests/test_dashboard_background_identity.py
@@ -1,0 +1,241 @@
+"""Identity-aware background dashboard reuse: CLI ``--background`` and the
+MCP ``puppetmaster_dashboard`` tool.
+
+Pre-fix, both paths declared "reusing it" on bare liveness -- *something*
+answered ``GET /api/jobs`` on host:port -- with no way to tell whether that
+something was this project's dashboard, a different project's, or a
+mismatched --all-projects scope. The early return also preceded the runfile
+write, so the caller that "reused" the server had no runfile of its own:
+its own ``--status``/``--stop`` then had nothing to work with, and it could
+neither confirm nor stop the server it was told to use. See
+docs/CHANGELOG.md.
+
+CLI-level and MCP-level, with the dashboard identity functions and
+``subprocess.Popen``/``_spawn_dashboard_server`` patched -- no real process is
+spawned, so these stay fast and CI-safe. A new file for the same reason as
+test_dashboard_ports.py: keeps this workstream's tests out of the way of the
+concurrent Ctrl-C workstream's edits to test_puppetmaster.py.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+
+import puppetmaster.dashboard as dash
+
+
+class BackgroundDashboardIdentityTests(unittest.TestCase):
+    def _args(self, **overrides) -> argparse.Namespace:
+        defaults = dict(
+            port=None,
+            port_search=False,
+            host="127.0.0.1",
+            no_open=True,
+            allow_external=False,
+            all_projects=False,
+            mobile=False,
+            qr=False,
+            background=False,
+            stop=False,
+            status=False,
+            write_runfile=False,
+            job_id=None,
+            backend="sqlite",
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_background_reuses_only_same_project(self) -> None:
+        """A foreign dashboard answering on the requested port must not be
+        reused -- _start_background_dashboard must spawn its own instead.
+        Pre-fix this was `_dispatch.py`'s bare `dashboard_alive()` check,
+        which said "reusing it" here and handed the caller project A's URL
+        while it asked for project B (reproduced verbatim in the research
+        harness)."""
+        from puppetmaster.cli._dispatch import _start_background_dashboard
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            spawned = MagicMock()
+            spawned.pid = 4242
+            spawned.poll.return_value = None
+            child_runfile = {
+                "pid": 4242, "host": "127.0.0.1", "port": 8787,
+                "url": "http://127.0.0.1:8787/",
+            }
+            with patch.object(
+                dash, "read_dashboard_runfile", side_effect=[None, child_runfile]
+            ), patch.object(
+                dash, "dashboard_serves", side_effect=[False, True]
+            ), patch("subprocess.Popen", return_value=spawned) as popen:
+                rc = _start_background_dashboard(
+                    self._args(), state_dir, "127.0.0.1",
+                    port=8787, auto_port=True,
+                    source="loopback", allow_external=False,
+                )
+        popen.assert_called_once()
+        self.assertEqual(rc, 0)
+
+    def test_background_reuse_writes_runfile(self) -> None:
+        """Genuine reuse (this project's own dashboard identifies itself)
+        must write a runfile before returning -- pre-fix the early return
+        preceded the runfile write, so the reusing caller had no runfile of
+        its own (verified: --status/--stop then failed for it)."""
+        from puppetmaster.cli._dispatch import _start_background_dashboard
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            identity = {
+                "service": "puppetmaster-dashboard", "pid": 9999,
+                "state_dir_id": "irrelevant-mocked", "all_projects": False,
+            }
+            with patch.object(
+                dash, "read_dashboard_runfile", return_value=None
+            ), patch.object(
+                dash, "dashboard_serves", return_value=True
+            ), patch.object(
+                dash, "dashboard_identity", return_value=identity
+            ), patch("subprocess.Popen") as popen:
+                rc = _start_background_dashboard(
+                    self._args(), state_dir, "127.0.0.1",
+                    port=8787, auto_port=True,
+                    source="loopback", allow_external=False,
+                )
+            popen.assert_not_called()
+            self.assertEqual(rc, 0)
+            info = dash.read_dashboard_runfile(state_dir)
+            self.assertIsNotNone(info)
+            self.assertEqual(info["pid"], 9999)
+            self.assertEqual(info["port"], 8787)
+
+    def test_status_reports_foreign_dashboard_distinctly(self) -> None:
+        """Pre-fix, `--status` printed "No background dashboard is running"
+        for a runfile that *was* tracked, just answered by another project
+        -- confusing when the caller had just been told a dashboard was
+        running. Post-fix it must say so distinctly, not fall back to
+        "not running"."""
+        from puppetmaster.cli._dispatch import _run_dashboard_command
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            tracked = {
+                "pid": 1234, "host": "127.0.0.1", "port": 8787,
+                "url": "http://127.0.0.1:8787/",
+            }
+            with patch.object(
+                dash, "read_dashboard_runfile", return_value=tracked
+            ), patch.object(
+                dash, "dashboard_serves", return_value=False
+            ), patch.object(
+                dash, "dashboard_alive", return_value=True
+            ):
+                out = io.StringIO()
+                with contextlib.redirect_stdout(out):
+                    rc = _run_dashboard_command(self._args(status=True), state_dir)
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        self.assertIn("another project", text)
+        self.assertNotIn("No background dashboard is running", text)
+
+    def test_stop_after_reuse_can_stop(self) -> None:
+        """Pre-fix, the reusing caller's --stop said "no background
+        dashboard is tracked here" and the server survived (it had never
+        gotten a runfile). Post-fix, reuse writes one, so --stop works."""
+        from puppetmaster.cli._dispatch import (
+            _run_dashboard_command,
+            _start_background_dashboard,
+        )
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            identity = {
+                "service": "puppetmaster-dashboard", "pid": 424242,
+                "state_dir_id": "x", "all_projects": False,
+            }
+            with patch.object(
+                dash, "read_dashboard_runfile", return_value=None
+            ), patch.object(
+                dash, "dashboard_serves", return_value=True
+            ), patch.object(
+                dash, "dashboard_identity", return_value=identity
+            ), patch("subprocess.Popen") as popen:
+                reuse_rc = _start_background_dashboard(
+                    self._args(), state_dir, "127.0.0.1",
+                    port=8787, auto_port=True,
+                    source="loopback", allow_external=False,
+                )
+            self.assertEqual(reuse_rc, 0)
+            popen.assert_not_called()
+
+            stop_rc = _run_dashboard_command(self._args(stop=True), state_dir)
+        self.assertEqual(stop_rc, 0)
+        self.assertIsNone(dash.read_dashboard_runfile(state_dir))
+
+    def test_background_parent_reports_child_bumped_port(self) -> None:
+        """The child may bump past the requested port; the parent's
+        announcement must report the *actual* port, not the one it asked
+        for (pre-fix the parent always printed its own --port)."""
+        from puppetmaster.cli._dispatch import _start_background_dashboard
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            spawned = MagicMock()
+            spawned.pid = 5150
+            spawned.poll.return_value = None
+            bumped = {
+                "pid": 5150, "host": "127.0.0.1", "port": 8788,
+                "url": "http://127.0.0.1:8788/",
+            }
+            with patch.object(
+                dash, "read_dashboard_runfile", side_effect=[None, bumped]
+            ), patch.object(
+                dash, "dashboard_serves", side_effect=[False, True]
+            ), patch("subprocess.Popen", return_value=spawned):
+                out = io.StringIO()
+                with contextlib.redirect_stdout(out):
+                    rc = _start_background_dashboard(
+                        self._args(), state_dir, "127.0.0.1",
+                        port=8787, auto_port=True,
+                        source="loopback", allow_external=False,
+                    )
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        self.assertIn("8788", text)
+        self.assertNotIn("http://127.0.0.1:8787/", text)
+
+    def test_mcp_dashboard_does_not_reuse_foreign_project(self) -> None:
+        """Same defect as test_background_reuses_only_same_project, on the
+        MCP puppetmaster_dashboard tool's identical code shape."""
+        import puppetmaster.mcp_server as mcp
+
+        spawned = MagicMock()
+        spawned.pid = 6060
+        spawned.poll.return_value = None
+        child_runfile = {
+            "pid": 6060, "host": "127.0.0.1", "port": 8787,
+            "url": "http://127.0.0.1:8787/",
+        }
+        with patch.object(
+            dash, "dashboard_serves", side_effect=[False, True]
+        ), patch.object(
+            dash, "read_dashboard_runfile", return_value=child_runfile
+        ), patch.object(mcp, "_spawn_dashboard_server", return_value=spawned) as popen:
+            result = mcp.call_tool("puppetmaster_dashboard", {"cwd": "/tmp"})
+        popen.assert_called_once()
+        body = json.loads(result["content"][0]["text"])
+        self.assertTrue(body["started"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dashboard_background_identity.py
+++ b/tests/test_dashboard_background_identity.py
@@ -22,6 +22,8 @@ import argparse
 import contextlib
 import io
 import json
+import os
+import threading
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -121,15 +123,25 @@ class BackgroundDashboardIdentityTests(unittest.TestCase):
         for a runfile that *was* tracked, just answered by another project
         -- confusing when the caller had just been told a dashboard was
         running. Post-fix it must say so distinctly, not fall back to
-        "not running"."""
+        "not running". A real (non-None) foreign identity, not just a
+        legacy 404 -- see test_status_falls_back_to_own_pid_pre_upgrade for
+        the pre-/api/meta case (§F5)."""
         from puppetmaster.cli._dispatch import _run_dashboard_command
 
         with TemporaryDirectory() as tmp:
             state_dir = Path(tmp) / ".puppetmaster"
             state_dir.mkdir()
+            # Deliberately not 8787 (this machine's own live dashboard) --
+            # dashboard_identity/pid_alive are mocked below so nothing here
+            # ever reaches the network either way, but a non-default port
+            # keeps that true even if a future edit drops a mock.
             tracked = {
-                "pid": 1234, "host": "127.0.0.1", "port": 8787,
-                "url": "http://127.0.0.1:8787/",
+                "pid": 1234, "host": "127.0.0.1", "port": 19100,
+                "url": "http://127.0.0.1:19100/",
+            }
+            foreign_identity = {
+                "service": "puppetmaster-dashboard", "pid": 4321,
+                "state_dir_id": "not-this-project", "all_projects": False,
             }
             with patch.object(
                 dash, "read_dashboard_runfile", return_value=tracked
@@ -137,6 +149,10 @@ class BackgroundDashboardIdentityTests(unittest.TestCase):
                 dash, "dashboard_serves", return_value=False
             ), patch.object(
                 dash, "dashboard_alive", return_value=True
+            ), patch.object(
+                dash, "dashboard_identity", return_value=foreign_identity
+            ), patch.object(
+                dash, "pid_alive", return_value=False
             ):
                 out = io.StringIO()
                 with contextlib.redirect_stdout(out):
@@ -146,10 +162,89 @@ class BackgroundDashboardIdentityTests(unittest.TestCase):
         self.assertIn("another project", text)
         self.assertNotIn("No background dashboard is running", text)
 
+    def test_status_falls_back_to_own_pid_pre_upgrade(self) -> None:
+        """A pre-upgrade dashboard 404s /api/meta (dashboard_identity ->
+        None), which used to be indistinguishable from a genuine foreign
+        server -- every existing user with a background board hits this in
+        the upgrade window. If the runfile's own tracked pid is still
+        alive, --status must report it as this project's (§F5), not claim
+        it's "serving another project", which is simply false."""
+        from puppetmaster.cli._dispatch import _run_dashboard_command
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            tracked = {
+                "pid": 5678, "host": "127.0.0.1", "port": 19101,
+                "url": "http://127.0.0.1:19101/",
+            }
+            with patch.object(
+                dash, "read_dashboard_runfile", return_value=tracked
+            ), patch.object(
+                dash, "dashboard_serves", return_value=False
+            ), patch.object(
+                dash, "dashboard_alive", return_value=True
+            ), patch.object(
+                dash, "dashboard_identity", return_value=None
+            ), patch.object(
+                dash, "pid_alive", return_value=True
+            ):
+                out = io.StringIO()
+                with contextlib.redirect_stdout(out):
+                    rc = _run_dashboard_command(self._args(status=True), state_dir)
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        self.assertIn("Background dashboard running", text)
+        self.assertIn("predates /api/meta", text)
+        self.assertNotIn("another project", text)
+
+    def test_status_still_reports_foreign_when_pid_also_dead(self) -> None:
+        """The fallback is specifically "no /api/meta, but our own tracked
+        pid is alive" -- if the tracked pid is also dead, this must not
+        become a way to call a truly foreign/dead-tracked server "ours"."""
+        from puppetmaster.cli._dispatch import _run_dashboard_command
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            tracked = {
+                "pid": 9012, "host": "127.0.0.1", "port": 19102,
+                "url": "http://127.0.0.1:19102/",
+            }
+            with patch.object(
+                dash, "read_dashboard_runfile", return_value=tracked
+            ), patch.object(
+                dash, "dashboard_serves", return_value=False
+            ), patch.object(
+                dash, "dashboard_alive", return_value=True
+            ), patch.object(
+                dash, "dashboard_identity", return_value=None
+            ), patch.object(
+                dash, "pid_alive", return_value=False
+            ):
+                out = io.StringIO()
+                with contextlib.redirect_stdout(out):
+                    rc = _run_dashboard_command(self._args(status=True), state_dir)
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        self.assertIn("another project", text)
+
     def test_stop_after_reuse_can_stop(self) -> None:
         """Pre-fix, the reusing caller's --stop said "no background
         dashboard is tracked here" and the server survived (it had never
-        gotten a runfile). Post-fix, reuse writes one, so --stop works."""
+        gotten a runfile). Post-fix, reuse writes one, so --stop works.
+
+        Asserts on more than rc==0 + runfile-is-None: mutation-tested --
+        deleting the runfile write in `_reuse` leaves those two vacuous
+        (stop returns 0 and the never-written runfile is already None
+        either way). Checking for "Stopped the background dashboard" in
+        the output actually distinguishes the two (the no-runfile case
+        prints "No background dashboard to stop" instead).
+
+        pid_alive is mocked False for the --stop call specifically so this
+        never sends a real SIGTERM: pid 424242 is not alive on this
+        Windows box (pids are multiples of 4), but on Linux, with a large
+        pid_max, it plausibly could be a live, unrelated process."""
         from puppetmaster.cli._dispatch import (
             _run_dashboard_command,
             _start_background_dashboard,
@@ -177,8 +272,12 @@ class BackgroundDashboardIdentityTests(unittest.TestCase):
             self.assertEqual(reuse_rc, 0)
             popen.assert_not_called()
 
-            stop_rc = _run_dashboard_command(self._args(stop=True), state_dir)
+            with patch.object(dash, "pid_alive", return_value=False):
+                out = io.StringIO()
+                with contextlib.redirect_stdout(out):
+                    stop_rc = _run_dashboard_command(self._args(stop=True), state_dir)
         self.assertEqual(stop_rc, 0)
+        self.assertIn("Stopped the background dashboard", out.getvalue())
         self.assertIsNone(dash.read_dashboard_runfile(state_dir))
 
     def test_background_parent_reports_child_bumped_port(self) -> None:
@@ -347,6 +446,464 @@ class BackgroundDashboardIdentityTests(unittest.TestCase):
         popen.assert_called_once()
         body = json.loads(result["content"][0]["text"])
         self.assertTrue(body["started"])
+
+
+class ExplicitPortReuseGateTests(unittest.TestCase):
+    """§F1 -- an explicit --port is a promise the caller may depend on (a
+    script, a bookmark, a reverse proxy). Pre-fix, the own-runfile
+    pre-check consulted neither `auto_port` nor whether the tracked port
+    equalled the requested one, so a tracked dashboard on a *different*
+    port than the one just asked for was "reused" anyway -- the explicit
+    --port was silently discarded with exit 0 and nothing bound on the
+    requested port. Both the CLI (`_start_background_dashboard`) and the
+    MCP tool (`run_dashboard`) had the identical shape."""
+
+    def _args(self, **overrides) -> argparse.Namespace:
+        defaults = dict(
+            port=None, port_search=False, host="127.0.0.1", no_open=True,
+            allow_external=False, all_projects=False, mobile=False, qr=False,
+            background=False, stop=False, status=False, write_runfile=False,
+            job_id=None, backend="sqlite",
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_cli_explicit_port_mismatch_does_not_reuse(self) -> None:
+        """The tracked dashboard genuinely IS this project's own -- it
+        answers identity-true at its own (18801) port -- but the caller
+        explicitly asked for a *different* port (18811). Reusing it anyway
+        is exactly F1: the explicit --port gets silently discarded with
+        exit 0 instead of being honored or strict-failed. Mocking
+        dashboard_serves as a blanket False here would pass even on the
+        unfixed code for the wrong reason (it'd never reuse *anything*),
+        so this keys the mock on which port is being asked about."""
+        from puppetmaster.cli._dispatch import _start_background_dashboard
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            tracked = {
+                "pid": 7001, "host": "127.0.0.1", "port": 18801,
+                "url": "http://127.0.0.1:18801/",
+            }
+            spawned = MagicMock()
+            spawned.pid = 7002
+            spawned.poll.return_value = 0  # "exits" immediately -- this
+            # test only cares whether a spawn was *attempted* (i.e. reuse
+            # was correctly refused for the mismatched port), not whether
+            # the fake child comes up.
+
+            def _serves(host, port, sd, *, all_projects=False, timeout=1.0):
+                return port == 18801  # only the tracked port identifies as ours
+
+            with patch.object(
+                dash, "read_dashboard_runfile", return_value=tracked
+            ), patch.object(
+                dash, "pid_alive", return_value=True
+            ), patch.object(
+                dash, "dashboard_serves", side_effect=_serves
+            ), patch("subprocess.Popen", return_value=spawned) as popen:
+                _start_background_dashboard(
+                    self._args(), state_dir, "127.0.0.1",
+                    port=18811, auto_port=False,
+                    source="loopback", allow_external=False,
+                )
+        popen.assert_called_once()
+
+    def test_cli_explicit_port_matching_tracked_port_still_reuses(self) -> None:
+        from puppetmaster.cli._dispatch import _start_background_dashboard
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            tracked = {
+                "pid": 7003, "host": "127.0.0.1", "port": 18802,
+                "url": "http://127.0.0.1:18802/",
+            }
+            with patch.object(
+                dash, "read_dashboard_runfile", return_value=tracked
+            ), patch.object(
+                dash, "pid_alive", return_value=True
+            ), patch.object(
+                dash, "dashboard_serves", return_value=True
+            ), patch("subprocess.Popen") as popen:
+                rc = _start_background_dashboard(
+                    self._args(), state_dir, "127.0.0.1",
+                    port=18802, auto_port=False,
+                    source="loopback", allow_external=False,
+                )
+        self.assertEqual(rc, 0)
+        popen.assert_not_called()
+
+    def test_cli_port_search_with_explicit_port_allows_reuse_at_different_port(self) -> None:
+        """--port N --port-search derives auto_port=True (verified in
+        DashboardArgvDerivationTests) -- an explicit port paired with
+        --port-search is *not* a strict promise, so this must reuse a
+        tracked dashboard even on a different port, same as a bare
+        --background with no --port at all."""
+        from puppetmaster.cli._dispatch import _start_background_dashboard
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            tracked = {
+                "pid": 7004, "host": "127.0.0.1", "port": 18803,
+                "url": "http://127.0.0.1:18803/",
+            }
+            with patch.object(
+                dash, "read_dashboard_runfile", return_value=tracked
+            ), patch.object(
+                dash, "pid_alive", return_value=True
+            ), patch.object(
+                dash, "dashboard_serves", return_value=True
+            ), patch("subprocess.Popen") as popen:
+                rc = _start_background_dashboard(
+                    self._args(), state_dir, "127.0.0.1",
+                    port=18813, auto_port=True,
+                    source="loopback", allow_external=False,
+                )
+        self.assertEqual(rc, 0)
+        popen.assert_not_called()
+
+    def test_mcp_explicit_port_mismatch_does_not_reuse(self) -> None:
+        """Mirrors test_cli_explicit_port_mismatch_does_not_reuse's setup:
+        dashboard_serves is keyed on the port it's asked about (True only
+        for the tracked 18804) so this actually exercises the buggy shape
+        rather than passing vacuously against a blanket False."""
+        import puppetmaster.mcp_server as mcp
+
+        tracked = {
+            "pid": 7005, "host": "127.0.0.1", "port": 18804,
+            "url": "http://127.0.0.1:18804/",
+        }
+        spawned = MagicMock()
+        spawned.pid = 7006
+        spawned.poll.return_value = 0  # "exits" immediately -- only the
+        # spawn attempt (i.e. reuse correctly refused) matters here.
+
+        def _serves(host, port, sd, *, all_projects=False, timeout=1.0):
+            return port == 18804  # only the tracked port identifies as ours
+
+        with patch.object(
+            dash, "read_dashboard_runfile", return_value=tracked
+        ), patch.object(
+            dash, "pid_alive", return_value=True
+        ), patch.object(
+            dash, "dashboard_serves", side_effect=_serves
+        ), patch.object(mcp, "_spawn_dashboard_server", return_value=spawned) as popen:
+            mcp.call_tool("puppetmaster_dashboard", {"cwd": "/tmp", "port": 18814})
+        popen.assert_called_once()
+
+    def test_mcp_explicit_port_matching_tracked_port_still_reuses(self) -> None:
+        import puppetmaster.mcp_server as mcp
+
+        tracked = {
+            "pid": 7007, "host": "127.0.0.1", "port": 18805,
+            "url": "http://127.0.0.1:18805/",
+        }
+        with patch.object(
+            dash, "read_dashboard_runfile", return_value=tracked
+        ), patch.object(
+            dash, "pid_alive", return_value=True
+        ), patch.object(
+            dash, "dashboard_serves", return_value=True
+        ), patch.object(mcp, "_spawn_dashboard_server") as popen:
+            result = mcp.call_tool(
+                "puppetmaster_dashboard", {"cwd": "/tmp", "port": 18805}
+            )
+        popen.assert_not_called()
+        body = json.loads(result["content"][0]["text"])
+        self.assertTrue(body["already_running"])
+        self.assertEqual(body["port"], 18805)
+
+
+class HostNormalizationReuseTests(unittest.TestCase):
+    """§F2 -- a tracked runfile always records the literal address the
+    child bound (e.g. "127.0.0.1"), never a loopback alias. Comparing that
+    raw string against a fresh request's host *spelling* -- "localhost" --
+    never matched, so a repeated --host localhost span up a brand-new
+    server on every call and orphaned the rest (only the last spawn ever
+    gets tracked)."""
+
+    def _args(self, **overrides) -> argparse.Namespace:
+        defaults = dict(
+            port=None, port_search=False, host="localhost", no_open=True,
+            allow_external=False, all_projects=False, mobile=False, qr=False,
+            background=False, stop=False, status=False, write_runfile=False,
+            job_id=None, backend="sqlite",
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_cli_localhost_request_reuses_127_0_0_1_tracked_dashboard(self) -> None:
+        """The tracked dashboard is on a *different* (bumped) port than the
+        one being requested here -- 18806 vs. 18800, mirroring the
+        reviewer's repro where a blocker forces the child to bump past the
+        literal requested port. That means the literal-port fallback probe
+        (at 18800) can't rescue this: only the own-runfile pre-check, at
+        the tracked 18806, can find it -- so this only passes if that
+        check's host comparison is actually normalized. Keying the
+        dashboard_serves mock on which port it's asked about (rather than
+        a blanket True) is what makes that fallback path fail on unfixed
+        code instead of masking the bug."""
+        from puppetmaster.cli._dispatch import _start_background_dashboard
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            tracked = {
+                "pid": 7101, "host": "127.0.0.1", "port": 18806,
+                "url": "http://127.0.0.1:18806/",
+            }
+
+            def _serves(host, port, sd, *, all_projects=False, timeout=1.0):
+                return port == 18806  # only the tracked (bumped) port
+
+            with patch.object(
+                dash, "read_dashboard_runfile", return_value=tracked
+            ), patch.object(
+                dash, "pid_alive", return_value=True
+            ), patch.object(
+                dash, "dashboard_serves", side_effect=_serves
+            ), patch("subprocess.Popen") as popen:
+                rc = _start_background_dashboard(
+                    self._args(), state_dir, "localhost",
+                    port=18800, auto_port=True,
+                    source="loopback", allow_external=False,
+                )
+        self.assertEqual(rc, 0)
+        popen.assert_not_called()
+
+    def test_mcp_localhost_request_reuses_127_0_0_1_tracked_dashboard(self) -> None:
+        """MCP always requests host="127.0.0.1" for a non-mobile call
+        (mcp_server.py never sends "localhost" itself), but an
+        older/hand-edited runfile could still carry "localhost" from a
+        different tool version -- the comparison must fold that too. As
+        above, the tracked (bumped) port 18807 differs from the default
+        8787 this call implicitly asks for, so only the own-runfile
+        pre-check -- not the literal-port fallback -- can find it."""
+        import puppetmaster.mcp_server as mcp
+
+        tracked = {
+            "pid": 7102, "host": "localhost", "port": 18807,
+            "url": "http://localhost:18807/",
+        }
+
+        def _serves(host, port, sd, *, all_projects=False, timeout=1.0):
+            return port == 18807  # only the tracked (bumped) port
+
+        spawned = MagicMock()
+        spawned.pid = 7103
+        spawned.poll.return_value = 0
+        with patch.object(
+            dash, "read_dashboard_runfile", return_value=tracked
+        ), patch.object(
+            dash, "pid_alive", return_value=True
+        ), patch.object(
+            dash, "dashboard_serves", side_effect=_serves
+        ), patch.object(mcp, "_spawn_dashboard_server", return_value=spawned) as popen:
+            # No explicit port -- auto_port=True, requested port defaults to
+            # 8787, which differs from the tracked (bumped) 18807.
+            result = mcp.call_tool("puppetmaster_dashboard", {"cwd": "/tmp"})
+        popen.assert_not_called()
+        body = json.loads(result["content"][0]["text"])
+        self.assertTrue(body["already_running"])
+
+
+class DashboardArgvDerivationTests(unittest.TestCase):
+    """§F7 -- `_run_dashboard_command`'s explicit/auto_port derivation
+    (the riskiest edit in this branch) had zero coverage: every identity
+    test above pre-derives port/auto_port directly rather than parsing
+    argv, and `_run_dashboard_command` is otherwise only ever driven with
+    status=True/stop=True, both of which return before touching this
+    logic at all. Drives the real argv -> parser -> serve() kwargs path."""
+
+    def _serve_kwargs(self, argv: list[str]) -> dict:
+        from puppetmaster.cli._dispatch import _run_dashboard_command
+        from puppetmaster.cli._parser import build_parser
+
+        args = build_parser().parse_args(argv)
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            with patch(
+                "puppetmaster.dashboard.serve", return_value=MagicMock()
+            ) as serve_mock, patch.object(
+                dash, "resolve_mobile_host", return_value=("100.64.0.7", "tailscale")
+            ):
+                _run_dashboard_command(args, state_dir)
+        return serve_mock.call_args.kwargs
+
+    def test_no_port_flag_auto_bumps_from_8787(self) -> None:
+        kwargs = self._serve_kwargs(["dashboard"])
+        self.assertEqual(kwargs["port"], 8787)
+        self.assertTrue(kwargs["auto_port"])
+
+    def test_explicit_port_is_strict(self) -> None:
+        kwargs = self._serve_kwargs(["dashboard", "--port", "18777"])
+        self.assertEqual(kwargs["port"], 18777)
+        self.assertFalse(kwargs["auto_port"])
+
+    def test_explicit_port_with_port_search_is_not_strict(self) -> None:
+        kwargs = self._serve_kwargs(
+            ["dashboard", "--port", "18777", "--port-search"]
+        )
+        self.assertEqual(kwargs["port"], 18777)
+        self.assertTrue(kwargs["auto_port"])
+
+    def test_bare_port_search_auto_bumps_from_8787(self) -> None:
+        kwargs = self._serve_kwargs(["dashboard", "--port-search"])
+        self.assertEqual(kwargs["port"], 8787)
+        self.assertTrue(kwargs["auto_port"])
+
+    def test_mobile_without_port_auto_bumps_from_8787(self) -> None:
+        kwargs = self._serve_kwargs(["dashboard", "--mobile"])
+        self.assertEqual(kwargs["port"], 8787)
+        self.assertTrue(kwargs["auto_port"])
+
+
+class RealServerIdentityTests(unittest.TestCase):
+    """§F7 -- every test above (and every test in this file before this
+    class) mocks `dashboard_serves`/`dashboard_identity` out entirely.
+    Mutation-tested: replacing `dashboard_serves` with the pre-fix bare
+    `dashboard_alive` leaves all of them green. The identity *function*
+    itself is guarded separately (test_dashboard_ports.py's
+    DashboardServesTests, against real bound servers) -- what's missing is
+    coverage of the CLI wiring actually calling it for real. These two
+    exercise `_start_background_dashboard`'s own-runfile pre-check against
+    a real, live dashboard with nothing mocked but the eventual subprocess
+    spawn."""
+
+    def test_reuses_real_own_dashboard(self) -> None:
+        from puppetmaster.cli._dispatch import _start_background_dashboard
+        from puppetmaster.dashboard import serve, write_dashboard_runfile
+        from puppetmaster.store_factory import create_store
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            create_store("sqlite", state_dir).init()
+            httpd = serve(
+                state_dir, backend="sqlite", host="127.0.0.1", port=0,
+                open_browser=False, serve_forever=False,
+            )
+            self.addCleanup(httpd.server_close)
+            thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+            thread.start()
+            self.addCleanup(httpd.shutdown)
+            port = httpd.server_address[1]
+            write_dashboard_runfile(state_dir, {
+                "pid": os.getpid(), "host": "127.0.0.1", "port": port,
+                "url": f"http://127.0.0.1:{port}/",
+            })
+
+            args = argparse.Namespace(
+                port=None, port_search=False, host="127.0.0.1", no_open=True,
+                allow_external=False, all_projects=False, mobile=False,
+                qr=False, background=True, stop=False, status=False,
+                write_runfile=False, job_id=None, backend="sqlite",
+            )
+            with patch("subprocess.Popen") as popen:
+                rc = _start_background_dashboard(
+                    args, state_dir, "127.0.0.1",
+                    port=port, auto_port=True,
+                    source="loopback", allow_external=False,
+                )
+        popen.assert_not_called()
+        self.assertEqual(rc, 0)
+
+    def test_does_not_reuse_real_foreign_dashboard(self) -> None:
+        """dir_b's runfile claims dir_a's real, live server (a stale
+        runfile, or -- pre-fix -- exactly the identity-blind bug this
+        whole branch fixes). Real dashboard_serves/dashboard_identity must
+        refuse it and fall through to spawning dir_b's own."""
+        from puppetmaster.cli._dispatch import _start_background_dashboard
+        from puppetmaster.dashboard import serve, write_dashboard_runfile
+        from puppetmaster.store_factory import create_store
+
+        with TemporaryDirectory() as tmp:
+            dir_a = Path(tmp) / "a"
+            dir_b = Path(tmp) / "b"
+            create_store("sqlite", dir_a).init()
+            create_store("sqlite", dir_b).init()
+            httpd = serve(
+                dir_a, backend="sqlite", host="127.0.0.1", port=0,
+                open_browser=False, serve_forever=False,
+            )
+            self.addCleanup(httpd.server_close)
+            thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+            thread.start()
+            self.addCleanup(httpd.shutdown)
+            port = httpd.server_address[1]
+            write_dashboard_runfile(dir_b, {
+                "pid": os.getpid(), "host": "127.0.0.1", "port": port,
+                "url": f"http://127.0.0.1:{port}/",
+            })
+
+            spawned = MagicMock()
+            spawned.pid = 8080
+            spawned.poll.return_value = 0  # "exits" immediately -- this
+            # test only cares whether a spawn was *attempted* (i.e. reuse
+            # was correctly refused), not whether the fake child comes up.
+            args = argparse.Namespace(
+                port=None, port_search=False, host="127.0.0.1", no_open=True,
+                allow_external=False, all_projects=False, mobile=False,
+                qr=False, background=True, stop=False, status=False,
+                write_runfile=False, job_id=None, backend="sqlite",
+            )
+            with patch("subprocess.Popen", return_value=spawned) as popen:
+                _start_background_dashboard(
+                    args, dir_b, "127.0.0.1",
+                    port=port, auto_port=True,
+                    source="loopback", allow_external=False,
+                )
+        popen.assert_called_once()
+
+
+class ChildStderrTailTests(unittest.TestCase):
+    """`--background`'s failure message used to be generic no matter what
+    actually went wrong, because the child's stderr was DEVNULL'd outright.
+    It's now captured to a file and quoted on failure -- these guard the
+    small helper that reads it back."""
+
+    def test_missing_file_returns_empty_string(self) -> None:
+        from puppetmaster.cli._dispatch import _read_child_stderr_tail
+
+        with TemporaryDirectory() as tmp:
+            self.assertEqual(
+                _read_child_stderr_tail(Path(tmp) / "does-not-exist.log"), ""
+            )
+
+    def test_empty_file_returns_empty_string(self) -> None:
+        from puppetmaster.cli._dispatch import _read_child_stderr_tail
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "empty.log"
+            path.write_text("", encoding="utf-8")
+            self.assertEqual(_read_child_stderr_tail(path), "")
+
+    def test_returns_captured_content(self) -> None:
+        from puppetmaster.cli._dispatch import _read_child_stderr_tail
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "err.log"
+            path.write_text(
+                "Traceback (most recent call last):\nOSError: port in use\n",
+                encoding="utf-8",
+            )
+            tail = _read_child_stderr_tail(path)
+        self.assertIn("OSError: port in use", tail)
+
+    def test_caps_to_max_bytes_from_the_end(self) -> None:
+        """A tail, not a head -- the actual error is usually the last
+        thing written, so a giant traceback should still surface it."""
+        from puppetmaster.cli._dispatch import _read_child_stderr_tail
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "big.log"
+            path.write_text("x" * 10000 + "THE REAL ERROR", encoding="utf-8")
+            tail = _read_child_stderr_tail(path, max_bytes=100)
+        self.assertLessEqual(len(tail), 100)
+        self.assertIn("THE REAL ERROR", tail)
 
 
 if __name__ == "__main__":

--- a/tests/test_dashboard_background_identity.py
+++ b/tests/test_dashboard_background_identity.py
@@ -214,6 +214,113 @@ class BackgroundDashboardIdentityTests(unittest.TestCase):
         self.assertIn("8788", text)
         self.assertNotIn("http://127.0.0.1:8787/", text)
 
+    def test_background_own_runfile_reuse_is_host_gated(self) -> None:
+        """A loopback dashboard tracked from an earlier plain --background
+        must not be "reused" for a later --mobile request that needs an
+        externally-reachable bind -- it must spawn a new, properly-bound
+        server on the requested host instead."""
+        from puppetmaster.cli._dispatch import _start_background_dashboard
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            loopback_runfile = {
+                "pid": 1111, "host": "127.0.0.1", "port": 8787,
+                "url": "http://127.0.0.1:8787/",
+            }
+            spawned = MagicMock()
+            spawned.pid = 2222
+            spawned.poll.return_value = None
+            mobile_runfile = {
+                "pid": 2222, "host": "100.64.0.7", "port": 8787,
+                "url": "http://100.64.0.7:8787/",
+            }
+            with patch.object(
+                dash, "read_dashboard_runfile",
+                side_effect=[loopback_runfile, mobile_runfile],
+            ), patch.object(
+                dash, "pid_alive", return_value=True
+            ), patch.object(
+                dash, "dashboard_serves", side_effect=[False, True]
+            ), patch("subprocess.Popen", return_value=spawned) as popen:
+                rc = _start_background_dashboard(
+                    self._args(mobile=True), state_dir, "100.64.0.7",
+                    port=8787, auto_port=True,
+                    source="tailscale", allow_external=True,
+                )
+        popen.assert_called_once()
+        self.assertEqual(rc, 0)
+
+    def test_mcp_dashboard_own_runfile_reuse_is_host_gated(self) -> None:
+        """Same host-gating as test_background_own_runfile_reuse_is_host_gated,
+        on the MCP tool's mirrored pre-check."""
+        import puppetmaster.mcp_server as mcp
+
+        loopback_runfile = {
+            "pid": 3333, "host": "127.0.0.1", "port": 8787,
+            "url": "http://127.0.0.1:8787/",
+        }
+        spawned = MagicMock()
+        spawned.pid = 4444
+        spawned.poll.return_value = None
+        mobile_runfile = {
+            "pid": 4444, "host": "100.64.0.7", "port": 8787,
+            "url": "http://100.64.0.7:8787/",
+        }
+        with patch.object(
+            dash, "resolve_mobile_host", return_value=("100.64.0.7", "tailscale")
+        ), patch.object(
+            dash, "read_dashboard_runfile",
+            side_effect=[loopback_runfile, mobile_runfile],
+        ), patch.object(
+            dash, "pid_alive", return_value=True
+        ), patch.object(
+            dash, "dashboard_serves", side_effect=[False, True]
+        ), patch.object(
+            mcp, "_spawn_dashboard_server", return_value=spawned
+        ) as popen, patch.object(
+            dash, "write_qr_png", return_value=True
+        ):
+            result = mcp.call_tool(
+                "puppetmaster_dashboard", {"cwd": "/tmp", "mobile": True}
+            )
+        popen.assert_called_once()
+        body = json.loads(result["content"][0]["text"])
+        self.assertTrue(body["started"])
+        self.assertEqual(body["host"], "100.64.0.7")
+
+    def test_status_uses_tracked_all_projects_not_invocation_flag(self) -> None:
+        """`dashboard --status` (all_projects defaults False) after
+        `dashboard --background --all-projects` must still report the board
+        it started, not "serving another project" -- --status asks whether
+        what its own runfile points at is still there, not whether that
+        matches this invocation's flags."""
+        from puppetmaster.cli._dispatch import _run_dashboard_command
+
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            tracked = {
+                "pid": 5555, "host": "127.0.0.1", "port": 8787,
+                "url": "http://127.0.0.1:8787/", "all_projects": True,
+            }
+
+            def _serves(host, port, sd, *, all_projects=False, timeout=1.0):
+                return all_projects is True  # "matches" only when asked True
+
+            with patch.object(
+                dash, "read_dashboard_runfile", return_value=tracked
+            ), patch.object(dash, "dashboard_serves", side_effect=_serves):
+                out = io.StringIO()
+                with contextlib.redirect_stdout(out):
+                    rc = _run_dashboard_command(
+                        self._args(status=True, all_projects=False), state_dir
+                    )
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        self.assertIn("Background dashboard running", text)
+        self.assertNotIn("another project", text)
+
     def test_mcp_dashboard_does_not_reuse_foreign_project(self) -> None:
         """Same defect as test_background_reuses_only_same_project, on the
         MCP puppetmaster_dashboard tool's identical code shape."""
@@ -229,7 +336,12 @@ class BackgroundDashboardIdentityTests(unittest.TestCase):
         with patch.object(
             dash, "dashboard_serves", side_effect=[False, True]
         ), patch.object(
-            dash, "read_dashboard_runfile", return_value=child_runfile
+            # None first: MCP's own-runfile pre-check must find nothing
+            # tracked for this project before falling through to the
+            # literal-port probe (mocked False -- a foreign dashboard) and
+            # spawning its own. The child's runfile only appears once the
+            # poll loop looks for it (second call).
+            dash, "read_dashboard_runfile", side_effect=[None, child_runfile]
         ), patch.object(mcp, "_spawn_dashboard_server", return_value=spawned) as popen:
             result = mcp.call_tool("puppetmaster_dashboard", {"cwd": "/tmp"})
         popen.assert_called_once()

--- a/tests/test_dashboard_ports.py
+++ b/tests/test_dashboard_ports.py
@@ -16,9 +16,11 @@ two changes landing as separate PRs.
 from __future__ import annotations
 
 import errno
+import json
 import os
 import socket
 import threading
+import time
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -27,6 +29,7 @@ from puppetmaster.dashboard import (
     _port_taken,
     _state_dir_id,
     bind_dashboard_server,
+    dashboard_identity,
     dashboard_serves,
     make_handler,
     read_dashboard_runfile,
@@ -161,6 +164,17 @@ class BindDashboardServerTests(unittest.TestCase):
         self.assertIn(str(port), message)
         self.assertIn(str(port + 2), message)
 
+    def test_invalid_port_reports_actual_problem(self) -> None:
+        """70000 isn't a TCP port at all -- pre-fix this was reported as
+        "already in use", which is simply false: the bind loop's own
+        `candidate > 65535` guard breaks out before ever attempting a
+        bind."""
+        with self.assertRaises(OSError) as ctx:
+            bind_dashboard_server("127.0.0.1", 70000, _handler(), auto_port=False)
+        message = str(ctx.exception)
+        self.assertNotIn("already in use", message)
+        self.assertIn("70000", message)
+
 
 class ApiMetaTests(unittest.TestCase):
     def test_api_meta_reports_project_identity(self) -> None:
@@ -279,6 +293,123 @@ class RunfileAndOnBoundTests(unittest.TestCase):
             )
             self.addCleanup(httpd.server_close)
             self.assertEqual(calls, [("127.0.0.1", port + 1)])
+
+
+class DashboardIdentityRobustnessTests(unittest.TestCase):
+    """`dashboard_identity` against misbehaving (or hostile) listeners on the
+    port -- a real dashboard's own /api/meta is already covered by
+    ApiMetaTests; these exercise the "something else is on this port"
+    cases an ordinary `dashboard --background` can hit."""
+
+    @staticmethod
+    def _one_shot_server(respond) -> "tuple[socket.socket, int]":
+        """A raw socket server that accepts exactly one connection, hands
+        it to `respond(conn)` on a background thread, and returns
+        (listening_socket, port)."""
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        port = srv.getsockname()[1]
+
+        def _serve() -> None:
+            try:
+                conn, _ = srv.accept()
+            except OSError:
+                return
+            try:
+                respond(conn)
+            except OSError:
+                pass
+            finally:
+                conn.close()
+
+        threading.Thread(target=_serve, daemon=True).start()
+        return srv, port
+
+    def test_truncated_body_returns_none_not_a_traceback(self) -> None:
+        """A server that sends a valid Content-Length header then closes
+        early used to escape as a raw http.client.IncompleteRead out of an
+        ordinary `dashboard --background` -- the docstring promises None
+        for exactly this "can't vouch for it" case (§F3)."""
+
+        def truncate(conn: socket.socket) -> None:
+            conn.recv(4096)
+            conn.sendall(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                b"Content-Length: 55\r\n\r\n1234567890"
+            )
+
+        srv, port = self._one_shot_server(truncate)
+        self.addCleanup(srv.close)
+        self.assertIsNone(dashboard_identity("127.0.0.1", port, timeout=1.0))
+
+    def test_non_http_squatter_returns_none_not_a_traceback(self) -> None:
+        """A non-HTTP service on the port (e.g. an SSH banner) raises
+        http.client.BadStatusLine, which the pre-fix `except (OSError,
+        ValueError)` also did not catch."""
+
+        def banner(conn: socket.socket) -> None:
+            conn.recv(4096)
+            conn.sendall(b"SSH-2.0-OpenSSH_9.6\r\n")
+
+        srv, port = self._one_shot_server(banner)
+        self.addCleanup(srv.close)
+        self.assertIsNone(dashboard_identity("127.0.0.1", port, timeout=1.0))
+
+    def test_slow_dribbler_is_bounded_by_a_wall_clock_deadline(self) -> None:
+        """`timeout=1.0` bounds each individual recv, not the call as a
+        whole: a peer trickling one byte at a time keeps every recv under
+        that timeout, so a bare per-recv timeout let this run for 12s
+        against a declared 1.0s budget (measured). Must return within a
+        small constant factor of `timeout`, not "eventually"."""
+        payload = json.dumps(
+            {"service": "puppetmaster-dashboard", "pid": 1, "state_dir_id": "x"}
+        ).encode("utf-8")
+
+        def dribble(conn: socket.socket) -> None:
+            conn.recv(4096)
+            conn.sendall(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                + f"Content-Length: {len(payload)}\r\n\r\n".encode("utf-8")
+            )
+            for byte in payload:
+                conn.sendall(bytes([byte]))
+                time.sleep(0.5)
+
+        srv, port = self._one_shot_server(dribble)
+        self.addCleanup(srv.close)
+        started = time.monotonic()
+        result = dashboard_identity("127.0.0.1", port, timeout=1.0)
+        elapsed = time.monotonic() - started
+        self.assertIsNone(result)
+        self.assertLess(elapsed, 3.0, "must be bounded, not proportional to body size")
+
+    def test_flood_body_is_capped_not_read_into_memory_whole(self) -> None:
+        """A huge declared Content-Length must not be read in full -- the
+        payload is one small JSON object; anything that large is not a
+        dashboard, and reading it whole is an unbounded-memory foot-gun."""
+
+        def flood(conn: socket.socket) -> None:
+            conn.recv(4096)
+            declared = 400 * 1024 * 1024
+            conn.sendall(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                + f"Content-Length: {declared}\r\n\r\n".encode("utf-8")
+            )
+            chunk = b"0" * 65536
+            try:
+                for _ in range(20):
+                    conn.sendall(chunk)
+            except OSError:
+                pass
+
+        srv, port = self._one_shot_server(flood)
+        self.addCleanup(srv.close)
+        started = time.monotonic()
+        result = dashboard_identity("127.0.0.1", port, timeout=2.0)
+        elapsed = time.monotonic() - started
+        self.assertIsNone(result)
+        self.assertLess(elapsed, 5.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_dashboard_ports.py
+++ b/tests/test_dashboard_ports.py
@@ -1,0 +1,285 @@
+"""Dashboard port-collision remediation: bind-retry, project identity on the
+wire (/api/meta), and truthful port propagation.
+
+Two projects' `puppetmaster dashboard` used to silently collide: on Windows,
+SO_REUSEADDR's inverted semantics let a second dashboard bind "successfully"
+over the first's live listener, so the newcomer prints a URL and opens a
+browser tab that the kernel never routes a single request to (the first
+binder answers everything). See docs/CHANGELOG.md for the full writeup.
+
+A new file, deliberately: tests/test_puppetmaster.py is huge and a
+concurrent, independent workstream (server_close() on Ctrl-C) edits its
+DashboardTests class around the same lines this change would otherwise touch.
+Keeping the new socket-binding tests here avoids any collision between the
+two changes landing as separate PRs.
+"""
+from __future__ import annotations
+
+import errno
+import os
+import socket
+import threading
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from puppetmaster.dashboard import (
+    _port_taken,
+    _state_dir_id,
+    bind_dashboard_server,
+    dashboard_serves,
+    make_handler,
+    read_dashboard_runfile,
+    serve,
+)
+from puppetmaster.store_factory import create_store
+
+
+def _free_port() -> int:
+    """A port that's probably free right now.
+
+    TOCTOU-y like the rest of this codebase's port helpers (see
+    puppetmaster/ports.py's own documented caveat) — acceptable for tests
+    that immediately occupy it themselves.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _occupy(port: int, *, reuse: bool) -> socket.socket:
+    """Bind+listen on ``port`` with a plain socket — stands in for "some
+    other process (or dashboard) already holds this port"."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    if reuse:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", port))
+    sock.listen(1)
+    return sock
+
+
+def _handler():
+    """A handler for bind-only tests that never actually dispatch a request."""
+    return make_handler(lambda: None)
+
+
+def _store_dir(tmp) -> Path:
+    store_dir = Path(tmp) / ".puppetmaster"
+    create_store("sqlite", store_dir).init()
+    return store_dir
+
+
+def _serve_requests(test: unittest.TestCase, httpd) -> None:
+    """Start serving on a background thread and register cleanup, for tests
+    that need to actually issue an HTTP request against a serve_forever=False
+    server (which only binds -- nothing answers until serve_forever runs)."""
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    test.addCleanup(httpd.shutdown)
+
+
+class PortTakenClassificationTests(unittest.TestCase):
+    def test_port_taken_classifies_bind_errors(self) -> None:
+        # 10048 / EADDRINUSE -- the ordinary "something's listening" case.
+        in_use = OSError()
+        in_use.errno = errno.EADDRINUSE
+        in_use.winerror = 10048
+        self.assertTrue(_port_taken(in_use))
+
+        # Windows WSAEACCES: PermissionError(errno=EACCES, winerror=10013) --
+        # both "incompatible SO_REUSEADDR on the incumbent" and "port sits in
+        # a Hyper-V/WSL/winnat reserved range" surface this way. Constructed
+        # via the 2-arg form + an attribute assignment (not the 4-arg
+        # ``OSError(13, "x", None, 10013)`` form) because the 4-arg form's
+        # winerror slot is a no-op on POSIX, which would make this assertion
+        # pass on this Windows box but silently stop testing anything once
+        # run under Linux CI.
+        windows_denied = PermissionError(13, "denied")
+        windows_denied.winerror = 10013
+        self.assertTrue(_port_taken(windows_denied))
+
+        # POSIX privileged-port EACCES (no winerror) must NOT be treated as
+        # "bump past it" -- that would retry a permissions wall
+        # max_attempts times instead of surfacing the real problem.
+        posix_denied = PermissionError(13, "denied")
+        self.assertFalse(_port_taken(posix_denied))
+
+
+class BindDashboardServerTests(unittest.TestCase):
+    def test_serve_bumps_to_next_free_port_by_default(self) -> None:
+        port = _free_port()
+        occupied = _occupy(port, reuse=False)
+        self.addCleanup(occupied.close)
+        httpd = bind_dashboard_server("127.0.0.1", port, _handler())
+        self.addCleanup(httpd.server_close)
+        self.assertEqual(httpd.server_address[1], port + 1)
+
+    @unittest.skipUnless(os.name == "nt", "Windows-only: SO_REUSEADDR hijack")
+    def test_two_serves_on_same_port_do_not_both_bind(self) -> None:
+        """The headline regression test. Pre-fix, the second serve() call
+        returned a bound server that never received a request (the first
+        binder silently kept every connection)."""
+        port = _free_port()
+        with TemporaryDirectory() as tmp:
+            state_dir = _store_dir(tmp)
+            first = serve(
+                state_dir, backend="sqlite", host="127.0.0.1", port=port,
+                open_browser=False, serve_forever=False, auto_port=False,
+            )
+            self.addCleanup(first.server_close)
+            with self.assertRaises(OSError) as ctx:
+                second = serve(
+                    state_dir, backend="sqlite", host="127.0.0.1", port=port,
+                    open_browser=False, serve_forever=False, auto_port=False,
+                )
+                second.server_close()  # pragma: no cover - only if it wrongly binds
+            # bind_dashboard_server raises a friendlier, message-only OSError
+            # `from` the real socket error (plan §3.1) -- the actual errno
+            # lives on the chained cause, not the raised exception itself.
+            self.assertIn(str(port), str(ctx.exception))
+            self.assertIsInstance(ctx.exception.__cause__, OSError)
+            self.assertIn(
+                ctx.exception.__cause__.errno, (errno.EADDRINUSE, errno.EACCES)
+            )
+
+    def test_explicit_port_collision_is_strict(self) -> None:
+        port = _free_port()
+        occupied = _occupy(port, reuse=False)
+        self.addCleanup(occupied.close)
+        with self.assertRaises(OSError) as ctx:
+            bind_dashboard_server("127.0.0.1", port, _handler(), auto_port=False)
+        self.assertIn(str(port), str(ctx.exception))
+
+    def test_port_search_gives_up_after_max_attempts(self) -> None:
+        port = _free_port()
+        occupied = [_occupy(port + i, reuse=False) for i in range(3)]
+        for sock in occupied:
+            self.addCleanup(sock.close)
+        with self.assertRaises(OSError) as ctx:
+            bind_dashboard_server("127.0.0.1", port, _handler(), max_attempts=3)
+        message = str(ctx.exception)
+        self.assertIn(str(port), message)
+        self.assertIn(str(port + 2), message)
+
+
+class ApiMetaTests(unittest.TestCase):
+    def test_api_meta_reports_project_identity(self) -> None:
+        import json
+        import urllib.request
+
+        with TemporaryDirectory() as tmp:
+            state_dir = _store_dir(tmp)
+            httpd = serve(
+                state_dir, backend="sqlite", host="127.0.0.1", port=0,
+                open_browser=False, serve_forever=False,
+            )
+            self.addCleanup(httpd.server_close)
+            _serve_requests(self, httpd)
+            port = httpd.server_address[1]
+            with urllib.request.urlopen(f"http://127.0.0.1:{port}/api/meta") as resp:
+                payload = json.loads(resp.read())
+            self.assertEqual(payload["service"], "puppetmaster-dashboard")
+            self.assertEqual(payload["pid"], os.getpid())
+            self.assertEqual(payload["state_dir_id"], _state_dir_id(state_dir))
+
+    def test_api_meta_does_not_leak_absolute_path(self) -> None:
+        import urllib.request
+
+        with TemporaryDirectory() as tmp:
+            state_dir = _store_dir(tmp)
+            httpd = serve(
+                state_dir, backend="sqlite", host="127.0.0.1", port=0,
+                open_browser=False, serve_forever=False,
+            )
+            self.addCleanup(httpd.server_close)
+            _serve_requests(self, httpd)
+            port = httpd.server_address[1]
+            with urllib.request.urlopen(f"http://127.0.0.1:{port}/api/meta") as resp:
+                raw = resp.read().decode("utf-8")
+            self.assertNotIn(str(state_dir.resolve()), raw)
+            self.assertNotIn(str(tmp), raw)
+
+
+class DashboardServesTests(unittest.TestCase):
+    def test_dashboard_serves_distinguishes_projects(self) -> None:
+        with TemporaryDirectory() as tmp:
+            dir_a = _store_dir(Path(tmp) / "a")
+            dir_b = _store_dir(Path(tmp) / "b")
+            server_a = serve(
+                dir_a, backend="sqlite", host="127.0.0.1", port=0,
+                open_browser=False, serve_forever=False,
+            )
+            self.addCleanup(server_a.server_close)
+            _serve_requests(self, server_a)
+            port_a = server_a.server_address[1]
+            self.assertTrue(dashboard_serves("127.0.0.1", port_a, dir_a))
+            self.assertFalse(dashboard_serves("127.0.0.1", port_a, dir_b))
+
+    def test_dashboard_serves_false_for_legacy_server(self) -> None:
+        """A pre-upgrade dashboard (or any plain web server) 200s /api/jobs
+        but 404s /api/meta -- it must never be mistaken for "ours". This
+        pins the rollout contract: no flag day, no coordinated upgrade."""
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        class _Legacy(BaseHTTPRequestHandler):
+            def log_message(self, *args) -> None:
+                pass
+
+            def do_GET(self) -> None:
+                if self.path == "/api/jobs":
+                    body = b"[]"
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.end_headers()
+                    self.wfile.write(body)
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+
+        httpd = HTTPServer(("127.0.0.1", 0), _Legacy)
+        self.addCleanup(httpd.server_close)
+        port = httpd.server_address[1]
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        self.addCleanup(httpd.shutdown)
+        with TemporaryDirectory() as tmp:
+            state_dir = _store_dir(tmp)
+            self.assertFalse(dashboard_serves("127.0.0.1", port, state_dir))
+
+
+class RunfileAndOnBoundTests(unittest.TestCase):
+    def test_serve_writes_runfile_with_actual_bound_port(self) -> None:
+        with TemporaryDirectory() as tmp:
+            state_dir = _store_dir(tmp)
+            port = _free_port()
+            occupied = _occupy(port, reuse=False)
+            self.addCleanup(occupied.close)
+            httpd = serve(
+                state_dir, backend="sqlite", host="127.0.0.1", port=port,
+                open_browser=False, serve_forever=False,
+                runfile_state_dir=state_dir,
+            )
+            self.addCleanup(httpd.server_close)
+            info = read_dashboard_runfile(state_dir)
+            self.assertEqual(info["port"], port + 1)
+            self.assertEqual(info["pid"], os.getpid())
+
+    def test_on_bound_receives_actual_port(self) -> None:
+        with TemporaryDirectory() as tmp:
+            state_dir = _store_dir(tmp)
+            port = _free_port()
+            occupied = _occupy(port, reuse=False)
+            self.addCleanup(occupied.close)
+            calls = []
+            httpd = serve(
+                state_dir, backend="sqlite", host="127.0.0.1", port=port,
+                open_browser=False, serve_forever=False,
+                on_bound=lambda h, p: calls.append((h, p)),
+            )
+            self.addCleanup(httpd.server_close)
+            self.assertEqual(calls, [("127.0.0.1", port + 1)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -24125,9 +24125,12 @@ class PuppetmasterMcpVerbTests(unittest.TestCase):
 
     def test_dashboard_tool_reuses_running_server(self) -> None:
         import puppetmaster.mcp_server as mcp
+        import puppetmaster.dashboard as dash
 
         self.assertIn("puppetmaster_dashboard", {tool.name for tool in mcp.tools()})
-        with patch.object(mcp, "_dashboard_alive", return_value=True), patch.object(
+        # Reuse is identity-aware (dashboard_serves), not bare liveness — a
+        # foreign responder on the same host:port must never count as "ours".
+        with patch.object(dash, "dashboard_serves", return_value=True), patch.object(
             mcp, "_spawn_dashboard_server"
         ) as popen:
             result = mcp.call_tool(
@@ -24141,19 +24144,29 @@ class PuppetmasterMcpVerbTests(unittest.TestCase):
 
     def test_dashboard_tool_starts_server_when_absent(self) -> None:
         import puppetmaster.mcp_server as mcp
+        import puppetmaster.dashboard as dash
 
         spawned = MagicMock()
         spawned.pid = 4321
         spawned.poll.return_value = None
-        # alive checks: initial probe (absent), readiness loop, post-loop verify
+        # The child writes its own runfile post-bind (--write-runfile); the
+        # parent polls for it rather than re-probing host:port.
+        runfile = {
+            "pid": 4321, "host": "127.0.0.1", "port": 9000,
+            "url": "http://127.0.0.1:9000/",
+        }
+        # identity checks: initial probe (absent), post-spawn confirm (ours)
         with patch.object(
-            mcp, "_dashboard_alive", side_effect=[False, True, True]
+            dash, "dashboard_serves", side_effect=[False, True]
+        ), patch.object(
+            dash, "read_dashboard_runfile", return_value=runfile
         ), patch.object(mcp, "_spawn_dashboard_server", return_value=spawned) as popen:
             result = mcp.call_tool("puppetmaster_dashboard", {"cwd": "/tmp", "port": 9000})
         body = json.loads(result["content"][0]["text"])
         command = popen.call_args.args[0]
         self.assertIn("dashboard", command)
         self.assertIn("--no-open", command)
+        self.assertIn("--write-runfile", command)
         self.assertIn("9000", command)
         self.assertTrue(body["started"])
         self.assertEqual(body["pid"], 4321)
@@ -24161,6 +24174,7 @@ class PuppetmasterMcpVerbTests(unittest.TestCase):
 
     def test_dashboard_tool_forwards_all_projects_flag(self) -> None:
         import puppetmaster.mcp_server as mcp
+        import puppetmaster.dashboard as dash
 
         schema = mcp.dashboard_schema()
         self.assertIn("all_projects", schema["properties"])
@@ -24168,8 +24182,14 @@ class PuppetmasterMcpVerbTests(unittest.TestCase):
         spawned = MagicMock()
         spawned.pid = 5555
         spawned.poll.return_value = None
+        runfile = {
+            "pid": 5555, "host": "127.0.0.1", "port": 8787,
+            "url": "http://127.0.0.1:8787/",
+        }
         with patch.object(
-            mcp, "_dashboard_alive", side_effect=[False, True, True]
+            dash, "dashboard_serves", side_effect=[False, True]
+        ), patch.object(
+            dash, "read_dashboard_runfile", return_value=runfile
         ), patch.object(mcp, "_spawn_dashboard_server", return_value=spawned) as popen:
             result = mcp.call_tool(
                 "puppetmaster_dashboard", {"cwd": "/tmp", "all_projects": True}
@@ -24181,12 +24201,19 @@ class PuppetmasterMcpVerbTests(unittest.TestCase):
 
     def test_dashboard_tool_omits_all_projects_by_default(self) -> None:
         import puppetmaster.mcp_server as mcp
+        import puppetmaster.dashboard as dash
 
         spawned = MagicMock()
         spawned.pid = 5556
         spawned.poll.return_value = None
+        runfile = {
+            "pid": 5556, "host": "127.0.0.1", "port": 8787,
+            "url": "http://127.0.0.1:8787/",
+        }
         with patch.object(
-            mcp, "_dashboard_alive", side_effect=[False, True, True]
+            dash, "dashboard_serves", side_effect=[False, True]
+        ), patch.object(
+            dash, "read_dashboard_runfile", return_value=runfile
         ), patch.object(mcp, "_spawn_dashboard_server", return_value=spawned) as popen:
             mcp.call_tool("puppetmaster_dashboard", {"cwd": "/tmp"})
         command = popen.call_args.args[0]
@@ -24194,13 +24221,14 @@ class PuppetmasterMcpVerbTests(unittest.TestCase):
 
     def test_dashboard_tool_reports_failed_start(self) -> None:
         import puppetmaster.mcp_server as mcp
+        import puppetmaster.dashboard as dash
 
         dead = MagicMock()
         dead.pid = 4321
         dead.poll.return_value = 1
-        with patch.object(mcp, "_dashboard_alive", return_value=False), patch.object(
-            mcp, "_spawn_dashboard_server", return_value=dead
-        ):
+        with patch.object(dash, "dashboard_serves", return_value=False), patch.object(
+            dash, "read_dashboard_runfile", return_value=None
+        ), patch.object(mcp, "_spawn_dashboard_server", return_value=dead):
             result = mcp.call_tool("puppetmaster_dashboard", {"cwd": "/tmp"})
         self.assertTrue(result["isError"])
         body = json.loads(result["content"][0]["text"])
@@ -24213,16 +24241,20 @@ class PuppetmasterMcpVerbTests(unittest.TestCase):
         spawned = MagicMock()
         spawned.pid = 7777
         spawned.poll.return_value = None
+        runfile = {
+            "pid": 7777, "host": "100.64.0.7", "port": 8787,
+            "url": "http://100.64.0.7:8787/",
+        }
         with patch.object(
             dash, "resolve_mobile_host", return_value=("100.64.0.7", "tailscale")
         ), patch.object(
-            mcp, "_dashboard_alive", side_effect=[False, True, True]
+            dash, "dashboard_serves", side_effect=[False, True]
+        ), patch.object(
+            dash, "read_dashboard_runfile", return_value=runfile
         ), patch.object(
             mcp, "_spawn_dashboard_server", return_value=spawned
         ) as popen, patch.object(
             dash, "write_qr_png", return_value=True
-        ), patch.object(
-            dash, "write_dashboard_runfile"
         ):
             result = mcp.call_tool(
                 "puppetmaster_dashboard", {"cwd": "/tmp", "mobile": True}

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -24130,9 +24130,11 @@ class PuppetmasterMcpVerbTests(unittest.TestCase):
         self.assertIn("puppetmaster_dashboard", {tool.name for tool in mcp.tools()})
         # Reuse is identity-aware (dashboard_serves), not bare liveness — a
         # foreign responder on the same host:port must never count as "ours".
+        # No tracked runfile (None) so the own-runfile pre-check falls
+        # through to the literal-port probe, which this mocks True.
         with patch.object(dash, "dashboard_serves", return_value=True), patch.object(
-            mcp, "_spawn_dashboard_server"
-        ) as popen:
+            dash, "read_dashboard_runfile", return_value=None
+        ), patch.object(mcp, "_spawn_dashboard_server") as popen:
             result = mcp.call_tool(
                 "puppetmaster_dashboard", {"cwd": "/tmp", "job_id": "job_abc"}
             )
@@ -24155,11 +24157,14 @@ class PuppetmasterMcpVerbTests(unittest.TestCase):
             "pid": 4321, "host": "127.0.0.1", "port": 9000,
             "url": "http://127.0.0.1:9000/",
         }
-        # identity checks: initial probe (absent), post-spawn confirm (ours)
+        # identity checks: initial probe (absent), post-spawn confirm (ours).
+        # read_dashboard_runfile: None first (own-runfile pre-check finds
+        # nothing tracked, so it can't short-circuit to a false "reuse"),
+        # then the child's runfile once the poll loop looks for it.
         with patch.object(
             dash, "dashboard_serves", side_effect=[False, True]
         ), patch.object(
-            dash, "read_dashboard_runfile", return_value=runfile
+            dash, "read_dashboard_runfile", side_effect=[None, runfile]
         ), patch.object(mcp, "_spawn_dashboard_server", return_value=spawned) as popen:
             result = mcp.call_tool("puppetmaster_dashboard", {"cwd": "/tmp", "port": 9000})
         body = json.loads(result["content"][0]["text"])
@@ -24189,7 +24194,7 @@ class PuppetmasterMcpVerbTests(unittest.TestCase):
         with patch.object(
             dash, "dashboard_serves", side_effect=[False, True]
         ), patch.object(
-            dash, "read_dashboard_runfile", return_value=runfile
+            dash, "read_dashboard_runfile", side_effect=[None, runfile]
         ), patch.object(mcp, "_spawn_dashboard_server", return_value=spawned) as popen:
             result = mcp.call_tool(
                 "puppetmaster_dashboard", {"cwd": "/tmp", "all_projects": True}
@@ -24213,7 +24218,7 @@ class PuppetmasterMcpVerbTests(unittest.TestCase):
         with patch.object(
             dash, "dashboard_serves", side_effect=[False, True]
         ), patch.object(
-            dash, "read_dashboard_runfile", return_value=runfile
+            dash, "read_dashboard_runfile", side_effect=[None, runfile]
         ), patch.object(mcp, "_spawn_dashboard_server", return_value=spawned) as popen:
             mcp.call_tool("puppetmaster_dashboard", {"cwd": "/tmp"})
         command = popen.call_args.args[0]
@@ -24250,7 +24255,7 @@ class PuppetmasterMcpVerbTests(unittest.TestCase):
         ), patch.object(
             dash, "dashboard_serves", side_effect=[False, True]
         ), patch.object(
-            dash, "read_dashboard_runfile", return_value=runfile
+            dash, "read_dashboard_runfile", side_effect=[None, runfile]
         ), patch.object(
             mcp, "_spawn_dashboard_server", return_value=spawned
         ) as popen, patch.object(


### PR DESCRIPTION
## The bug

`puppetmaster dashboard` in a second project directory doesn't start a dashboard for that project — it silently shadows the first. Two independent defects, both reproduced end-to-end through the real CLI.

**Mechanism A — foreground.** `serve()` built a stock `ThreadingHTTPServer`, which inherits stdlib's `allow_reuse_address = 1`. On Windows `SO_REUSEADDR` has inverted semantics: a second process's `bind()` succeeds **over an actively listening socket**. Two projects, same port:

```
both processes printed "BIND OK"; both showed LISTENING in netstat;
all 3/3 requests were answered by the FIRST binder
-> the tab opened for project BRAVO served PROJECT-ALPHA's jobs
```

So the second server *is* running, is correct, is unreachable, and reports success. Worse tail: kill the first binder and the shadowed server silently takes over the same URL, so an open tab switches projects with no reload. The repo already documents this exact inverted semantics in `ports.py`, but the dashboard never got the guard.

**Mechanism B — background / MCP.** `_start_background_dashboard` early-returned on a bare `dashboard_alive(host, port)` liveness probe with no project identity, so project B was told *"already serving … reusing it"* and handed A's URL. That early return also preceded `write_dashboard_runfile`, so **B got no runfile at all**: B's `--status` reported nothing running, B's `--stop` was a no-op, and A's `--stop` killed the server B depended on.

## The fix

- **Bind-retry, not probe-then-bind.** New `bind_dashboard_server()` binds a dashboard-specific server class with `allow_reuse_address = 0` **on Windows only**, retrying on real collisions. `ports.reserve_port()` was rejected as the primary mechanism — its bind-probe-then-close has an inherent TOCTOU window it documents itself. A measured bind-semantics matrix showed the Windows hijack requires *both* sockets to opt into `SO_REUSEADDR`, so clearing it on our side alone protects in both directions — including against an already-running pre-upgrade dashboard. **No flag day.** POSIX keeps `1`, where it only reclaims a `TIME_WAIT` socket.
- The retry matches `errno.EADDRINUSE` **and** `winerror == 10013` specifically. On Windows 10048 arrives as `errno == EADDRINUSE`, but 10013 arrives as `PermissionError` with `errno == 13`; matching that on winerror rather than `EACCES` keeps a POSIX privileged-port failure from being silently swallowed into a port bump. A non-collision `OSError` propagates (verified: WinError 10049 in 0.00s).
- **Project identity on the wire.** New `GET /api/meta` returns a hashed `state_dir_id` + pid, so reuse, `--status`, and the MCP path compare *project* rather than "something answered". A pre-upgrade dashboard 404s it and is correctly treated as foreign. Human-readable fields are loopback-gated via `client_address[0]` (unspoofable by `Host`/`X-Forwarded-For`), since the board is unauthenticated and reachable off-loopback under `--mobile`.
- **Truthful port propagation.** The *serving child* now writes its own runfile post-bind and the parent reads it back. Previously the parent recorded its own requested `--port`, which was wrong the moment the child bumped — this also fixes the `--mobile` banner/QR printing the pre-bump port *before* the bind had happened.

## BREAKING: `--port` semantics

Omit `--port` (the common case) and a busy port auto-bumps to the next free one — capped at 20 candidates, then a hard error naming the range tried. **A named port is now strict:** `--port N` on a busy port fails instead of quietly serving somewhere else, because a named port is a promise a script, bookmark, or reverse-proxy config may depend on. Pass `--port-search` to opt back into bumping from an explicit `--port`. `docs/DASHBOARD.md` documents all of this.

## Adversarial review — one blocker found and fixed

An independent review broke the first two commits. The own-project-reuse pre-check consulted neither `auto_port` nor whether the tracked port matched the requested one, so with a dashboard live on 18761, `--background --port 18771` (free) printed *"already serving at 18761 — reusing it"* and exited 0 with nothing on 18771 — a **regression against main**, contradicting this same diff's MCP schema text. Reuse is now gated on `auto_port or tracked_port == port`, in both the CLI and MCP paths.

I reproduced that independently in both directions: on the pre-fix commit `--port 18812` yields *"already serving at 18811"* with no listener on 18812; on HEAD it binds 18812.

Also fixed from that review: host-spelling comparison (`localhost` vs the recorded `127.0.0.1`) now normalized through one shared helper; `dashboard_identity` no longer lets `http.client` exceptions escape as a traceback from an ordinary command; the identity probe gained a real wall-clock deadline and a body cap (a 1-byte-per-0.5s dribbler previously held it 12s against a declared 1s budget, and a 400 MB body was buffered whole); `--status` no longer calls your own pre-upgrade dashboard "another project" during the upgrade window; a vacuous test now asserts something a mutated `_reuse` can't satisfy; a test that could have sent a real `SIGTERM` to an unrelated pid on Linux now mocks `pid_alive`; and the `--port` argv derivation — the riskiest edit here — went from zero coverage to explicit tests, alongside tests that drive the real identity path rather than mocking it.

## Verified not broken

Measured rather than reasoned: no Windows restart regression from `allow_reuse_address = 0` (immediate rebind succeeds with TIME_WAIT entries present, flag either way); `--port default=None` has no missed consumers (`commands_gate`, `mcp_remote`, `commands_mcp`, `mcp serve-remote` all have separate namespaces, and no `ArgumentDefaultsHelpFormatter` renders "(default: None)"); old-format runfiles still read fine; bare `dashboard` still lands on 8787 when free.

Suite: 1929 tests on main → 1949 here. Failure-*name* diff shows no new failures — only a known pre-existing flaky pair that swaps.

## Relationship to the other dashboard PR

There's a companion PR for the Ctrl-C hang. The two touch the same function but disjoint regions — this one owns everything through the bind, that one owns the blocking tail, which is byte-identical to main here. They auto-merge with only a `docs/CHANGELOG.md` conflict.

**Suggested merge order: the Ctrl-C PR first**, since its `httpd.server_close()` keeps this PR's port tests from flaking. I ran the combined smoke test on a throwaway merge of both: Ctrl-C exits in 0.53s, the socket is released, and an **immediate** restart on the same port succeeds — so the Windows `allow_reuse_address = 0` here does not reintroduce "Address already in use" after Ctrl-C. The double `server_close()` the merge produces was separately verified idempotent on CPython 3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
