### PR TITLE
Fix: the test suite ran against live provider APIs on any machine with an API key

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,48 @@
+## Unreleased
+
+**Fix: the test suite silently retargeted itself onto live provider APIs on any
+machine with an LLM API key.**
+
+`tests/hermetic_env.py` isolated the suite from the host's Puppetmaster config
+but not from the host's provider credentials. With, say, `GOOGLE_API_KEY` set,
+`available_providers()` was non-empty, so the auto-route path in the
+orchestrator reconciled the curated agentic catalog and persisted it through
+`save_registry(..., default_registry_path())` — which resolves to the very
+`PUPPETMASTER_MODELS_PATH` sentinel the harness had just created as
+*deliberately missing*. From that point the registry stayed populated with
+`agentic/gemini-*` for the rest of the process: every later "empty registry" or
+"routes to claude-code/cursor/local" assertion saw `agentic`, and worker tests
+quietly executed against the live API instead of the local stub. Measured on one
+developer machine: **13 failures and 820s with keys present, 0 failures and 464s
+without** — same commit, same box. CI was green throughout, because CI has no
+keys.
+
+- **Provider credentials are cleared for the suite**, derived from
+  `PROVIDER_REGISTRY` rather than hardcoded, so a provider added later is
+  covered without touching the harness. Includes the numbered rotation siblings
+  (`OPENAI_API_KEY_2` …) and the presence vars that opt keyless local endpoints
+  (Ollama / LM Studio) in. `PUPPETMASTER_DISABLED_PROVIDERS` is cleared too — a
+  provider the developer disconnected in Settings shouldn't change what tests
+  see either. Note `PUPPETMASTER_AUTODISCOVER=0` did *not* gate this path;
+  catalog reconciliation runs on the routing path, not via autodiscovery.
+- **A leaked registry is now reaped after every test, naming the culprit.**
+  Clearing credentials fixes today's writer; this is the guard for the next code
+  path that writes the pinned registry. Reaping happens *after* the test rather
+  than before, so the stderr warning names the test that actually did it instead
+  of the damage surfacing hundreds of tests later as an unrelated routing
+  assertion. The `.discovery.json` sidecar is reaped with it.
+- **`ensure_cursor_sdk` refuses to `npm install` into a git checkout.** Its
+  default prefix is `puppetmaster/..` — site-packages for a pip/pipx install,
+  but the *repo root* in a checkout, where `npm install --prefix` rewrote the
+  tracked `package.json` (bumping `@cursor/sdk` past its pinned range) so a
+  later `git commit -a` shipped a dependency change nobody asked for. An
+  explicit `package_root=` still installs anywhere, deliberately. This is a
+  user-visible behaviour change for anyone running from a checkout.
+- **`test_daemon_worker_mode_uses_warm_worker` no longer flakes under load** —
+  its `thread.join(timeout=3)` was a real-time budget on reaping an
+  already-finished job's thread. A genuine hang still fails the test; a busy
+  machine no longer does.
+
 ## v1.22.14
 
 Absorb of [@bsmi021](https://github.com/bsmi021) PR

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,23 +25,35 @@ keys.
   provider the developer disconnected in Settings shouldn't change what tests
   see either. Note `PUPPETMASTER_AUTODISCOVER=0` did *not* gate this path;
   catalog reconciliation runs on the routing path, not via autodiscovery.
-- **A leaked registry is now reaped after every test, naming the culprit.**
+- **A leaked registry now fails the test that caused it.** It is reaped so
+  later tests stay isolated, and the leak is reported as a failure of the
+  guilty test — reaping alone would *silence* the canary
+  (`test_models_path_points_at_missing_sentinel` can no longer fail once the
+  leak is always cleaned up before it looks). An `atexit` hook cannot do this:
+  CPython prints "Exception ignored in atexit callback" and still exits 0.
   Clearing credentials fixes today's writer; this is the guard for the next code
   path that writes the pinned registry. Reaping happens *after* the test rather
   than before, so the stderr warning names the test that actually did it instead
   of the damage surfacing hundreds of tests later as an unrelated routing
   assertion. The `.discovery.json` sidecar is reaped with it.
-- **`ensure_cursor_sdk` refuses to `npm install` into a git checkout.** Its
+- **`ensure_cursor_sdk` passes `--no-save`, and five tests stop shelling out to
+  real npm.** `npm install --prefix X` also *writes the manifest* at X. The
   default prefix is `puppetmaster/..` — site-packages for a pip/pipx install,
-  but the *repo root* in a checkout, where `npm install --prefix` rewrote the
-  tracked `package.json` (bumping `@cursor/sdk` past its pinned range) so a
-  later `git commit -a` shipped a dependency change nobody asked for. An
-  explicit `package_root=` still installs anywhere, deliberately. This is a
-  user-visible behaviour change for anyone running from a checkout.
-- **`test_daemon_worker_mode_uses_warm_worker` no longer flakes under load** —
-  its `thread.join(timeout=3)` was a real-time budget on reaping an
-  already-finished job's thread. A genuine hang still fails the test; a busy
-  machine no longer does.
+  but the repo root for an editable install, an sdist, or a Docker `COPY` of
+  the source, where it rewrote the project's own tracked `package.json`
+  (bumping `@cursor/sdk` past its pinned range) so a later `git commit -a`
+  shipped a dependency change nobody asked for. Node resolves `node_modules`
+  without reading that manifest, so `--no-save` costs nothing. Separately,
+  `SetupHooksStepTests` patched `install_cursor_mcp` but not
+  `ensure_cursor_sdk`, so five tests ran a real network install; they now patch
+  it. Measured on a `git archive` export: before, 7.9s and `@cursor/sdk`
+  bumped; after, 2.7s, manifest untouched, no `node_modules`.
+- **`test_daemon_worker_mode_uses_warm_worker` no longer flakes under load.**
+  Its `thread.join(timeout=3)` is a real-time budget on reaping an
+  already-finished job's thread. This was *not* the baseline failure above
+  (that was the routing cascade, five lines further down the test); it is a
+  separate flake that only became visible once the cascade was fixed. A genuine
+  hang still fails the test; a busy machine no longer does.
 
 ## v1.22.14
 

--- a/puppetmaster/installers.py
+++ b/puppetmaster/installers.py
@@ -124,6 +124,17 @@ class SdkBootstrapResult:
     location: Optional[str] = None
 
 
+def _default_package_root() -> Path:
+    """Where ``npm install --prefix`` points when the caller didn't say.
+
+    ``puppetmaster/..`` — site-packages for a pip/pipx install, which is the
+    directory Node's resolution walks up to from ``cursor_sdk_runner.mjs``.
+    Split out so the checkout guard below is testable without patching
+    ``__file__``.
+    """
+    return Path(__file__).resolve().parent.parent
+
+
 def ensure_cursor_sdk(
     root: Optional[Path] = None,
     *,
@@ -158,7 +169,21 @@ def ensure_cursor_sdk(
             "`puppetmaster install-cursor-mcp` to bootstrap @cursor/sdk",
         )
 
-    install_root = package_root or Path(__file__).resolve().parent.parent
+    install_root = package_root or _default_package_root()
+    # In a pip/pipx install that parent is site-packages, which is exactly
+    # where Node's resolution needs the SDK. In a git checkout it is the repo
+    # root, and `npm install --prefix <repo>` rewrites the *tracked*
+    # package.json (bumping @cursor/sdk to whatever satisfies the range) —
+    # so a later `git commit -a` silently ships a dependency bump nobody
+    # asked for. Refuse, unless the caller named the root deliberately.
+    if package_root is None and (install_root / ".git").exists():
+        return SdkBootstrapResult(
+            "skipped",
+            f"refusing to `npm install` into the git checkout at {install_root} "
+            "— it would rewrite the tracked package.json. Run this from an "
+            "installed copy, or pass package_root= to target a directory "
+            "deliberately.",
+        )
     try:
         completed = subprocess.run(
             # as_posix(): npm accepts forward slashes on every platform, and

--- a/puppetmaster/installers.py
+++ b/puppetmaster/installers.py
@@ -180,9 +180,11 @@ def ensure_cursor_sdk(
         return SdkBootstrapResult(
             "skipped",
             f"refusing to `npm install` into the git checkout at {install_root} "
-            "— it would rewrite the tracked package.json. Run this from an "
-            "installed copy, or pass package_root= to target a directory "
-            "deliberately.",
+            "— `--prefix` there rewrites the tracked package.json and a later "
+            "`git commit -a` would ship the dependency bump. This checkout "
+            f"already declares @cursor/sdk, so run `npm install` in "
+            f"{install_root} yourself (Node resolves it from there), or pass "
+            "package_root= to target a directory deliberately.",
         )
     try:
         completed = subprocess.run(

--- a/puppetmaster/installers.py
+++ b/puppetmaster/installers.py
@@ -129,7 +129,7 @@ def _default_package_root() -> Path:
 
     ``puppetmaster/..`` — site-packages for a pip/pipx install, which is the
     directory Node's resolution walks up to from ``cursor_sdk_runner.mjs``.
-    Split out so the checkout guard below is testable without patching
+    Split out so tests can point the default somewhere safe without patching
     ``__file__``.
     """
     return Path(__file__).resolve().parent.parent
@@ -170,28 +170,27 @@ def ensure_cursor_sdk(
         )
 
     install_root = package_root or _default_package_root()
-    # In a pip/pipx install that parent is site-packages, which is exactly
-    # where Node's resolution needs the SDK. In a git checkout it is the repo
-    # root, and `npm install --prefix <repo>` rewrites the *tracked*
-    # package.json (bumping @cursor/sdk to whatever satisfies the range) —
-    # so a later `git commit -a` silently ships a dependency bump nobody
-    # asked for. Refuse, unless the caller named the root deliberately.
-    if package_root is None and (install_root / ".git").exists():
-        return SdkBootstrapResult(
-            "skipped",
-            f"refusing to `npm install` into the git checkout at {install_root} "
-            "— `--prefix` there rewrites the tracked package.json and a later "
-            "`git commit -a` would ship the dependency bump. This checkout "
-            f"already declares @cursor/sdk, so run `npm install` in "
-            f"{install_root} yourself (Node resolves it from there), or pass "
-            "package_root= to target a directory deliberately.",
-        )
     try:
         completed = subprocess.run(
             # as_posix(): npm accepts forward slashes on every platform, and
             # native backslashes get mangled by Git-Bash-style shells on
             # Windows (same class of bug as the v0.9.34 hook-path fix).
-            [npm, "install", "@cursor/sdk", "--prefix", install_root.as_posix()],
+            # --no-save: we only need @cursor/sdk resolvable under
+            # <prefix>/node_modules. Without it npm also *writes the manifest*
+            # at the prefix — and when the prefix is a git checkout (an
+            # editable install, an sdist, a Docker COPY of the source) that is
+            # the repo's own tracked package.json, silently bumping @cursor/sdk
+            # past its pinned range so a later `git commit -a` ships a
+            # dependency change nobody asked for. Node resolution never reads
+            # that manifest, so skipping the write costs nothing.
+            [
+                npm,
+                "install",
+                "@cursor/sdk",
+                "--no-save",
+                "--prefix",
+                install_root.as_posix(),
+            ],
             capture_output=True,
             text=True,
             timeout=timeout_seconds,

--- a/tests/hermetic_env.py
+++ b/tests/hermetic_env.py
@@ -13,6 +13,7 @@ effect before exercising Puppetmaster code.
 from __future__ import annotations
 
 import atexit
+import contextlib
 import os
 import shutil
 import sys
@@ -30,6 +31,11 @@ _ATEXIT_REGISTERED = False
 # How many tests left a registry behind at the sentinel path (see
 # ``reap_leaked_registry``). Exposed for the harness's own tests.
 _LEAKED_REGISTRY_REAPS = 0
+# Test ids that leaked, kept for diagnostics (the failure itself is reported
+# against the guilty test -- see _fail_leaking_test).
+_LEAKED_REGISTRY_TESTS: list[str] = []
+# >0 while a test leaks on purpose (the reaper's own test).
+_EXPECT_REGISTRY_LEAK = 0
 
 # Host pins that short-circuit discovery / routing when left in place.
 _PIN_KEYS_TO_CLEAR = (
@@ -51,16 +57,40 @@ def _provider_credential_env_names() -> "tuple[str, ...]":
     rotation siblings (``OPENAI_API_KEY_2`` ...) and the presence vars that
     opt keyless local endpoints (Ollama / LM Studio) in.
     """
-    from puppetmaster.providers import PROVIDER_REGISTRY, _numbered_env_names
+    from puppetmaster.providers import PROVIDER_REGISTRY
+
+    try:
+        from puppetmaster.providers import _numbered_env_names
+    except ImportError:  # private helper; keep isolation working if it moves
+        def _numbered_env_names(name: str) -> "list[str]":
+            return [name] + [f"{name}_{i}" for i in range(2, 10)]
 
     names: list[str] = []
     for desc in PROVIDER_REGISTRY.values():
         for var in desc.api_key_env_vars:
             names.extend(_numbered_env_names(var))
         names.extend(desc.presence_env_vars)
+    # Not in PROVIDER_REGISTRY (it drives the Cursor *CLI/SDK* path, not a
+    # direct-API provider) but it still turns on plan-catalog discovery.
+    names.extend(_numbered_env_names("CURSOR_API_KEY"))
     # dict.fromkeys: de-dupe (gemini lists GOOGLE_API_KEY too) but keep order
     # stable so the restore path is deterministic.
     return tuple(dict.fromkeys(names))
+
+
+def _clear_provider_credentials(env) -> "list[str]":
+    """Remove every provider credential from ``env``; return what was removed.
+
+    Split out from :func:`apply_hermetic_isolation` so the behaviour is
+    testable on a fixture dict. Testing it against ``os.environ`` alone is
+    vacuous on a keyless machine (CI) — there the assertion holds whether or
+    not the clearing works.
+    """
+    removed = []
+    for key in _provider_credential_env_names():
+        if env.pop(key, None) is not None:
+            removed.append(key)
+    return removed
 
 
 def _sentinel_paths() -> "tuple[Path, ...]":
@@ -71,6 +101,50 @@ def _sentinel_paths() -> "tuple[Path, ...]":
 
     sentinel = Path(_ISOLATION_TMP) / "models-does-not-exist.json"
     return (sentinel, discovery_meta_path(sentinel))
+
+
+@contextlib.contextmanager
+def expect_registry_leak():
+    """Mark a deliberate leak so it doesn't fail the run at exit.
+
+    Only the harness's own test for the reaper should need this.
+    """
+    global _EXPECT_REGISTRY_LEAK
+    _EXPECT_REGISTRY_LEAK += 1
+    try:
+        yield
+    finally:
+        _EXPECT_REGISTRY_LEAK -= 1
+
+
+_LEAK_MESSAGE = (
+    "hermetic isolation was broken: this test wrote a model registry to "
+    "PUPPETMASTER_MODELS_PATH, which the suite pins at a path that must stay "
+    "absent. It was reaped so later tests stay isolated, but the write itself "
+    "is the bug — something under test called save_registry() against "
+    "default_registry_path(). With a provider credential in the environment "
+    "that is exactly how routing used to retarget the whole suite onto a live "
+    "API."
+)
+
+
+def _fail_leaking_test(case: unittest.TestCase, result) -> None:
+    """Record a leak as a failure of the test that caused it.
+
+    Reaping keeps later tests isolated, but on its own it would *silence* the
+    canary that caught this class of bug — with the reaper in place,
+    ``test_models_path_points_at_missing_sentinel`` can no longer fail, because
+    the leak is always cleaned up before it looks. So the leak still fails the
+    run; it just fails the guilty test instead of an innocent one downstream.
+
+    (An ``atexit`` hook cannot do this job: CPython prints "Exception ignored
+    in atexit callback" and still exits 0 — verified on 3.12 — so a leak would
+    report as a green run.)
+    """
+    if result is None:
+        return
+    error = AssertionError(f"{_LEAK_MESSAGE}\n(test: {case.id()})")
+    result.addFailure(case, (AssertionError, error, error.__traceback__))
 
 
 def reap_leaked_registry(test_id: str = "") -> bool:
@@ -98,6 +172,8 @@ def reap_leaked_registry(test_id: str = "") -> bool:
         reaped = True
     if reaped:
         _LEAKED_REGISTRY_REAPS += 1
+        if not _EXPECT_REGISTRY_LEAK:
+            _LEAKED_REGISTRY_TESTS.append(test_id or "<unknown test>")
         print(
             f"hermetic_env: {test_id or 'a test'} left a model registry at the "
             f"pinned sentinel path; reaped it so later tests stay isolated. "
@@ -150,11 +226,11 @@ def apply_hermetic_isolation(*, register_atexit: bool = True) -> None:
     # instead of the pinned adapter — while worker tests quietly execute
     # against the live API. CI is green precisely because it has no keys;
     # clearing them here is what makes a local run mean the same thing.
-    for key in _provider_credential_env_names():
-        os.environ.pop(key, None)
+    _clear_provider_credentials(os.environ)
 
     # Orchestrator plan-catalog auto-discovery shells out to the Cursor SDK
     # when CURSOR_API_KEY is set; tests that need it inject their own fetcher.
+    _ENV_BEFORE["PUPPETMASTER_AUTODISCOVER"] = os.environ.get("PUPPETMASTER_AUTODISCOVER")
     os.environ.setdefault("PUPPETMASTER_AUTODISCOVER", "0")
 
     # Keep process-local provider circuit state from leaking across tests.
@@ -192,17 +268,17 @@ def apply_hermetic_isolation(*, register_atexit: bool = True) -> None:
             reset_cursor_codegraph_invocation_cache()
         except Exception:
             pass
+        outcome = _ORIG_TESTCASE_RUN(self, result)
+        # Reap AFTER the test, not before: this attributes the leak to the test
+        # that actually wrote the registry, instead of the isolation silently
+        # absorbing it and the damage surfacing hundreds of tests later as an
+        # unrelated routing assertion.
         try:
-            return _ORIG_TESTCASE_RUN(self, result)
-        finally:
-            # Reap AFTER the test, not before: this way the warning names the
-            # test that actually wrote the registry, instead of the isolation
-            # silently absorbing it and the damage surfacing hundreds of tests
-            # later as an unrelated routing assertion.
-            try:
-                reap_leaked_registry(self.id())
-            except Exception:
-                pass
+            if reap_leaked_registry(self.id()) and not _EXPECT_REGISTRY_LEAK:
+                _fail_leaking_test(self, result if result is not None else outcome)
+        except Exception:
+            pass
+        return outcome
 
     unittest.TestCase.run = _hermetic_run  # type: ignore[method-assign]
 

--- a/tests/hermetic_env.py
+++ b/tests/hermetic_env.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import atexit
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -26,6 +27,9 @@ _ENV_BEFORE: dict[str, Optional[str]] = {}
 _ISOLATION_TMP: Optional[str] = None
 _ORIG_TESTCASE_RUN = None
 _ATEXIT_REGISTERED = False
+# How many tests left a registry behind at the sentinel path (see
+# ``reap_leaked_registry``). Exposed for the harness's own tests.
+_LEAKED_REGISTRY_REAPS = 0
 
 # Host pins that short-circuit discovery / routing when left in place.
 _PIN_KEYS_TO_CLEAR = (
@@ -33,7 +37,75 @@ _PIN_KEYS_TO_CLEAR = (
     "PUPPETMASTER_CODEGRAPH_JS",
     "PUPPETMASTER_STATE_DIR",
     "PUPPETMASTER_CURSOR_INPUT",
+    # A provider the developer disconnected in Marionette Settings must not
+    # change what the suite sees either — tests that care set it themselves.
+    "PUPPETMASTER_DISABLED_PROVIDERS",
 )
+
+
+def _provider_credential_env_names() -> "tuple[str, ...]":
+    """Every env var that can make a direct-API provider auto-routable.
+
+    Derived from ``PROVIDER_REGISTRY`` rather than hardcoded, so a provider
+    added later is covered without touching this file. Includes the numbered
+    rotation siblings (``OPENAI_API_KEY_2`` ...) and the presence vars that
+    opt keyless local endpoints (Ollama / LM Studio) in.
+    """
+    from puppetmaster.providers import PROVIDER_REGISTRY, _numbered_env_names
+
+    names: list[str] = []
+    for desc in PROVIDER_REGISTRY.values():
+        for var in desc.api_key_env_vars:
+            names.extend(_numbered_env_names(var))
+        names.extend(desc.presence_env_vars)
+    # dict.fromkeys: de-dupe (gemini lists GOOGLE_API_KEY too) but keep order
+    # stable so the restore path is deterministic.
+    return tuple(dict.fromkeys(names))
+
+
+def _sentinel_paths() -> "tuple[Path, ...]":
+    """The registry the harness promises is absent, plus its meta sidecar."""
+    if _ISOLATION_TMP is None:
+        return ()
+    from puppetmaster.model_registry import discovery_meta_path
+
+    sentinel = Path(_ISOLATION_TMP) / "models-does-not-exist.json"
+    return (sentinel, discovery_meta_path(sentinel))
+
+
+def reap_leaked_registry(test_id: str = "") -> bool:
+    """Delete any registry a test wrote at the pinned sentinel path.
+
+    ``hermetic_env`` points ``PUPPETMASTER_MODELS_PATH`` at a file that does
+    not exist, but nothing stops code under test from *creating* it: routing
+    persists a reconciled catalog through ``save_registry(...,
+    default_registry_path())``. When that happens the registry stays populated
+    for the rest of the process and every later "empty registry" assertion
+    fails hundreds of tests downstream of the one that actually did it.
+
+    So we reap after each test and name the culprit on stderr. Returns True if
+    something was reaped.
+    """
+    global _LEAKED_REGISTRY_REAPS
+    reaped = False
+    for path in _sentinel_paths():
+        try:
+            if not path.exists():
+                continue
+            path.unlink()
+        except OSError:
+            continue
+        reaped = True
+    if reaped:
+        _LEAKED_REGISTRY_REAPS += 1
+        print(
+            f"hermetic_env: {test_id or 'a test'} left a model registry at the "
+            f"pinned sentinel path; reaped it so later tests stay isolated. "
+            f"Something under test called save_registry() against "
+            f"default_registry_path().",
+            file=sys.stderr,
+        )
+    return reaped
 
 
 def apply_hermetic_isolation(*, register_atexit: bool = True) -> None:
@@ -60,12 +132,25 @@ def apply_hermetic_isolation(*, register_atexit: bool = True) -> None:
     _ENV_BEFORE[ONLY_ENV] = os.environ.get(ONLY_ENV)
     for key in _PIN_KEYS_TO_CLEAR:
         _ENV_BEFORE[key] = os.environ.get(key)
+    for key in _provider_credential_env_names():
+        _ENV_BEFORE[key] = os.environ.get(key)
 
     os.environ["PUPPETMASTER_MODELS_PATH"] = str(sentinel)
     os.environ["PUPPETMASTER_PROVIDER_HEALTH_PATH"] = str(health_db)
     os.environ["PUPPETMASTER_RATE_LIMIT_PATH"] = str(rate_limit_db)
     os.environ[ONLY_ENV] = ",".join(KNOWN_ADAPTERS)
     for key in _PIN_KEYS_TO_CLEAR:
+        os.environ.pop(key, None)
+
+    # A developer's own provider API keys must not reach the suite. With, say,
+    # GOOGLE_API_KEY set, ``available_providers()`` is non-empty, so the
+    # auto-route path in the orchestrator reconciles the curated agentic
+    # catalog, persists it to PUPPETMASTER_MODELS_PATH above (creating the
+    # "missing" sentinel), and every later routing assertion sees `agentic`
+    # instead of the pinned adapter — while worker tests quietly execute
+    # against the live API. CI is green precisely because it has no keys;
+    # clearing them here is what makes a local run mean the same thing.
+    for key in _provider_credential_env_names():
         os.environ.pop(key, None)
 
     # Orchestrator plan-catalog auto-discovery shells out to the Cursor SDK
@@ -107,7 +192,17 @@ def apply_hermetic_isolation(*, register_atexit: bool = True) -> None:
             reset_cursor_codegraph_invocation_cache()
         except Exception:
             pass
-        return _ORIG_TESTCASE_RUN(self, result)
+        try:
+            return _ORIG_TESTCASE_RUN(self, result)
+        finally:
+            # Reap AFTER the test, not before: this way the warning names the
+            # test that actually wrote the registry, instead of the isolation
+            # silently absorbing it and the damage surfacing hundreds of tests
+            # later as an unrelated routing assertion.
+            try:
+                reap_leaked_registry(self.id())
+            except Exception:
+                pass
 
     unittest.TestCase.run = _hermetic_run  # type: ignore[method-assign]
 

--- a/tests/test_hermetic_env.py
+++ b/tests/test_hermetic_env.py
@@ -1,6 +1,8 @@
 """Regression: unittest discover must isolate host Puppetmaster env pins."""
 from __future__ import annotations
 
+import contextlib
+import io
 import os
 import sys
 
@@ -49,6 +51,41 @@ class HermeticEnvIsolationTests(unittest.TestCase):
         self.assertEqual(leaked, [], f"provider credentials leaked into the suite: {leaked}")
         self.assertEqual(available_providers(), set())
 
+    def test_clearing_removes_credentials_from_a_populated_env(self) -> None:
+        """The assertion above is vacuous on a keyless machine.
+
+        On CI there are no provider keys, so "none leaked" holds whether or not
+        the clearing works. Drive the clearing over a fixture that definitely
+        has keys, so this fails on CI too if the mechanism breaks.
+        """
+        fake = {
+            "GOOGLE_API_KEY": "g",
+            "OPENROUTER_API_KEY": "o",
+            "ANTHROPIC_API_KEY": "a",
+            "OPENAI_API_KEY_3": "numbered sibling",
+            "CURSOR_API_KEY": "c",
+            "PATH": "/keep/me",
+        }
+        removed = hermetic_env._clear_provider_credentials(fake)
+
+        self.assertEqual(fake, {"PATH": "/keep/me"}, "non-credentials must survive")
+        for expected in (
+            "GOOGLE_API_KEY",
+            "OPENROUTER_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY_3",
+            "CURSOR_API_KEY",
+        ):
+            self.assertIn(expected, removed)
+
+        from puppetmaster.providers import available_providers
+
+        self.assertEqual(
+            available_providers(env={"GOOGLE_API_KEY": "g"}),
+            {"gemini"},
+            "control: a key really does make a provider available",
+        )
+
     def test_credential_names_are_derived_from_the_registry(self) -> None:
         """Derived, not hardcoded, so a provider added later is covered."""
         names = hermetic_env._provider_credential_env_names()
@@ -75,9 +112,6 @@ class HermeticEnvIsolationTests(unittest.TestCase):
         silently poisoning every later test. Reaping happens *after* each test
         so the warning names the culprit.
         """
-        import io
-        import contextlib
-
         from puppetmaster.model_registry import ModelSpec, save_registry
 
         sentinel = Path(os.environ["PUPPETMASTER_MODELS_PATH"])
@@ -101,7 +135,9 @@ class HermeticEnvIsolationTests(unittest.TestCase):
 
         stderr = io.StringIO()
         result = unittest.TestResult()
-        with contextlib.redirect_stderr(stderr):
+        # expect_registry_leak: this leak is deliberate, so it must not be
+        # reported as a failure the way an undeclared one is.
+        with contextlib.redirect_stderr(stderr), hermetic_env.expect_registry_leak():
             _LeakyTest().run(result)
 
         # Without these two the test passes vacuously when the leak never
@@ -121,6 +157,63 @@ class HermeticEnvIsolationTests(unittest.TestCase):
         before = hermetic_env._LEAKED_REGISTRY_REAPS
         self.assertFalse(hermetic_env.reap_leaked_registry("noop"))
         self.assertEqual(hermetic_env._LEAKED_REGISTRY_REAPS, before)
+
+    def test_a_real_leak_fails_the_test_that_caused_it(self) -> None:
+        """Reaping must not *silence* the canary.
+
+        Cleaning up after each test keeps later tests isolated, but it also
+        means test_models_path_points_at_missing_sentinel can no longer fail --
+        the leak is always gone before it looks. The write is still the bug, so
+        it has to fail the run somewhere. It fails the guilty test, at the
+        scene, instead of an innocent one hundreds of tests later.
+
+        (atexit cannot do this job: CPython prints "Exception ignored in atexit
+        callback" and still exits 0, so a leak would report as a green run.)
+        """
+        from puppetmaster.model_registry import ModelSpec, save_registry
+
+        sentinel = Path(os.environ["PUPPETMASTER_MODELS_PATH"])
+        leak = {}
+
+        class _LeakyTest(unittest.TestCase):
+            def runTest(self) -> None:  # noqa: N802 - unittest API
+                save_registry([ModelSpec(id="x/leaked", adapter="agentic",
+                                         adapter_model_name="leaked")])
+                leak["created"] = sentinel.exists()
+
+        # No expect_registry_leak() here: this is the undeclared case, which
+        # must be reported as a failure.
+        result = unittest.TestResult()
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            case = _LeakyTest()
+            case.run(result)
+
+        self.assertTrue(leak.get("created"), "the inner test never created the registry")
+        self.assertEqual(result.errors, [], f"inner test errored: {result.errors}")
+        self.assertEqual(
+            len(result.failures), 1, "an undeclared leak must fail its own test"
+        )
+        failed_case, message = result.failures[0]
+        self.assertIs(failed_case, case, "the failure must be attributed to the culprit")
+        self.assertIn("hermetic isolation was broken", message)
+        self.assertIn("save_registry", message)
+        self.assertFalse(result.wasSuccessful())
+
+    def test_declared_leaks_do_not_fail_their_test(self) -> None:
+        """The reaper's own test leaks on purpose; that must stay green."""
+        from puppetmaster.model_registry import ModelSpec, save_registry
+
+        class _DeliberateLeak(unittest.TestCase):
+            def runTest(self) -> None:  # noqa: N802 - unittest API
+                save_registry([ModelSpec(id="x/ok", adapter="agentic",
+                                         adapter_model_name="ok")])
+
+        result = unittest.TestResult()
+        with contextlib.redirect_stderr(io.StringIO()), hermetic_env.expect_registry_leak():
+            _DeliberateLeak().run(result)
+        self.assertTrue(result.wasSuccessful(), f"{result.failures}")
+
 
 
 if __name__ == "__main__":

--- a/tests/test_hermetic_env.py
+++ b/tests/test_hermetic_env.py
@@ -32,6 +32,96 @@ class HermeticEnvIsolationTests(unittest.TestCase):
     def test_autodiscover_disabled_for_suite(self) -> None:
         self.assertEqual(os.environ.get("PUPPETMASTER_AUTODISCOVER"), "0")
 
+    def test_no_provider_credentials_reach_the_suite(self) -> None:
+        """The developer's own API keys must not make a provider routable.
+
+        With one set, ``available_providers()`` is non-empty, the auto-route
+        path reconciles the curated agentic catalog into the registry, and
+        routing/worker tests silently retarget onto a live API.
+        """
+        from puppetmaster.providers import available_providers
+
+        leaked = [
+            name
+            for name in hermetic_env._provider_credential_env_names()
+            if os.environ.get(name)
+        ]
+        self.assertEqual(leaked, [], f"provider credentials leaked into the suite: {leaked}")
+        self.assertEqual(available_providers(), set())
+
+    def test_credential_names_are_derived_from_the_registry(self) -> None:
+        """Derived, not hardcoded, so a provider added later is covered."""
+        names = hermetic_env._provider_credential_env_names()
+        self.assertIn("GOOGLE_API_KEY", names)  # gemini's second var
+        self.assertIn("OPENROUTER_API_KEY", names)
+        self.assertIn("ANTHROPIC_API_KEY", names)
+        self.assertIn("AWS_BEARER_TOKEN_BEDROCK", names)
+        # numbered rotation siblings, and keyless-provider presence vars
+        self.assertIn("OPENAI_API_KEY_2", names)
+        presence = {
+            var
+            for desc in __import__(
+                "puppetmaster.providers", fromlist=["PROVIDER_REGISTRY"]
+            ).PROVIDER_REGISTRY.values()
+            for var in desc.presence_env_vars
+        }
+        self.assertTrue(presence.issubset(set(names)))
+        self.assertEqual(len(names), len(set(names)), "duplicate env names")
+
+    def test_reaper_deletes_a_registry_a_test_leaked(self) -> None:
+        """The guard for the next code path that writes the pinned registry.
+
+        Clearing credentials stops today's writer; this stops tomorrow's from
+        silently poisoning every later test. Reaping happens *after* each test
+        so the warning names the culprit.
+        """
+        import io
+        import contextlib
+
+        from puppetmaster.model_registry import ModelSpec, save_registry
+
+        sentinel = Path(os.environ["PUPPETMASTER_MODELS_PATH"])
+        before = hermetic_env._LEAKED_REGISTRY_REAPS
+        leak: dict[str, bool] = {}
+
+        class _LeakyTest(unittest.TestCase):
+            def runTest(self) -> None:  # noqa: N802 - unittest API
+                # Exactly what orchestrator._apply_auto_routing does: persist to
+                # default_registry_path(), which resolves to the sentinel.
+                save_registry(
+                    [
+                        ModelSpec(
+                            id="x/leaked",
+                            adapter="agentic",
+                            adapter_model_name="leaked",
+                        )
+                    ]
+                )
+                leak["created"] = sentinel.exists()
+
+        stderr = io.StringIO()
+        result = unittest.TestResult()
+        with contextlib.redirect_stderr(stderr):
+            _LeakyTest().run(result)
+
+        # Without these two the test passes vacuously when the leak never
+        # happens (a swallowed error in the inner test would leave the sentinel
+        # trivially absent).
+        self.assertEqual(result.errors, [], f"the leaking test itself errored: {result.errors}")
+        self.assertTrue(leak.get("created"), "the inner test never created the registry")
+
+        self.assertFalse(
+            sentinel.exists(), "the reaper left the leaked registry in place"
+        )
+        self.assertEqual(hermetic_env._LEAKED_REGISTRY_REAPS, before + 1)
+        self.assertIn("left a model registry", stderr.getvalue())
+        self.assertIn("_LeakyTest", stderr.getvalue(), "the warning must name the culprit")
+
+    def test_reaper_is_quiet_and_reports_false_when_nothing_leaked(self) -> None:
+        before = hermetic_env._LEAKED_REGISTRY_REAPS
+        self.assertFalse(hermetic_env.reap_leaked_registry("noop"))
+        self.assertEqual(hermetic_env._LEAKED_REGISTRY_REAPS, before)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -20844,63 +20844,56 @@ class EnsureCursorSdkTests(unittest.TestCase):
         self.assertEqual(result.status, "skipped")
         self.assertIn("npm not on PATH", result.detail)
 
-    def test_refuses_to_install_into_a_git_checkout(self) -> None:
-        """`npm install --prefix <repo>` rewrites the *tracked* package.json.
+    def test_npm_install_never_writes_the_manifest_at_the_prefix(self) -> None:
+        """`npm install --prefix X` also writes X/package.json without --no-save.
 
-        The default package root is ``puppetmaster/..``, which is site-packages
-        for a pip install but the repo root in a checkout — so running from a
-        checkout bumped @cursor/sdk in git and a later `git commit -a` shipped
-        a dependency change nobody asked for. Refuse unless the caller named
-        the root deliberately.
+        The default prefix is ``puppetmaster/..`` -- site-packages for a pip
+        install, but the *repo root* for an editable install, an sdist, or a
+        Docker COPY of the source. There it rewrote the project's own tracked
+        package.json, bumping @cursor/sdk past its pinned range so a later
+        `git commit -a` shipped a dependency change nobody asked for. Node
+        resolves node_modules without reading that manifest, so --no-save
+        costs nothing and is the fix.
         """
         from types import SimpleNamespace
 
         from puppetmaster.installers import ensure_cursor_sdk
 
         with TemporaryDirectory() as tmp:
-            checkout = Path(tmp) / "repo"
-            (checkout / "puppetmaster").mkdir(parents=True)
-            # A worktree's .git is a FILE, not a directory — cover that case,
-            # since it is exactly how this bug was found.
-            (checkout / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+            prefix = Path(tmp) / "repo"
+            prefix.mkdir()
+            manifest = prefix / "package.json"
+            original = '{"optionalDependencies": {"@cursor/sdk": "^1.0.26"}}'
+            manifest.write_text(original, encoding="utf-8")
             calls = []
 
-            def fake_run(cmd, **kwargs):  # pragma: no cover - must not run
+            def fake_run(cmd, **kwargs):
                 calls.append(cmd)
-                raise AssertionError("npm must not be invoked for a checkout")
+                return SimpleNamespace(returncode=0, stdout="added 7 packages", stderr="")
 
             with patch(
-                "puppetmaster.diagnostics._find_cursor_sdk_install", return_value=None
-            ), patch(
-                "puppetmaster.installers._default_package_root", return_value=checkout
-            ), patch(
-                "puppetmaster.installers.subprocess.run", side_effect=fake_run
-            ):
+                "puppetmaster.diagnostics._find_cursor_sdk_install",
+                side_effect=[None, prefix / "node_modules" / "@cursor" / "sdk"],
+            ), patch("puppetmaster.installers.subprocess.run", side_effect=fake_run):
                 result = ensure_cursor_sdk(
-                    Path(tmp), npm_executable="/usr/local/bin/npm"
+                    Path(tmp), package_root=prefix, npm_executable="/usr/local/bin/npm"
                 )
 
-            self.assertEqual(result.status, "skipped")
-            self.assertIn("git checkout", result.detail)
-            self.assertIn("package_root", result.detail)
-            self.assertEqual(calls, [], "npm was invoked against the checkout")
+            self.assertEqual(result.status, "installed")
+            self.assertIn(
+                "--no-save",
+                calls[0],
+                "without --no-save npm rewrites the manifest at the prefix",
+            )
+            # The flag must precede --prefix's value, not trail the whole
+            # command, or npm treats it as a package name.
+            self.assertLess(calls[0].index("--no-save"), calls[0].index("--prefix"))
+            self.assertEqual(
+                manifest.read_text(encoding="utf-8"),
+                original,
+                "the manifest at the prefix must be byte-identical afterwards",
+            )
 
-            # An explicit package_root is a deliberate choice: still allowed,
-            # even when it is the checkout.
-            with patch(
-                "puppetmaster.diagnostics._find_cursor_sdk_install", return_value=None
-            ), patch(
-                "puppetmaster.installers._default_package_root", return_value=checkout
-            ), patch(
-                "puppetmaster.installers.subprocess.run",
-                return_value=SimpleNamespace(returncode=0, stdout="ok", stderr=""),
-            ):
-                explicit = ensure_cursor_sdk(
-                    Path(tmp),
-                    package_root=checkout,
-                    npm_executable="/usr/local/bin/npm",
-                )
-            self.assertNotEqual(explicit.status, "skipped")
 
     def test_installs_via_npm_into_package_root(self) -> None:
         from types import SimpleNamespace
@@ -20927,7 +20920,14 @@ class EnsureCursorSdkTests(unittest.TestCase):
         self.assertEqual(result.location, str(sdk_path))
         self.assertEqual(
             calls[0],
-            ["/usr/local/bin/npm", "install", "@cursor/sdk", "--prefix", "/fake/site-packages"],
+            [
+                "/usr/local/bin/npm",
+                "install",
+                "@cursor/sdk",
+                "--no-save",
+                "--prefix",
+                "/fake/site-packages",
+            ],
         )
 
     def test_error_when_npm_fails(self) -> None:
@@ -20941,9 +20941,6 @@ class EnsureCursorSdkTests(unittest.TestCase):
         with TemporaryDirectory() as tmp, \
                 patch("puppetmaster.diagnostics._find_cursor_sdk_install", return_value=None), \
                 patch("puppetmaster.installers.subprocess.run", side_effect=fake_run):
-            # Explicit package_root: without one the default is the repo root,
-            # and running the suite from a checkout now (correctly) refuses to
-            # npm-install there — see test_refuses_to_install_into_a_git_checkout.
             result = ensure_cursor_sdk(
                 Path("/tmp"),
                 package_root=Path(tmp),
@@ -25688,7 +25685,9 @@ class SetupHooksStepTests(unittest.TestCase):
             cwd0 = Path.cwd()
             try:
                 os.chdir(tmp)
-                with patch.object(cli, "install_cursor_mcp", return_value=_Res()), \
+                with patch.object(cli, "ensure_cursor_sdk", return_value=MagicMock(
+                            status="unchanged", detail="stubbed: no real npm in tests")), \
+                        patch.object(cli, "install_cursor_mcp", return_value=_Res()), \
                         patch.object(cli, "install_codex_mcp", return_value=_Res()), \
                         patch.object(cli, "install_claude_mcp", return_value=_Res()), \
                         patch.object(cli, "resolve_claude_command", return_value="claude"), \
@@ -25713,7 +25712,9 @@ class SetupHooksStepTests(unittest.TestCase):
             cwd0 = Path.cwd()
             try:
                 os.chdir(tmp)
-                with patch.object(cli, "install_cursor_mcp", return_value=_Res()), \
+                with patch.object(cli, "ensure_cursor_sdk", return_value=MagicMock(
+                            status="unchanged", detail="stubbed: no real npm in tests")), \
+                        patch.object(cli, "install_cursor_mcp", return_value=_Res()), \
                         patch.object(cli, "install_codex_mcp", return_value=_Res()), \
                         patch("puppetmaster.platform_lock.is_configured", return_value=True), \
                         patch("puppetmaster.platform_lock.enabled_adapters", return_value={"cursor"}):
@@ -25736,7 +25737,9 @@ class SetupHooksStepTests(unittest.TestCase):
             home = Path(home_tmp)
             try:
                 os.chdir(tmp)
-                with patch.object(cli, "install_cursor_mcp", return_value=_Res()), \
+                with patch.object(cli, "ensure_cursor_sdk", return_value=MagicMock(
+                            status="unchanged", detail="stubbed: no real npm in tests")), \
+                        patch.object(cli, "install_cursor_mcp", return_value=_Res()), \
                         patch.object(cli, "install_codex_mcp", return_value=_Res()), \
                         patch("puppetmaster.platform_lock.is_configured", return_value=True), \
                         patch("puppetmaster.platform_lock.enabled_adapters", return_value={"cursor"}), \
@@ -25770,7 +25773,9 @@ class SetupHooksStepTests(unittest.TestCase):
             cwd0 = Path.cwd()
             try:
                 os.chdir(tmp)
-                with patch.object(cli, "install_cursor_mcp", return_value=_Res()), \
+                with patch.object(cli, "ensure_cursor_sdk", return_value=MagicMock(
+                            status="unchanged", detail="stubbed: no real npm in tests")), \
+                        patch.object(cli, "install_cursor_mcp", return_value=_Res()), \
                         patch.object(cli, "install_codex_mcp", return_value=_Res()), \
                         patch.object(cli, "install_hermes_mcp", return_value=_Res()), \
                         patch.object(cli, "install_hermes_hooks", side_effect=fake_hermes_hooks), \

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -2320,7 +2320,11 @@ class PuppetmasterTests(unittest.TestCase):
                 roles=["explore"],
                 worker_id="daemon-test",
             ).run(max_tasks=1, max_idle_seconds=2)
-            thread.join(timeout=3)
+            # Generous budget on purpose: this only bounds how long we wait for
+            # an already-finished job's thread to be reaped, so a large value
+            # masks nothing (a genuine hang still fails, just later) while a
+            # tight one flakes whenever the machine is busy.
+            thread.join(timeout=30)
 
             self.assertFalse(thread.is_alive())
             self.assertNotIn("error", result_holder)
@@ -20840,6 +20844,64 @@ class EnsureCursorSdkTests(unittest.TestCase):
         self.assertEqual(result.status, "skipped")
         self.assertIn("npm not on PATH", result.detail)
 
+    def test_refuses_to_install_into_a_git_checkout(self) -> None:
+        """`npm install --prefix <repo>` rewrites the *tracked* package.json.
+
+        The default package root is ``puppetmaster/..``, which is site-packages
+        for a pip install but the repo root in a checkout — so running from a
+        checkout bumped @cursor/sdk in git and a later `git commit -a` shipped
+        a dependency change nobody asked for. Refuse unless the caller named
+        the root deliberately.
+        """
+        from types import SimpleNamespace
+
+        from puppetmaster.installers import ensure_cursor_sdk
+
+        with TemporaryDirectory() as tmp:
+            checkout = Path(tmp) / "repo"
+            (checkout / "puppetmaster").mkdir(parents=True)
+            # A worktree's .git is a FILE, not a directory — cover that case,
+            # since it is exactly how this bug was found.
+            (checkout / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+            calls = []
+
+            def fake_run(cmd, **kwargs):  # pragma: no cover - must not run
+                calls.append(cmd)
+                raise AssertionError("npm must not be invoked for a checkout")
+
+            with patch(
+                "puppetmaster.diagnostics._find_cursor_sdk_install", return_value=None
+            ), patch(
+                "puppetmaster.installers._default_package_root", return_value=checkout
+            ), patch(
+                "puppetmaster.installers.subprocess.run", side_effect=fake_run
+            ):
+                result = ensure_cursor_sdk(
+                    Path(tmp), npm_executable="/usr/local/bin/npm"
+                )
+
+            self.assertEqual(result.status, "skipped")
+            self.assertIn("git checkout", result.detail)
+            self.assertIn("package_root", result.detail)
+            self.assertEqual(calls, [], "npm was invoked against the checkout")
+
+            # An explicit package_root is a deliberate choice: still allowed,
+            # even when it is the checkout.
+            with patch(
+                "puppetmaster.diagnostics._find_cursor_sdk_install", return_value=None
+            ), patch(
+                "puppetmaster.installers._default_package_root", return_value=checkout
+            ), patch(
+                "puppetmaster.installers.subprocess.run",
+                return_value=SimpleNamespace(returncode=0, stdout="ok", stderr=""),
+            ):
+                explicit = ensure_cursor_sdk(
+                    Path(tmp),
+                    package_root=checkout,
+                    npm_executable="/usr/local/bin/npm",
+                )
+            self.assertNotEqual(explicit.status, "skipped")
+
     def test_installs_via_npm_into_package_root(self) -> None:
         from types import SimpleNamespace
 
@@ -20876,9 +20938,17 @@ class EnsureCursorSdkTests(unittest.TestCase):
         def fake_run(cmd, **kwargs):
             return SimpleNamespace(returncode=1, stdout="", stderr="npm ERR! network timeout")
 
-        with patch("puppetmaster.diagnostics._find_cursor_sdk_install", return_value=None), \
+        with TemporaryDirectory() as tmp, \
+                patch("puppetmaster.diagnostics._find_cursor_sdk_install", return_value=None), \
                 patch("puppetmaster.installers.subprocess.run", side_effect=fake_run):
-            result = ensure_cursor_sdk(Path("/tmp"), npm_executable="/usr/local/bin/npm")
+            # Explicit package_root: without one the default is the repo root,
+            # and running the suite from a checkout now (correctly) refuses to
+            # npm-install there — see test_refuses_to_install_into_a_git_checkout.
+            result = ensure_cursor_sdk(
+                Path("/tmp"),
+                package_root=Path(tmp),
+                npm_executable="/usr/local/bin/npm",
+            )
         self.assertEqual(result.status, "error")
         self.assertIn("npm ERR! network timeout", result.detail)
 


### PR DESCRIPTION
## The bug

On any developer machine with an LLM API key, the test suite silently retargeted itself onto **live provider APIs** — and 13 tests failed as a result. CI never saw it, because CI has no keys.

`tests/hermetic_env.py` isolates the suite from the host's *Puppetmaster* config (`PUPPETMASTER_*` pins, a real `~/.puppetmaster/models.json`, in-flight Cursor worker env) but not from the host's *provider credentials*. The chain:

1. `GOOGLE_API_KEY` (or any provider key) is set → `providers.available_providers()` is non-empty.
2. Any plain `Orchestrator.run()` — dozens of tests do this — reaches `_apply_auto_routing`, where `reconcile_agentic_catalog` merges the curated agentic catalog and persists it via `save_registry(..., default_registry_path())`.
3. `default_registry_path()` resolves `$PUPPETMASTER_MODELS_PATH` — **the sentinel the harness had just created as deliberately missing**.
4. The registry stays populated with `agentic/gemini-*` for the rest of the process. Every later "empty registry" / "routes to claude-code|cursor|local" assertion sees `agentic`, and worker tests execute against the live API instead of the local stub.

Note `PUPPETMASTER_AUTODISCOVER=0` does **not** gate this — catalog reconciliation runs on the routing path, not via autodiscovery.

Instrumented proof — one ordinary `Orchestrator.run()` after importing `hermetic_env` exactly as the suite does:

```
sentinel        : ...\pm-test-empty-b0jra772\models-does-not-exist.json
exists at start : False
!!! save_registry() TARGETING THE SENTINEL !!!
    orchestrator.py:358 run -> :1479 _create_tasks -> :1704 _apply_auto_routing
exists after run: True    2 models: ['agentic/gemini-2-5-flash', 'agentic/gemini-2-5-pro']
```

Measured on one developer machine, same commit (`ad8b942`), quiet:

| | keys set | keys cleared |
|---|---|---|
| Result | **13 failures** | OK |
| Runtime | 820s | 464s |
| Tracked tree | `package.json` mutated | clean |

Nine of the 13 are routing assertions seeing `agentic`; four are tests where a real adapter actually ran. The 17x runtime gap on the affected tests (182s → 11s) is the tell — that was billable network traffic, and it is also why two of those tests looked "flaky": a live model answered differently each run.

## The fix

- **Provider credentials are cleared for the suite**, derived from `PROVIDER_REGISTRY` rather than hardcoded, so a provider added later is covered without touching the harness. Includes numbered rotation siblings (`OPENAI_API_KEY_2` …), the presence vars that opt keyless local endpoints (Ollama / LM Studio) in, and `CURSOR_API_KEY`. `PUPPETMASTER_DISABLED_PROVIDERS` is cleared too — a provider disconnected in Settings shouldn't change what tests see either.
- **A leaked registry now fails the test that caused it.** Clearing credentials fixes today's writer; this guards the next one. It is reaped so later tests stay isolated, but reaping *alone* would silence the canary — once the leak is always cleaned up before `test_models_path_points_at_missing_sentinel` looks, that test can never fail again.
- **`ensure_cursor_sdk` passes `--no-save`**, and five tests stop shelling out to real npm. See below.
- **`test_daemon_worker_mode_uses_warm_worker`** no longer flakes under load — its `thread.join(timeout=3)` is a real-time budget on reaping an already-finished job's thread. This was *not* the baseline failure (that was the cascade, five lines further down); it is a separate flake that only became visible once the cascade was fixed.

## Acceptance

Full suite on this branch with `GOOGLE_API_KEY`/`OPENROUTER_API_KEY` **still set** — the exact condition that produced 13 failures:

```
Ran 1989 tests in 245.524s
OK (skipped=14)
git status --porcelain -> (empty)
leaked-registry warnings: 0
```

(1989 vs 1929 because `main` moved from `ad8b942` to `b8048b4` and this PR adds tests; the A/B pair above is commit-matched, this run is not.)

## Two things an adversarial review corrected mid-PR

**The npm culprit was never the provider keys.** My first pass concluded the tracked-`package.json` rewrite was downstream of the same root cause, because the keys-cleared run had a clean tree. That baseline was **contaminated** — the earlier run had already left `node_modules/@cursor/sdk`, so the next one took `ensure_cursor_sdk`'s `"unchanged"` early return and never shelled out. The real cause is independent: `SetupHooksStepTests` patches `install_cursor_mcp` but **not** `ensure_cursor_sdk`, so `commands_install.py:901` runs a real `npm install` in five tests, no provider involved.

That also means my first fix — refusing to install into a git checkout — fixed the wrong thing. It missed the sdist / Docker `COPY` / site-packages cases (a `git archive` export has no `.git` and still network-installs) and broke editable installs, whose default prefix *is* a checkout, with no CLI flag to override. Replaced with `npm install --no-save`, which leaves the manifest byte-identical everywhere and still installs, plus patching those five tests.

Measured on a clean `git archive` export:

| | `main` | this branch |
|---|---|---|
| `SetupHooksStepTests` | 7.9s | 2.7s |
| `package.json` | **bumped ^1.0.26 → ^1.0.28** | untouched |
| `node_modules` | created | none |

**Reaping silenced the canary.** Injecting a leaking test into both trees:

| | which test fails |
|---|---|
| `main` | `test_models_path_points_at_missing_sentinel` — an innocent test; the culprit passes |
| this branch | `test_writes_the_registry` — the culprit itself |

Both exit non-zero, so nothing is hidden; the failure just moved to the scene. An `atexit` hook cannot do this job — CPython prints `Exception ignored in atexit callback` and **still exits 0** (verified on 3.12), so a broken-isolation run would report green.

## Notes for review

- **`--no-save` is a user-visible change** for anyone whose install prefix is a writable checkout. Node resolves `node_modules` without reading the manifest, so the SDK still works; only the manifest write stops.
- **One question rather than a change:** `orchestrator.py:1697-1706` writes a user-global file as a side effect of routing a job, wrapped in `except Exception: pass`. That is deliberate and documented, and real users benefit — but it means running a swarm silently mutates `~/.puppetmaster/models.json` and a failure to do so is unobservable. The suite is just the first consumer to notice. Worth a look, not filed as a defect.
- The bedrock entry is covered via `AWS_BEARER_TOKEN_BEDROCK`; `~/.aws` IAM auth is separately held out by the provider-health DB pin the harness already sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
