### PR TITLE
Add Antigravity CLI adapter (agy) with Gemini 3.7 / 3.6 / 3.5 / 3.1 Pro support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/professorpalmer/Puppetmaster/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://github.com/professorpalmer/Puppetmaster/blob/main/pyproject.toml)
 
-Puppetmaster runs multi-step engineering work through the agent tools you already use: Cursor, Claude Code, Codex, Hermes, or a provider API. It starts independent workers, routes tasks to an available model, and stores their typed results in SQLite so jobs can be inspected and resumed. It is aimed at developers who want durable state and reviewable output for repository investigations, audits, refactors, and implementations.
+Puppetmaster runs multi-step engineering work through the agent tools you already use: Cursor, Claude Code, Codex, Hermes, Antigravity (Gemini 3.7 / 3.6 / 3.5 / 3.1 Pro), or a provider API. It starts independent workers, routes tasks to an available model, and stores their typed results in SQLite so jobs can be inspected and resumed. It is aimed at developers who want durable state and reviewable output for repository investigations, audits, refactors, and implementations.
 
 ## Measured results
 
@@ -38,9 +38,9 @@ puppetmaster setup               # installs MCP tools, rules, and hooks
 puppetmaster setup --platforms cursor
 ```
 
-Restart Cursor, Codex, Claude, or Hermes after setup. The host then has the `puppetmaster_*` MCP tools and, where supported, hooks that suggest delegation for larger tasks. Disable those hooks with `PUPPETMASTER_AUTO_INVOKE_DISABLED=1`. For CI, use `--platforms <comma-list>` or `--platforms all`. Add another adapter later with `puppetmaster platform enable <name>`.
+Restart Cursor, Codex, Claude, Antigravity, or Hermes after setup. The host then has the `puppetmaster_*` MCP tools and, where supported, hooks that suggest delegation for larger tasks. Disable those hooks with `PUPPETMASTER_AUTO_INVOKE_DISABLED=1`. For CI, use `--platforms <comma-list>` or `--platforms all`. Add another adapter later with `puppetmaster platform enable <name>`.
 
-The built-in `agentic` adapter needs only a provider API key, so it can run without an external CLI. See [adapter setup](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/ADAPTERS.md) for provider and Hermes details.
+The built-in `agentic` adapter needs only a provider API key, so it can run without an external CLI. See [adapter setup](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/ADAPTERS.md) for provider, Antigravity, and Hermes details.
 
 ## Quickstart
 
@@ -76,13 +76,13 @@ More recipes are in [DAILY_DRIVER.md](https://github.com/professorpalmer/Puppetm
 Puppetmaster is a supervisor and job store for agent CLIs and provider adapters:
 
 ```text
-Cursor / Claude Code / Codex / Hermes / agentic
-        |
-        v
-supervisor -> model router -> independent workers -> SQLite artifacts
-                                                   |
-                                                   v
-                                            stitched summary
+Cursor / Claude Code / Codex / Hermes / Antigravity / agentic
+                                |
+                                v
+      supervisor -> model router -> independent workers -> SQLite artifacts
+                                                                |
+                                                                v
+                                                         stitched summary
 ```
 
 Workers claim tasks, write artifacts containing payloads and evidence, and do not share one growing transcript. The parent agent receives the stitched result and can inspect the stored artifacts with:
@@ -113,6 +113,7 @@ The [docs index](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/
 - [FEATURES.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/FEATURES.md) — adapters and shipped features
 - [SECURITY.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/SECURITY.md) — safety and threat model
 - [DASHBOARD.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/DASHBOARD.md) — live job dashboard
+- [CONCURRENT_SESSIONS.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/CONCURRENT_SESSIONS.md) — operating concurrent agent sessions, state scope, dashboard URLs, and worktrees
 - [OUTPUT_STYLE.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/OUTPUT_STYLE.md) and [COMPRESSION.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/COMPRESSION.md) — output and context options
 - [MOBILE.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/MOBILE.md) — watching jobs from a phone
 - [RESEARCH.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/RESEARCH.md) — durable autoresearch claims, runs, publishing, and verification
@@ -128,7 +129,7 @@ pip uninstall puppetmaster-ai   # or: pipx uninstall puppetmaster-ai
 
 ## Status
 
-Puppetmaster is a daily-driver beta at **v1.22.15**, suitable for supervised local engineering rather than hosted multi-user use. The current release includes SQLite-backed jobs, Cursor Agent MCP support, Grok Bot remote MCP (streamable HTTP pilot path), full-edit adapters, live-site browser swarms (Hermes preferred; agentic/OpenRouter via stdlib CDP), durable autoresearch claim/run/publish/verify loops, constrained model routing with optional evidence-backed role scorecards and a SWE-bench Bash Only community-prior connector (issue #28 / PR #30; Grok 4.6 remains the Cursor workhorse for ambitious and agentic work), shared verified context (admitted gists + dashboard Frontier), passive provider rate-limit harvest, AWS Bedrock, OpenCode Go, and Marionette-keyed Z.AI / MiniMax / NVIDIA NIM providers through the agentic adapter. Codex and Claude Code now send large prompts on stdin so Windows `CreateProcess` no longer fails with WinError 206. Spawned workers are exempt from the delegate-first gate so they do not try to start a swarm they cannot reach. v1.22.12 honors advertised swarm timeouts on `run` / `swarm` / `start_cursor_swarm` (instead of a silent 90s / 270s fallback), uses an explicit `max_timeout_seconds` as given, and reports the limit that actually killed the worker. v1.22.13 makes `puppetmaster dashboard` exit on Ctrl-C on Windows and release its listening socket. v1.22.15 stops the test suite from retargeting onto live provider APIs when a developer machine has keys, and `ensure_cursor_sdk` no longer rewrites tracked `package.json`. See the [feature matrix](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/FEATURES.md), [research guide](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/RESEARCH.md), [Grok Bot harness](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/GROK_BOT.md), and [CHANGELOG.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/CHANGELOG.md) for the current details.
+Puppetmaster is a daily-driver beta at **v1.22.15**, suitable for supervised local engineering rather than hosted multi-user use. The current release includes SQLite-backed jobs, Cursor Agent MCP support, Grok Bot remote MCP (streamable HTTP pilot path), full-edit adapters (including Google Antigravity CLI `agy` with Gemini 3.7 / 3.6 / 3.5 / 3.1 Pro), live-site browser swarms (Hermes preferred; agentic/OpenRouter via stdlib CDP), durable autoresearch claim/run/publish/verify loops, constrained model routing with optional evidence-backed role scorecards and a SWE-bench Bash Only community-prior connector (issue #28 / PR #30; Grok 4.6 remains the Cursor workhorse for ambitious and agentic work), shared verified context (admitted gists + dashboard Frontier), passive provider rate-limit harvest, AWS Bedrock, OpenCode Go, and Marionette-keyed Z.AI / MiniMax / NVIDIA NIM providers through the agentic adapter. Codex and Claude Code now send large prompts on stdin so Windows `CreateProcess` no longer fails with WinError 206. Spawned workers are exempt from the delegate-first gate so they do not try to start a swarm they cannot reach. v1.22.12 honors advertised swarm timeouts on `run` / `swarm` / `start_cursor_swarm` (instead of a silent 90s / 270s fallback), uses an explicit `max_timeout_seconds` as given, and reports the limit that actually killed the worker. v1.22.13 makes `puppetmaster dashboard` exit on Ctrl-C on Windows and release its listening socket. v1.22.15 stops the test suite from retargeting onto live provider APIs when a developer machine has keys, and `ensure_cursor_sdk` no longer rewrites tracked `package.json`. See the [feature matrix](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/FEATURES.md), [research guide](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/RESEARCH.md), [Grok Bot harness](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/GROK_BOT.md), and [CHANGELOG.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/CHANGELOG.md) for the current details.
 
 PyPI uses the package name [`puppetmaster-ai`](https://pypi.org/project/puppetmaster-ai/); the import name, CLI, and repository use `puppetmaster`.
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -214,6 +214,37 @@ If it returns `failure=dirty_worktree` in implement mode, run from a clean tree 
 
 When a Hermes implement worker edits tracked files, Puppetmaster records a `patch` artifact alongside the verification artifact.
 
+### `antigravity`
+
+Runs the Google Antigravity CLI (`agy --output-format json`) headlessly in non-interactive mode. Supports Gemini 3.7 Flash (`gemini-3.7-flash`), Gemini 3.6 Flash, Gemini 3.5 Flash, and Gemini 3.1 Pro with automatic reasoning effort mapping (`high`, `medium`, `low`).
+
+Two execution modes:
+- **`plan`** (analyze / read-only): Executes audit or inspection queries without modifying the working tree, extracting structured findings, risks, and decisions.
+- **`accept-edits`** (implement / full-edit): Passes `--dangerously-skip-permissions` to allow full workspace edits and captures the resulting diff as a `PATCH` artifact.
+
+Telemetry and Billing:
+- Captures input tokens, output tokens, thinking/reasoning tokens, and cache read tokens directly from the CLI JSON response.
+- Billing is automatically detected as `plan` when running on an authenticated `agy` session, or `api` when `GEMINI_API_KEY` / `GOOGLE_API_KEY` is present.
+
+Requirements:
+- `agy` CLI installed and on PATH, or `AGY_COMMAND` / `ANTIGRAVITY_COMMAND` / `payload.executable` set.
+- Antigravity session authenticated or `GEMINI_API_KEY` / `GOOGLE_API_KEY` set.
+
+```json
+{
+  "role": "gemini-audit",
+  "instruction": "Audit auth module and identify token expiration issues.",
+  "adapter": "antigravity",
+  "payload": {
+    "model": "gemini-3.7-flash",
+    "effort": "high",
+    "mode": "plan",
+    "cwd": ".",
+    "timeout_seconds": 300
+  }
+}
+```
+
 ### `agentic`
 
 Runs Puppetmaster's **standalone, provider-agnostic worker**: an in-process tool-use loop that calls provider HTTP APIs directly with your own API key (or AWS IAM for Bedrock). No external agent CLI (no Cursor, Claude Code, Codex, or Hermes binary required) — just a visible provider credential such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `OPENROUTER_API_KEY`, `OPENCODE_GO_API_KEY`, `ZAI_API_KEY` / `GLM_API_KEY` / `Z_AI_API_KEY`, `MINIMAX_API_KEY`, `NVIDIA_API_KEY`, or AWS Bedrock (`AWS_BEARER_TOKEN_BEDROCK` / `AWS_ACCESS_KEY_ID`+`AWS_SECRET_ACCESS_KEY` / `~/.aws`, with `provider=bedrock`).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,20 @@ Adds first-class support for running Google Antigravity CLI (`agy`) as an extern
 - **Structured token telemetry & billing**: Captures input tokens, output tokens, thinking/reasoning tokens, and cache read tokens directly from `agy` output into `VERIFICATION` artifacts. Implements billing posture detection in `platform_billing.py` (`plan` for subscription sessions, `api` when `GEMINI_API_KEY`/`GOOGLE_API_KEY` is present).
 - **Diagnostics and failure handling**: Integrated into `puppetmaster doctor`, adapter discovery, platform lock (`KNOWN_ADAPTERS`), and curated static catalogs (`CURATED_CATALOGS["antigravity"]`).
 
+**Fix: MCP jobs that completed successfully could still look hung or crashed to
+Codex and Claude clients.**
+
+- `puppetmaster_live_artifacts_follow` now returns terminal job state
+  immediately instead of waiting for an artifact that can never arrive and
+  reporting a false timeout.
+- Final JSON-RPC responses and keepalive notifications now share one serialized,
+  guarded stdio writer; a disconnected client no longer leaks an unobserved
+  `BrokenPipeError` / `OSError` from a worker-thread future.
+- On Windows, the default Codex adapter launch resolves the npm batch shim to
+  `node.exe` plus `@openai/codex/bin/codex.js`, keeping Puppetmaster in direct
+  ownership of the child process and its pipes. Explicit `CODEX_COMMAND` and
+  task executable overrides retain their existing command semantics.
+
 ## v1.22.15
 
 Absorb of [@bsmi021](https://github.com/bsmi021) PR

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,14 @@
+## Unreleased
+
+**Feature: Antigravity CLI adapter (`agy`) with Gemini 3.7 / 3.6 / 3.5 / 3.1 Pro integration.**
+
+Adds first-class support for running Google Antigravity CLI (`agy`) as an external worker adapter across Puppetmaster swarms, model routing, and task execution.
+
+- **Non-interactive execution lifecycle**: Launches `agy --output-format json` in headless print mode. In `implement` mode, passes `--mode accept-edits --dangerously-skip-permissions` to allow full repository edits and captures resulting changes as `PATCH` artifacts via git diff. In `analyze` mode, runs under `--mode plan` to emit structured findings, risks, and decisions without dirtying the working tree.
+- **Thinking / Effort resolution**: Seamlessly maps reasoning effort (`high`, `medium`, `low`) for Gemini 3.7 Flash (`gemini-3.7-flash`), Gemini 3.6 Flash, Gemini 3.5 Flash, and Gemini 3.1 Pro, defaulting to `high` effort when required by the model.
+- **Structured token telemetry & billing**: Captures input tokens, output tokens, thinking/reasoning tokens, and cache read tokens directly from `agy` output into `VERIFICATION` artifacts. Implements billing posture detection in `platform_billing.py` (`plan` for subscription sessions, `api` when `GEMINI_API_KEY`/`GOOGLE_API_KEY` is present).
+- **Diagnostics and failure handling**: Integrated into `puppetmaster doctor`, adapter discovery, platform lock (`KNOWN_ADAPTERS`), and curated static catalogs (`CURATED_CATALOGS["antigravity"]`).
+
 ## v1.22.15
 
 Absorb of [@bsmi021](https://github.com/bsmi021) PR

--- a/docs/CONCURRENT_SESSIONS.md
+++ b/docs/CONCURRENT_SESSIONS.md
@@ -1,0 +1,105 @@
+# Concurrent sessions and dashboards
+
+Puppetmaster is safe to use from several agent conversations and command
+shells at once, provided each operation uses an intentional workspace and
+state scope. This page is the operator contract for that situation.
+
+## Project scope is the default
+
+Without an explicit state override, runtime state is project-scoped: jobs,
+artifacts, promoted memory, streams, and the ordinary dashboard belong to the
+workspace selected for the operation. Separate repositories and separate Git
+worktrees therefore receive separate default state directories.
+
+For **write-side commands that accept `--cwd`**, the target workspace selects
+the default state directory as well as the worker's execution directory:
+
+```bash
+python -m puppetmaster swarm "Review the service" --cwd /path/to/project
+```
+
+The job above belongs to `/path/to/project`, even when the invoking shell is
+elsewhere. Run `python -m puppetmaster state` from that target workspace to
+print its default state location.
+
+This does not make separate conversations a security boundary. Processes under
+the same user can still share machine resources and explicitly user-global
+configuration. Treat project-scoped state as an operational isolation boundary,
+not a multi-user tenancy guarantee.
+
+## Explicit state overrides are deliberate sharing
+
+`--state-dir` and `PUPPETMASTER_STATE_DIR` override the project default. Use
+one only when sharing a state directory is intentional, such as a controlled
+CI location. A shared override shares jobs, artifacts, promoted memory, and a
+project-scoped dashboard.
+
+For compatibility, a **relative** explicit `--state-dir` value or relative
+`PUPPETMASTER_STATE_DIR` is still resolved from the launcher shell's current
+directory, not from `--cwd`. Prefer an absolute override when scripting, or
+change into the directory that should anchor a relative override:
+
+```bash
+python -m puppetmaster --state-dir C:/ci/puppetmaster-state swarm "Audit" --cwd C:/src/project
+```
+
+## Dashboard scope and port selection
+
+`python -m puppetmaster dashboard` shows only the current project's state by
+default. It does not discover every job on the machine. Use the aggregate view
+only when that is what you intend:
+
+```bash
+python -m puppetmaster dashboard --all-projects --background
+python -m puppetmaster jobs --all-projects
+```
+
+The dashboard's default port search starts at 8787 and automatically advances
+when another listener owns a port. Always open the **URL printed by the
+command or returned by the MCP tool**; do not reuse a hard-coded `:8787`
+bookmark. An explicit `--port` is strict and fails when busy; add
+`--port-search` if an explicitly requested starting port may auto-bump.
+
+The background dashboard reuses only a running board with the same state
+directory and scope. `--all-projects` is a different scope from the ordinary
+project dashboard, so start and inspect it intentionally.
+
+## Concurrent editing requires separate worktrees
+
+Do not run two full-edit or in-place edit jobs against the same checkout at the
+same time. The jobs can race after their clean-tree checks and each job can
+mistake the other's edits for its own patch.
+
+Use one write-capable job per checkout, or give each concurrent write job its
+own Git worktree:
+
+```bash
+git worktree add ../project-fix-a -b fix-a
+git worktree add ../project-fix-b -b fix-b
+python -m puppetmaster claude "Implement fix A" --cwd ../project-fix-a --permission-mode acceptEdits
+python -m puppetmaster claude "Implement fix B" --cwd ../project-fix-b --permission-mode acceptEdits
+```
+
+Read-only reviews and inspections can run concurrently. A write-capable job
+may still share provider quota, model policy, and local CPU/memory with other
+sessions; those are user-level resources rather than job-state leakage.
+
+## Quick diagnosis
+
+When a job is not on the dashboard you opened, first compare scopes instead of
+assuming the job failed:
+
+```bash
+python -m puppetmaster state
+python -m puppetmaster projects
+python -m puppetmaster jobs --all-projects
+python -m puppetmaster dashboard --all-projects --background
+```
+
+Use the exact URL printed by the final command. For a known job ID, read-only
+commands such as `show`, `status`, `feed`, and `artifacts` can locate the
+owning project state automatically unless an explicit state override is in
+force.
+
+See [DASHBOARD.md](DASHBOARD.md) for dashboard flags and
+[TROUBLESHOOTING.md](TROUBLESHOOTING.md) for state-directory diagnosis.

--- a/docs/DAILY_DRIVER.md
+++ b/docs/DAILY_DRIVER.md
@@ -87,4 +87,9 @@ python -m puppetmaster clean --completed
 
 SQLite is the default backend. Runtime state is stored outside the repository by default so Puppetmaster jobs, logs, artifacts, and SQLite files do not inflate `git status`. Use `--state-dir .puppetmaster` or `PUPPETMASTER_STATE_DIR=.puppetmaster` only when you intentionally want repo-local state.
 
+When several conversations or shells are active, keep write-capable jobs in
+separate worktrees, treat `--all-projects` as an explicit aggregate view, and
+open the dashboard URL that Puppetmaster actually returns. The full state and
+dashboard-scope contract is in [CONCURRENT_SESSIONS.md](CONCURRENT_SESSIONS.md).
+
 Use `--backend file` only when you want fully inspectable JSON state for debugging.

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -16,6 +16,13 @@ python -m puppetmaster dashboard            # jobs index for this workspace
 python -m puppetmaster dashboard <job_id>   # deep-link straight to one job
 ```
 
+The normal board is project-scoped: it shows the state directory for the
+workspace you selected, not every job on the machine. Use `--all-projects` only
+for an intentional aggregate view. When the command starts a board, open the
+exact URL it prints or that the MCP tool returns; the default port starts at
+8787 but may auto-bump. See [CONCURRENT_SESSIONS.md](CONCURRENT_SESSIONS.md)
+for the complete concurrent-session contract.
+
 From an agent, the MCP verb `puppetmaster_dashboard` starts the server (or reuses
 this project's own, if one is already running) and returns the URL to open — pass
 `job_id` to deep-link, `mobile: true` to get a phone URL + QR, and `stop: true` to

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -4,7 +4,7 @@ A full map of what ships today, plus the adapter matrix. For the design rational
 
 ## Adapters
 
-Five production adapters live plus the keys-only `agentic` standalone worker; twelve tiers in the starter registry (6 Cursor/Claude + 4 OpenAI + 2 Codex, including the Grok 4.6 Cursor overlay added in v1.22.3). Tier and pricing details in [docs/MODEL_ROUTING.md](MODEL_ROUTING.md); adapter wiring details in [docs/ADAPTERS.md](ADAPTERS.md).
+Six production adapters live plus the keys-only `agentic` standalone worker; curated tiers across Cursor, Claude, OpenAI, Codex, Antigravity (Gemini 3.7 / 3.6 / 3.5 / 3.1 Pro), and Hermes. Tier and pricing details in [docs/MODEL_ROUTING.md](MODEL_ROUTING.md); adapter wiring details in [docs/ADAPTERS.md](ADAPTERS.md).
 
 | Adapter | What it's for | Telemetry | Setup |
 |---|---|---|---|
@@ -12,6 +12,7 @@ Five production adapters live plus the keys-only `agentic` standalone worker; tw
 | `claude-code` | Full-edit workflows via the `claude` CLI | usage from CLI | `npm i -g @anthropic-ai/claude-code` + `ANTHROPIC_API_KEY` |
 | `openai` | Direct Chat Completions (the most pricing-transparent path) | real `usage.prompt_tokens`/`completion_tokens` | `OPENAI_API_KEY` |
 | `codex` | Full-edit via the OpenAI Codex CLI agent loop | `input_tokens` + `output_tokens` + `cached_input_tokens` + `reasoning_output_tokens` per turn | `npm i -g @openai/codex` + `codex login` |
+| `antigravity` | Analyze (`--mode plan`) + full-edit (`--mode accept-edits`) via Google Antigravity CLI (`agy --output-format json`); supports Gemini 3.7 / 3.6 / 3.5 / 3.1 Pro with reasoning effort | `input_tokens` + `output_tokens` + `thinking_tokens` + `cache_read_tokens` + `conversation_id` | `agy` CLI on PATH + Antigravity session / `GEMINI_API_KEY` |
 | `hermes` | Analyze + full-edit via the NousResearch Hermes CLI (`hermes chat`); preferred live-site browser adapter (`hermes chat -t browser`); auto-injects CodeGraph context, parses typed artifacts | exit-code- and diff-based success (Hermes exit codes are unreliable) | `pipx install hermes-agent` (or any `hermes` on PATH) + `puppetmaster install-hermes-mcp` |
 | `agentic` | Keys-only analyze + full-edit via direct provider HTTP APIs (no external CLI); browser-swarm fallback via stdlib CDP (OpenRouter / standalone keys) | tool-loop artifacts + PATCH on implement; tokens + cache reads + `price_job` / savings | any provider API key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `OPENROUTER_API_KEY`, `OPENCODE_GO_API_KEY`, `ZAI_API_KEY`/`GLM_API_KEY`/`Z_AI_API_KEY`, `MINIMAX_API_KEY`, `NVIDIA_API_KEY`) or AWS Bedrock IAM / `AWS_BEARER_TOKEN_BEDROCK` (`provider=bedrock`, Converse + ConverseStream + live catalog) |
 | `shell` | Bounded verification commands | n/a | none |

--- a/docs/MOBILE.md
+++ b/docs/MOBILE.md
@@ -116,7 +116,9 @@ python -m puppetmaster dashboard --mobile --qr
 ## 3. Open it on your phone
 
 - **Scan** the QR, or
-- type the URL (e.g. `http://100.96.89.15:8787/`) into your phone browser.
+- type the exact URL the command printed (for example,
+  `http://100.96.89.15:<returned-port>/`) into your phone browser. The default
+  search starts at 8787, but a concurrent dashboard can use a higher port.
 
 The board is responsive — the jobs grid, headlines, tables, and footer all reflow
 for a phone screen. Tap a job to drill in; the jobs index is the default landing.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ The full documentation set. Start at the [project README](../README.md) for the 
 | [COMPARISON.md](COMPARISON.md) | How it differs from LangGraph / CrewAI / Claude Agent SDK / native subagents + "pick X instead if…" |
 | [SECURITY.md](SECURITY.md) | Threat model: what it can do, what it touches, network egress, and how to run it safely |
 | [DAILY_DRIVER.md](DAILY_DRIVER.md) | Prompt recipes for review, swarm, implement, post-job inspection |
+| [CONCURRENT_SESSIONS.md](CONCURRENT_SESSIONS.md) | Concurrent agent/CLI operations: project state, dashboard URLs, explicit overrides, and isolated worktrees |
 | [DASHBOARD.md](DASHBOARD.md) | The live, zero-dependency web board: jobs index, routing rollup, and per-job detail |
 | [MOBILE.md](MOBILE.md) | Watch swarms from your phone: Tailscale setup, agent/CLI start, QR handoff, troubleshooting |
 
@@ -34,7 +35,7 @@ Reproducible evidence behind the durable-state thesis, including an independent 
 |---|---|
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Job / Task / Worker / Artifact / Stitcher / Memory object model |
 | [MODEL_ROUTING.md](MODEL_ROUTING.md) | Router policies, classifier, registry schema, the starter tiers |
-| [ADAPTERS.md](ADAPTERS.md) | All production adapters (cursor, claude-code, openai, codex, hermes, agentic) + shell + how to add a new one |
+| [ADAPTERS.md](ADAPTERS.md) | All production adapters (cursor, claude-code, openai, codex, hermes, antigravity, agentic) + shell + how to add a new one |
 | [CLI_REFERENCE.md](CLI_REFERENCE.md) | Every CLI subcommand, workflow config schema, daemon mode |
 | [CURSOR_AGENT_MCP.md](CURSOR_AGENT_MCP.md) | The MCP tool surface in detail |
 | [GROK_BOT.md](GROK_BOT.md) | Grok Bot as remote MCP pilot (streamable HTTP; supervise-first; not a worker adapter) |

--- a/puppetmaster/adapters/__init__.py
+++ b/puppetmaster/adapters/__init__.py
@@ -30,6 +30,7 @@ from puppetmaster.codegraph import (
 )
 from puppetmaster.failure import (
     NOT_AUTHENTICATED,
+    classify_antigravity_failure,
     classify_claude_code_failure,
     classify_codex_failure,
     classify_cursor_failure,
@@ -93,6 +94,13 @@ from ._streaming import (
     capture_subprocess_stdout,
     run_streamed_subprocess,
 )
+from .antigravity import (
+    DEFAULT_ANTIGRAVITY_EFFORT,
+    DEFAULT_ANTIGRAVITY_MODEL,
+    AntigravityAdapter,
+    build_antigravity_command,
+    resolve_antigravity_model,
+)
 from .claude_code import (
     DEFAULT_CLAUDE_CODE_MODEL,
     ClaudeCodeAdapter,
@@ -146,6 +154,7 @@ __all__ = [
     "ADAPTERS",
     "ADAPTER_INFO",
     "AdapterInfo",
+    "AntigravityAdapter",
     "Artifact",
     "ArtifactType",
     "ClaudeCodeAdapter",
@@ -153,6 +162,8 @@ __all__ = [
     "CliWorkerAdapter",
     "CodexAdapter",
     "CursorAdapter",
+    "DEFAULT_ANTIGRAVITY_EFFORT",
+    "DEFAULT_ANTIGRAVITY_MODEL",
     "DEFAULT_CLAUDE_CODE_MODEL",
     "DEFAULT_CODEX_MODEL",
     "DEFAULT_HERMES_ANALYZE_TOOLSETS",
@@ -173,6 +184,7 @@ __all__ = [
     "WorkerAdapter",
     "apply_worktree_ports",
     "available_hermes_providers",
+    "build_antigravity_command",
     "build_claude_code_command",
     "build_codex_exec_command",
     "build_hermes_chat_command",
@@ -180,6 +192,7 @@ __all__ = [
     "build_patch_payload",
     "build_structured_prompt",
     "capture_subprocess_stdout",
+    "classify_antigravity_failure",
     "classify_claude_code_failure",
     "classify_codex_failure",
     "classify_cursor_failure",
@@ -221,6 +234,7 @@ __all__ = [
     "prune_hermes_tool_sessions",
     "redact_secrets",
     "repo_file_census",
+    "resolve_antigravity_model",
     "resolve_claude_code_model",
     "resolve_command",
     "run_streamed_subprocess",

--- a/puppetmaster/adapters/agentic.py
+++ b/puppetmaster/adapters/agentic.py
@@ -1080,18 +1080,32 @@ class AgenticAdapter(FullEditWorkerAdapter):
         attempt = 0
         last: Optional[ProviderError] = None
         breaker = get_provider_circuit_breaker()
-        admission_key = resolve_circuit_key(provider, model)
         call_extra = dict(extra)
         tool_choice_stripped = False
         while True:
+            api_key = keys[key_index]
+            # The credential is part of admission: one exhausted rotating key
+            # must not preemptively block another key for the same endpoint.
+            admission_key = resolve_circuit_key(
+                provider, model, api_key=api_key,
+            )
             # Refuse before dialing when harvested remaining is 0 or the
             # process-local breaker is open (both raise recoverable 429s).
             from puppetmaster.rate_limit_state import admit_or_raise
 
-            admit_or_raise(admission_key)
-            breaker.before_call(admission_key)
+            try:
+                admit_or_raise(admission_key)
+                breaker.before_call(admission_key)
+            except ProviderError as exc:
+                # Admission happens before provider_chat, so it must use the
+                # same rotation path as a live 429.  Otherwise an exhausted A
+                # could incorrectly prevent an available B from being tried.
+                last = exc
+                if exc.status == 429 and key_index + 1 < len(keys):
+                    key_index += 1
+                    continue
+                raise
             recorded = False
-            api_key = keys[key_index]
             kwargs: dict = dict(
                 provider=provider, model=model, messages=messages,
                 tools=tools or None, extra=call_extra, timeout=timeout,

--- a/puppetmaster/adapters/antigravity.py
+++ b/puppetmaster/adapters/antigravity.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Mapping, Optional, Union
+
+from puppetmaster.codegraph import enrich_prompt_with_codegraph
+from puppetmaster.failure import classify_antigravity_failure
+from puppetmaster.models import Artifact, ArtifactType, Task
+from puppetmaster.usage import token_usage
+
+from ._base import (
+    CliInvocation,
+    CliWorkerAdapter,
+    build_patch_payload,
+    command_parts,
+    diff_source_payload,
+    make_patch_artifact,
+    missing_cli_artifact,
+    verification_artifact,
+)
+from ._base import _should_emit_patch_artifact
+from ._facade import facade
+from ._prompts import (
+    TASK_INSTRUCTION_HEADER,
+    prompt_with_memory,
+    with_job_brief,
+    with_report_contract,
+)
+from ._streaming import (
+    StreamedProcess,
+    _STDOUT_TAIL_CHARS,
+    _redacted_tail,
+    capture_subprocess_stdout,
+)
+from .cursor import (
+    cursor_result_artifacts,
+    implement_report_artifacts,
+)
+
+DEFAULT_ANTIGRAVITY_MODEL = "gemini-3.7-flash"
+DEFAULT_ANTIGRAVITY_EFFORT = "high"
+MODELS_REQUIRING_EFFORT = (
+    "gemini-3.7-flash",
+    "gemini-3.6-flash",
+    "gemini-3.5-flash",
+    "gemini-3.1-pro",
+)
+
+
+def resolve_antigravity_model(payload: Optional[Mapping[str, object]] = None) -> tuple[str, Optional[str]]:
+    """Determine effective model and reasoning effort for an Antigravity CLI run."""
+    payload = payload or {}
+    model = str(payload.get("model") or DEFAULT_ANTIGRAVITY_MODEL)
+    effort = payload.get("effort")
+    if effort is not None:
+        return model, str(effort)
+    if any(prefix in model.lower() for prefix in MODELS_REQUIRING_EFFORT):
+        return model, DEFAULT_ANTIGRAVITY_EFFORT
+    return model, None
+
+
+class AntigravityAdapter(CliWorkerAdapter):
+    """Worker adapter for Google Antigravity CLI (`agy`).
+
+    Executes non-interactive print sessions with structured JSON telemetry,
+    supporting both `plan` (read-only audit/analysis) and `accept-edits`
+    (full-edit code generation with patch attribution) modes.
+    """
+
+    name = "antigravity"
+    default_timeout_seconds = 600
+
+    def run(self, task: Task, goal: str, worker_id: str) -> list[Artifact]:
+        return self._run_cli_lifecycle(task, goal, worker_id)
+
+    def _resolve_cli_executable(self, task: Task) -> tuple[str, Optional[str]]:
+        executable = (
+            task.payload.get("executable")
+            or os.environ.get("AGY_COMMAND")
+            or os.environ.get("ANTIGRAVITY_COMMAND")
+            or "agy"
+        )
+        command_base = command_parts(executable)
+        resolved = facade("resolve_command")(command_base[0])
+        if resolved is None:
+            return str(executable), None
+        return str(executable), resolved
+
+    def _missing_cli(
+        self, task: Task, worker_id: str, executable_label: str
+    ) -> list[Artifact]:
+        return missing_cli_artifact(
+            task,
+            worker_id,
+            "antigravity",
+            executable_label,
+            (
+                "Antigravity CLI (agy) was not found on PATH. Install it or set "
+                "AGY_COMMAND / ANTIGRAVITY_COMMAND / payload.executable."
+            ),
+        )
+
+    def _prepare_cli_invocation(
+        self,
+        task: Task,
+        goal: str,
+        worker_id: str,
+        cwd: Path,
+        resolved: str,
+    ) -> Union[list[Artifact], CliInvocation]:
+        raw_instruction = str(task.payload.get("prompt") or task.instruction or "")
+        base_prompt = with_report_contract(
+            f"{TASK_INSTRUCTION_HEADER}\n{raw_instruction}"
+        )
+        prompt, codegraph_used = facade("enrich_prompt_with_codegraph")(
+            with_job_brief(prompt_with_memory(base_prompt, task), task),
+            task_description=str(task.payload.get("codegraph_task") or task.instruction or goal),
+            cwd=cwd,
+            disabled=bool(task.payload.get("disable_codegraph", False)),
+        )
+        executable = (
+            task.payload.get("executable")
+            or os.environ.get("AGY_COMMAND")
+            or os.environ.get("ANTIGRAVITY_COMMAND")
+            or "agy"
+        )
+        command_base = command_parts(executable)
+        model, effort = resolve_antigravity_model(task.payload)
+
+        read_only_intent = bool(task.payload.get("read_only")) or (
+            task.payload.get("sandbox") == "read-only"
+        )
+        mode = str(task.payload.get("mode") or ("plan" if read_only_intent else "accept-edits"))
+        write_capable = mode != "plan"
+        dangerously_skip = bool(task.payload.get("dangerously_skip_permissions", True))
+
+        command = build_antigravity_command(
+            prompt=prompt,
+            executable=[resolved, *command_base[1:]],
+            model=model,
+            mode=mode,
+            effort=effort,
+            cwd=cwd,
+            dangerously_skip_permissions=dangerously_skip,
+            extra_args=task.payload.get("extra_args"),
+        )
+        return CliInvocation(
+            command=command,
+            sidecar_name="antigravity_run",
+            extras={
+                "prompt": prompt,
+                "codegraph_used": codegraph_used,
+                "model": model,
+                "effort": effort,
+                "mode": mode,
+                "write_capable": write_capable,
+                "extra_dirty_message": (
+                    " For focused edits on a dirty tree, use puppetmaster_edit — it edits "
+                    "in place and needs no clean tree."
+                ),
+            },
+        )
+
+    def _apply_pre_run_guards(
+        self,
+        task: Task,
+        worker_id: str,
+        cwd: Path,
+        prepared: CliInvocation,
+    ) -> tuple[Optional[list[Artifact]], dict]:
+        if not prepared.extras.get("write_capable", True):
+            return None, facade("git_snapshot")(cwd)
+        return super()._apply_pre_run_guards(task, worker_id, cwd, prepared)
+
+    def _finalize_cli_run(
+        self,
+        task: Task,
+        worker_id: str,
+        goal: str,
+        prepared: CliInvocation,
+        before: dict,
+        after: dict,
+        completed: StreamedProcess,
+    ) -> list[Artifact]:
+        model = str(prepared.extras.get("model") or DEFAULT_ANTIGRAVITY_MODEL)
+        effort = prepared.extras.get("effort")
+        mode = str(prepared.extras.get("mode") or "accept-edits")
+        codegraph_used = bool(prepared.extras.get("codegraph_used"))
+        prompt = str(prepared.extras.get("prompt") or "")
+        cwd = Path(task.payload.get("cwd") or ".").resolve()
+
+        if completed.timed_out:
+            return self._handle_timeout(task, worker_id, before, after, completed, model, mode)
+
+        parsed_json = self._parse_agy_output(completed.stdout)
+        response_text = str(parsed_json.get("response") or completed.stdout or "").strip()
+        agy_status = str(parsed_json.get("status") or "")
+        agy_error = str(parsed_json.get("error") or "")
+        conversation_id = str(parsed_json.get("conversation_id") or "")
+        usage_data = parsed_json.get("usage") if isinstance(parsed_json.get("usage"), dict) else {}
+
+        tokens_in = int(usage_data.get("input_tokens") or 0)
+        tokens_out = int(usage_data.get("output_tokens") or 0)
+        reasoning_tokens = int(usage_data.get("thinking_tokens") or 0)
+        cached_tokens = int(usage_data.get("cache_read_tokens") or 0)
+
+        process_failed = completed.returncode != 0 or agy_status == "ERROR"
+        classified_failure = None
+        if process_failed:
+            combined_err = f"{completed.stderr}\n{completed.stdout}\n{agy_error}"
+            classified_failure = classify_antigravity_failure(combined_err)
+
+        stdout_capture = capture_subprocess_stdout(
+            text=completed.stdout, task=task, sidecar_name="antigravity_stdout", tail_chars=12000
+        )
+        stderr_capture = capture_subprocess_stdout(
+            text=completed.stderr, task=task, sidecar_name="antigravity_stderr"
+        )
+
+        verification = verification_artifact(
+            task=task,
+            worker_id=worker_id,
+            adapter="antigravity",
+            check=task.instruction,
+            result="failed" if process_failed else "passed",
+            confidence=0.55 if process_failed else 0.9,
+            evidence=(
+                ["adapter:antigravity", f"model:{model}", f"mode:{mode}"]
+                + ([f"effort:{effort}"] if effort else [])
+                + (["context:codegraph"] if codegraph_used else [])
+            ),
+            payload={
+                "returncode": completed.returncode,
+                "model": model,
+                "mode": mode,
+                "effort": effort,
+                "conversation_id": conversation_id,
+                "agy_status": agy_status,
+                "failure": classified_failure,
+                "stdout": _redacted_tail(completed.stdout, 12000),
+                "stderr": _redacted_tail(completed.stderr, _STDOUT_TAIL_CHARS),
+                "stdout_capture": stdout_capture,
+                "stderr_capture": stderr_capture,
+                "live_log": completed.live_log_path,
+                "cwd": str(cwd),
+                "tokens_in": tokens_in,
+                "tokens_out": tokens_out,
+                "tokens_total": tokens_in + tokens_out,
+                "cached_input_tokens": cached_tokens,
+                "reasoning_output_tokens": reasoning_tokens,
+                "base_sha": before["sha"],
+                "head_sha": after["sha"],
+                "changed_files": after["changed_files"],
+                "untracked_files": after["untracked_files"],
+                **diff_source_payload(before, after),
+            },
+        )
+        artifacts: list[Artifact] = [verification]
+
+        if not process_failed and response_text:
+            artifacts.extend(implement_report_artifacts(task, worker_id, response_text, adapter="antigravity"))
+
+        if _should_emit_patch_artifact(before, after):
+            artifacts.append(
+                make_patch_artifact(
+                    task,
+                    worker_id,
+                    before,
+                    after,
+                    adapter="antigravity",
+                    status="applied" if not process_failed else "failed",
+                    change="Antigravity modified repository files.",
+                    sidecar_name="antigravity_implement",
+                )
+            )
+        return artifacts
+
+    def _handle_timeout(
+        self,
+        task: Task,
+        worker_id: str,
+        before: dict,
+        after: dict,
+        completed: StreamedProcess,
+        model: str,
+        mode: str,
+    ) -> list[Artifact]:
+        timeout_seconds = int(task.payload.get("timeout_seconds", self.default_timeout_seconds))
+        stdout_capture = capture_subprocess_stdout(
+            text=completed.stdout, task=task, sidecar_name="antigravity_stdout_timeout"
+        )
+        stderr_capture = capture_subprocess_stdout(
+            text=completed.stderr, task=task, sidecar_name="antigravity_stderr_timeout"
+        )
+        artifacts: list[Artifact] = [
+            verification_artifact(
+                task=task,
+                worker_id=worker_id,
+                adapter="antigravity",
+                check=task.instruction,
+                result="failed",
+                confidence=0.6,
+                evidence=["adapter:antigravity", "timeout"],
+                payload={
+                    "failure": "timeout",
+                    "returncode": None,
+                    "model": model,
+                    "mode": mode,
+                    "stdout": _redacted_tail(completed.stdout, _STDOUT_TAIL_CHARS),
+                    "stderr": _redacted_tail(completed.stderr, _STDOUT_TAIL_CHARS),
+                    "stdout_capture": stdout_capture,
+                    "stderr_capture": stderr_capture,
+                    "live_log": completed.live_log_path,
+                    "timeout_seconds": timeout_seconds,
+                    "base_sha": before["sha"],
+                    "head_sha": after["sha"],
+                    "changed_files": after["changed_files"],
+                    "untracked_files": after["untracked_files"],
+                    **diff_source_payload(before, after),
+                },
+            )
+        ]
+        if _should_emit_patch_artifact(before, after):
+            artifacts.append(
+                Artifact(
+                    job_id=task.job_id,
+                    task_id=task.id,
+                    type=ArtifactType.PATCH,
+                    created_by=worker_id,
+                    confidence=0.5,
+                    evidence=["adapter:antigravity", f"base:{before['sha']}", "timeout"],
+                    payload=build_patch_payload(
+                        task=task,
+                        before=before,
+                        after=after,
+                        status="failed",
+                        change="Antigravity modified repository files before timing out.",
+                        sidecar_name="antigravity_implement_timeout",
+                    ),
+                )
+            )
+        return artifacts
+
+    def _parse_agy_output(self, stdout: str) -> dict[str, object]:
+        """Extract root JSON object from agy --output-format json output."""
+        text = (stdout or "").strip()
+        if not text:
+            return {}
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, dict):
+                return parsed
+        except (json.JSONDecodeError, TypeError):
+            pass
+        return {}
+
+
+def build_antigravity_command(
+    *,
+    prompt: str,
+    executable: Union[str, list[str]] = "agy",
+    model: Optional[str] = None,
+    mode: str = "accept-edits",
+    effort: Optional[str] = None,
+    cwd: Optional[Path] = None,
+    dangerously_skip_permissions: bool = True,
+    disable_slash_commands: bool = True,
+    extra_args: object = None,
+) -> list[str]:
+    """Build the non-interactive ``agy --output-format json`` argv."""
+    command = command_parts(executable)
+    command.extend(["--output-format", "json"])
+    if mode in ("accept-edits", "plan"):
+        command.extend(["--mode", mode])
+    if dangerously_skip_permissions and mode == "accept-edits":
+        command.append("--dangerously-skip-permissions")
+    if disable_slash_commands:
+        command.append("--disable-slash-commands")
+    if model:
+        command.extend(["--model", str(model)])
+    if effort:
+        command.extend(["--effort", str(effort)])
+    if cwd is not None:
+        command.extend(["--add-dir", str(cwd)])
+    if extra_args:
+        command.extend(command_parts(extra_args))
+    command.append(f"-p={prompt}")
+    return command

--- a/puppetmaster/adapters/codex.py
+++ b/puppetmaster/adapters/codex.py
@@ -41,6 +41,43 @@ from .cursor import (
 )
 
 DEFAULT_CODEX_MODEL = "gpt-5.4-mini"
+_CODEX_NPM_ENTRYPOINT = Path("node_modules") / "@openai" / "codex" / "bin" / "codex.js"
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _configured_codex_executable(task: Task) -> object:
+    return task.payload.get("executable") or os.environ.get("CODEX_COMMAND") or "codex"
+
+
+def _default_codex_command_base(resolved: str) -> Optional[list[str]]:
+    """Resolve the default Codex command without a Windows batch intermediary.
+
+    Global npm installs expose ``codex.CMD`` on Windows. Launching that shim
+    inserts ``cmd.exe`` between Puppetmaster and the long-lived Node process,
+    weakening signal, pipe, and timeout ownership. Resolve the package's real
+    JavaScript entrypoint and invoke it with Node directly instead.
+    """
+    resolved_path = Path(resolved)
+    if not _is_windows() or resolved_path.suffix.lower() not in {".cmd", ".bat"}:
+        return [resolved]
+
+    entrypoint = resolved_path.parent / _CODEX_NPM_ENTRYPOINT
+    node = facade("resolve_command")("node")
+    if node is None or not entrypoint.is_file():
+        return None
+    return [node, str(entrypoint)]
+
+
+def _codex_command_base(task: Task, resolved: str) -> Optional[list[str]]:
+    """Build the launch prefix while preserving explicit user commands."""
+    executable = _configured_codex_executable(task)
+    command = command_parts(executable)
+    if task.payload.get("executable") or os.environ.get("CODEX_COMMAND"):
+        return [resolved, *command[1:]]
+    return _default_codex_command_base(resolved)
 
 
 class CodexAdapter(CliWorkerAdapter):
@@ -71,7 +108,7 @@ class CodexAdapter(CliWorkerAdapter):
         return self._run_cli_lifecycle(task, goal, worker_id)
 
     def _resolve_cli_executable(self, task: Task) -> tuple[str, Optional[str]]:
-        executable = task.payload.get("executable") or os.environ.get("CODEX_COMMAND") or "codex"
+        executable = _configured_codex_executable(task)
         command_base = command_parts(executable)
         resolved = facade("resolve_command")(command_base[0])
         if resolved is None:
@@ -122,8 +159,10 @@ class CodexAdapter(CliWorkerAdapter):
             cwd=cwd,
             disabled=bool(task.payload.get("disable_codegraph", False)),
         )
-        executable = task.payload.get("executable") or os.environ.get("CODEX_COMMAND") or "codex"
-        command_base = command_parts(executable)
+        executable = _configured_codex_executable(task)
+        command_base = _codex_command_base(task, resolved)
+        if command_base is None:
+            return self._missing_cli(task, worker_id, str(executable))
         model = str(task.payload.get("model") or DEFAULT_CODEX_MODEL)
         sandbox = str(task.payload.get("sandbox") or "workspace-write")
         approval_policy = str(task.payload.get("approval_policy") or "never")
@@ -131,7 +170,7 @@ class CodexAdapter(CliWorkerAdapter):
         ephemeral = bool(task.payload.get("ephemeral", True))
         skip_git_repo_check = bool(task.payload.get("skip_git_repo_check", True))
         command = build_codex_exec_command(
-            executable=[resolved, *command_base[1:]],
+            executable=command_base,
             model=model,
             cwd=cwd,
             sandbox=sandbox,

--- a/puppetmaster/adapters/registry.py
+++ b/puppetmaster/adapters/registry.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from ._base import AdapterInfo, WorkerAdapter
 from .agentic import AgenticAdapter
+from .antigravity import AntigravityAdapter
 from .claude_code import ClaudeCodeAdapter
 from .codex import CodexAdapter
 from .cursor import CursorAdapter
@@ -20,6 +21,8 @@ ADAPTERS: dict[str, WorkerAdapter] = {
     "openai": OpenAIAdapter(),
     "codex": CodexAdapter(),
     "hermes": HermesAdapter(),
+    "antigravity": AntigravityAdapter(),
+    "agy": AntigravityAdapter(),
 }
 
 
@@ -95,6 +98,19 @@ ADAPTER_INFO = [
         requires=[
             "hermes CLI on PATH",
             "provider credential in ~/.hermes/.env or `hermes login` OAuth",
+        ],
+    ),
+    AdapterInfo(
+        name="antigravity",
+        status="optional",
+        description=(
+            "Runs the Google Antigravity CLI (`agy --output-format json`) headlessly "
+            "for analyze (`--mode plan`) and full-edit (`--mode accept-edits`) worker tasks. "
+            "Extracts structured token/thinking usage and attributes file edits via git diff."
+        ),
+        requires=[
+            "agy CLI on PATH",
+            "Antigravity CLI authenticated",
         ],
     ),
 ]

--- a/puppetmaster/cli/__init__.py
+++ b/puppetmaster/cli/__init__.py
@@ -67,6 +67,7 @@ from puppetmaster.cli.commands_jobs import (
     _run_reap_command,
     _run_wait_command,
     await_job_state,
+    read_job_state,
 )
 from puppetmaster.cli.commands_mcp import (
     _run_mcp_cleanup,
@@ -301,6 +302,7 @@ __all__ = [
     "artifact_headline",
     "artifact_job_id",
     "await_job_state",
+    "read_job_state",
     "build_parser",
     "create_store",
     "cursor_prompt",

--- a/puppetmaster/cli/_dispatch.py
+++ b/puppetmaster/cli/_dispatch.py
@@ -127,6 +127,25 @@ from puppetmaster.cli.commands_gate import (
 )
 
 
+def _resolve_command_state_dir(args: argparse.Namespace) -> Path:
+    """Resolve durable state for the command's workspace without moving overrides.
+
+    Worker-launching commands accept ``--cwd`` to select a target repository.
+    In the absence of an explicit state override, their durable job state must
+    follow that repository too.  Explicit ``--state-dir`` and
+    ``PUPPETMASTER_STATE_DIR`` retain the historic launcher-shell-relative
+    resolution so existing scripts keep their path semantics.
+    """
+    explicit_state_dir = getattr(args, "state_dir", None)
+    if explicit_state_dir or os.environ.get("PUPPETMASTER_STATE_DIR"):
+        return resolve_state_dir(explicit_state_dir)
+
+    command_cwd = getattr(args, "cwd", None)
+    if command_cwd:
+        return resolve_state_dir(cwd=Path(command_cwd))
+    return resolve_state_dir()
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     from puppetmaster.win_console import hide_child_consoles
 
@@ -573,7 +592,7 @@ def _main(argv: Optional[list[str]] = None) -> int:
     import puppetmaster.cli as cli
 
     args = build_parser().parse_args(argv)
-    state_dir = resolve_state_dir(args.state_dir)
+    state_dir = _resolve_command_state_dir(args)
     store = create_store(args.backend, state_dir)
     on_job_created = early_job_printer if args.emit_job_id_early else None
 

--- a/puppetmaster/cli/_parser.py
+++ b/puppetmaster/cli/_parser.py
@@ -2151,6 +2151,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="Heartbeat age that defines a stale server (default: 300).",
     )
     mcp_cleanup.add_argument(
+        "--pid",
+        dest="pids",
+        type=int,
+        action="append",
+        help="Explicit MCP server PID to terminate; may be repeated and intersects other selectors.",
+    )
+    mcp_cleanup.add_argument(
+        "--workspace",
+        help="Explicit workspace selector to terminate; normalized before matching.",
+    )
+    mcp_cleanup.add_argument(
+        "--idle-after-seconds",
+        type=float,
+        help="Terminate only servers with no inbound MCP message for this many seconds.",
+    )
+    mcp_cleanup.add_argument(
         "--json",
         action="store_true",
         help="Print the before/after registry payload as JSON.",

--- a/puppetmaster/cli/commands_jobs.py
+++ b/puppetmaster/cli/commands_jobs.py
@@ -55,6 +55,7 @@ from puppetmaster.mcp_registry import (
     prune_dead as registry_prune_dead,
     summarize as registry_summarize,
 )
+from puppetmaster.models import is_terminal_job_status
 from puppetmaster.redaction import redact_secrets
 from puppetmaster.orchestrator import Orchestrator
 from puppetmaster.state import (
@@ -68,6 +69,18 @@ from puppetmaster.worker_runtime import WorkerDaemon
 from puppetmaster.workers import WorkerSpec
 
 from puppetmaster.cli.helpers import _registry_path_from_args
+
+
+def read_job_state(store, job_id: str, *, timed_out: bool = False) -> dict:
+    """Return the canonical non-blocking state payload for one durable job."""
+    job = store.get_job(job_id)
+    return {
+        "job_id": job_id,
+        "status": str(job.status),
+        "terminal": is_terminal_job_status(job.status),
+        "timed_out": bool(timed_out),
+        "completed_at": job.completed_at,
+    }
 
 
 def await_job_state(
@@ -84,35 +97,15 @@ def await_job_state(
     (so the MCP path can return and be re-called). Uses the store's
     event-wait primitive between checks instead of busy-polling.
     """
-    from puppetmaster.models import JobStatus
-
-    terminal = {
-        JobStatus.COMPLETE,
-        JobStatus.FAILED,
-        JobStatus.STALLED,
-        JobStatus.CANCELLED,
-    }
     poll = max(0.05, poll_interval_seconds)
     deadline = time.monotonic() + timeout_seconds if timeout_seconds > 0 else None
     cursor = 0
     while True:
-        job = store.get_job(job_id)
-        if job.status in terminal:
-            return {
-                "job_id": job_id,
-                "status": str(job.status),
-                "terminal": True,
-                "timed_out": False,
-                "completed_at": job.completed_at,
-            }
+        state = read_job_state(store, job_id)
+        if state["terminal"]:
+            return state
         if deadline is not None and time.monotonic() >= deadline:
-            return {
-                "job_id": job_id,
-                "status": str(job.status),
-                "terminal": False,
-                "timed_out": True,
-                "completed_at": job.completed_at,
-            }
+            return {**state, "timed_out": True}
         block = poll if deadline is None else max(0.05, min(poll * 4, deadline - time.monotonic()))
         events = store.wait_for_events(
             job_id,
@@ -253,7 +246,6 @@ def _run_wait_command(args, store) -> int:
     deadline = (
         time.monotonic() + args.timeout_seconds if args.timeout_seconds > 0 else None
     )
-    terminal = {"complete", "failed", "stalled"}
     while True:
         try:
             from puppetmaster.liveness import reap_stalled_jobs
@@ -263,7 +255,8 @@ def _run_wait_command(args, store) -> int:
             pass
         job = store.get_job(args.job_id)
         status = str(job.status)
-        if status in terminal:
+        terminal = is_terminal_job_status(job.status)
+        if terminal:
             timed_out = False
             break
         if deadline is not None and time.monotonic() >= deadline:
@@ -282,7 +275,7 @@ def _run_wait_command(args, store) -> int:
     payload = {
         "job_id": args.job_id,
         "status": status,
-        "terminal": status in terminal,
+        "terminal": terminal,
         "timed_out": timed_out,
         "completed_at": job.completed_at,
     }

--- a/puppetmaster/cli/commands_mcp.py
+++ b/puppetmaster/cli/commands_mcp.py
@@ -50,6 +50,7 @@ from puppetmaster.hook_installers import (
     uninstall_hooks,
 )
 from puppetmaster.mcp_registry import (
+    kill_selected as registry_kill_selected,
     kill_stale as registry_kill_stale,
     list_entries as registry_list_entries,
     prune_dead as registry_prune_dead,
@@ -242,6 +243,21 @@ def _run_mcp_cleanup(args) -> int:
     before = registry_summarize(registry_list_entries())
     pruned = registry_prune_dead()
     killed: list = []
+    selected_killed: list = []
+    refused: list = []
+    pids = getattr(args, "pids", None)
+    workspace = getattr(args, "workspace", None)
+    idle_after = getattr(args, "idle_after_seconds", None)
+    has_selector = bool(pids) or workspace is not None or idle_after is not None
+    if has_selector:
+        selected = registry_kill_selected(
+            pids=pids,
+            workspace=workspace,
+            idle_after_seconds=float(idle_after) if idle_after is not None else None,
+            self_pid=os.getpid(),
+        )
+        selected_killed = [entry.to_payload() for entry in selected.killed]
+        refused = selected.refused
     if args.kill_stale:
         killed_entries = registry_kill_stale(
             stale_after_seconds=float(args.stale_after_seconds),
@@ -253,6 +269,8 @@ def _run_mcp_cleanup(args) -> int:
         "after": after,
         "pruned": [entry.to_payload() for entry in pruned],
         "killed": killed,
+        "selected_killed": selected_killed,
+        "refused": refused,
     }
     if args.json:
         print(json.dumps(payload, indent=2))
@@ -268,6 +286,14 @@ def _run_mcp_cleanup(args) -> int:
         print(f"killed stale: {len(killed)}")
         for row in killed:
             print(f"  - PID {row['pid']} ({row.get('workspace') or '-'})")
+    if has_selector:
+        print(f"selected killed: {len(selected_killed)}")
+        for row in selected_killed:
+            print(f"  - PID {row['pid']} ({row.get('workspace') or '-'})")
+        if refused:
+            print(f"selected refused: {len(refused)}")
+            for row in refused:
+                print(f"  - PID {row['pid']} ({row.get('reason')})")
     elif before["stale"]:
         print(
             f"note: {before['stale']} stale-but-alive server(s) detected; "

--- a/puppetmaster/diagnostics.py
+++ b/puppetmaster/diagnostics.py
@@ -63,6 +63,7 @@ def run_doctor(root: Path, state_dir: Optional[Path] = None) -> list[Check]:
         _guard("cursor-sdk", lambda: _cursor_sdk_check(root)),
         _guard("claude-code", _claude_code_check),
         _guard("codex", _codex_check),
+        _guard("antigravity", _antigravity_check),
         _guard("codegraph", lambda: _codegraph_check(root)),
         _guard("mcp-servers", _mcp_servers_check),
         _guard("CURSOR_API_KEY", lambda: _env_check("CURSOR_API_KEY")),
@@ -208,7 +209,7 @@ def _billing_checks() -> list[Check]:
     from puppetmaster.provider_health import bedrock_health_report
 
     checks: list[Check] = []
-    for adapter in ("agentic", "cursor", "claude-code", "codex", "hermes", "openai"):
+    for adapter in ("agentic", "cursor", "claude-code", "codex", "hermes", "openai", "antigravity"):
         try:
             status = detect_adapter_billing(adapter)
         except Exception as exc:  # pragma: no cover - defensive
@@ -279,6 +280,10 @@ _PROVIDER_CREDENTIAL_ENV_KEYS: dict[str, tuple[str, ...]] = {
         "CLAUDE_CODE_USE_BEDROCK",
         "AWS_PROFILE",
         "AWS_BEARER_TOKEN_BEDROCK",
+    ),
+    "antigravity": (
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
     ),
 }
 
@@ -508,6 +513,7 @@ def adapter_status(root: Path) -> list[dict[str, object]]:
     cursor_key = bool(os.environ.get("CURSOR_API_KEY"))
     claude_installed = _claude_code_installed()
     codex_installed = _codex_cli_installed()
+    antigravity_installed = _antigravity_installed()
     openai_key = bool(os.environ.get("OPENAI_API_KEY"))
     hermes_installed = _hermes_cli_installed()
     try:
@@ -550,6 +556,8 @@ def adapter_status(root: Path) -> list[dict[str, object]]:
             configured = hermes_installed and hermes_creds
         elif info.name == "agentic":
             configured = bool(agentic_providers)
+        elif info.name == "antigravity":
+            configured = antigravity_installed
         if info.status == "stub":
             configured = False
         rows.append(
@@ -768,6 +776,31 @@ def _hermes_cli_installed() -> bool:
 
 def _hermes_command() -> str:
     return os.environ.get("HERMES_COMMAND", "hermes")
+
+
+def _antigravity_check() -> Check:
+    if _antigravity_installed():
+        return Check("antigravity", "ok", _antigravity_command())
+    return Check(
+        "antigravity",
+        "optional",
+        "install the Antigravity CLI (agy) or set AGY_COMMAND / ANTIGRAVITY_COMMAND. "
+        "Required only if you want to route to antigravity/* tiers.",
+    )
+
+
+def _antigravity_installed() -> bool:
+    command = shlex.split(_antigravity_command())
+    if not command:
+        return False
+    first = command[0]
+    if Path(first).expanduser().exists():
+        return True
+    return shutil.which(first) is not None
+
+
+def _antigravity_command() -> str:
+    return os.environ.get("AGY_COMMAND") or os.environ.get("ANTIGRAVITY_COMMAND") or "agy"
 
 
 def _env_check(name: str) -> Check:

--- a/puppetmaster/failure.py
+++ b/puppetmaster/failure.py
@@ -117,12 +117,21 @@ _ADAPTER_EXTRA_RULES: dict[str, Tuple[Rule, ...]] = {
         (_any("no provider", "provider credentials"), NOT_AUTHENTICATED),
     ),
     "openai": (),
+    "antigravity": (
+        (_any("not recognized as a known model", "invalid model selection"), MODEL_UNAVAILABLE),
+        (_any("requires --effort", "invalid effort"), MODEL_UNAVAILABLE),
+        (_any("not authenticated", "please authenticate", "login to", "oauth"), NOT_AUTHENTICATED),
+    ),
 }
 
 
 def classify_adapter_failure(adapter: str, output: str) -> str:
     extra = _ADAPTER_EXTRA_RULES.get(adapter, ())
     return _classify(output, (*extra, *_BASE_RULES))
+
+
+def classify_antigravity_failure(output: str) -> str:
+    return classify_adapter_failure("antigravity", output)
 
 
 def classify_codex_failure(output: str) -> str:

--- a/puppetmaster/fs_permissions.py
+++ b/puppetmaster/fs_permissions.py
@@ -8,7 +8,10 @@ strip mode bits from ``mkdir``, so we always follow up with an explicit
 from __future__ import annotations
 
 import os
+import secrets
 from pathlib import Path
+
+from puppetmaster.interprocess_lock import InterProcessFileLock
 
 _DIR_MODE = 0o700
 _FILE_MODE = 0o600
@@ -51,20 +54,53 @@ def open_private(path: Path, flags: int) -> int:
     return os.open(path, flags)
 
 
-def write_private_text(path: Path, content: str, *, encoding: str = "utf-8") -> None:
+def write_private_text(
+    path: Path,
+    content: str,
+    *,
+    encoding: str = "utf-8",
+    lock: bool = True,
+) -> None:
+    """Atomically replace private text, serializing writers for ``path``.
+
+    The replacement file is written and synced in the destination directory
+    before ``os.replace`` makes it visible.  Pass ``lock=False`` only while a
+    caller already holds :meth:`InterProcessFileLock.for_target` over a larger
+    read-modify-write transaction.
+    """
+    if lock:
+        with InterProcessFileLock.for_target(path):
+            write_private_text(path, content, encoding=encoding, lock=False)
+        return
     mkdir_private(path.parent)
+    temp = path.parent / ("." + path.name + "." + secrets.token_hex(12) + ".tmp")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
     if supports_posix_modes():
-        fd = os.open(
-            path,
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_CLOEXEC", 0),
-            _FILE_MODE,
-        )
-        try:
-            os.write(fd, content.encode(encoding))
-        finally:
-            os.close(fd)
+        fd = os.open(temp, flags, _FILE_MODE)
     else:
-        path.write_text(content, encoding=encoding)
+        fd = os.open(temp, flags)
+    try:
+        with os.fdopen(fd, "w", encoding=encoding, closefd=False) as handle:
+            handle.write(content)
+            handle.flush()
+            try:
+                os.fsync(handle.fileno())
+            except OSError:
+                # Atomic replacement remains correct when an uncommon local
+                # filesystem cannot fsync a file descriptor.
+                pass
+        os.close(fd)
+        fd = -1
+        chmod_private_file(temp)
+        os.replace(temp, path)
+        chmod_private_file(path)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            temp.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def append_private_text(path: Path, content: str, *, encoding: str = "utf-8") -> None:

--- a/puppetmaster/interprocess_lock.py
+++ b/puppetmaster/interprocess_lock.py
@@ -1,0 +1,192 @@
+"""Small, dependency-free interprocess locks for shared local state.
+
+``InterProcessFileLock.for_target(path)`` serializes writers for one target
+file or directory.  It uses an adjacent ``.<name>.lock`` file, so independent
+targets never contend.  Lock ownership is recorded with a PID and a random
+token.  A later process recovers an orphan whose owner PID is no longer alive;
+malformed/unknown owners are recovered after ``stale_after`` seconds.
+
+The lock is advisory: every writer of a resource must use the same target.
+It is deliberately suitable for both files (policy documents) and directories
+(future workspace and dashboard leases).  Acquire it with a context manager:
+
+    with InterProcessFileLock.for_target(target):
+        ... read / modify / atomically replace target ...
+
+Release removes the lock only when the random token still matches.  Acquisition
+raises :class:`TimeoutError` rather than silently proceeding without a lock.
+"""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import time
+from pathlib import Path
+from typing import Optional
+
+
+_DEFAULT_TIMEOUT_SECONDS = 10.0
+_DEFAULT_STALE_AFTER_SECONDS = 120.0
+_POLL_SECONDS = 0.05
+
+
+def _lock_path_for(target: Path) -> Path:
+    return target.parent / ("." + target.name + ".lock")
+
+
+def _pid_is_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # A process owned by another account is still an active owner.
+        return True
+    except OSError:
+        return False
+    return True
+
+
+class InterProcessFileLock:
+    """An exclusive, stale-recovering lock adjacent to a target path.
+
+    Use :meth:`for_target` rather than inventing a lock-file name.  The target
+    itself need not exist.  ``timeout`` bounds waiting for an active peer;
+    ``stale_after`` is only used when an owner cannot be identified safely.
+    """
+
+    def __init__(
+        self,
+        target: Path,
+        *,
+        timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+        stale_after: float = _DEFAULT_STALE_AFTER_SECONDS,
+    ) -> None:
+        self.target = Path(target)
+        self.path = _lock_path_for(self.target)
+        self.timeout = timeout
+        self.stale_after = stale_after
+        self._token: Optional[str] = None
+
+    @classmethod
+    def for_target(
+        cls,
+        target: Path,
+        *,
+        timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+        stale_after: float = _DEFAULT_STALE_AFTER_SECONDS,
+    ) -> "InterProcessFileLock":
+        """Create the standard per-target writer lock.
+
+        The caller must keep the returned context open over its entire
+        read-modify-write operation, not merely the final write.
+        """
+        return cls(target, timeout=timeout, stale_after=stale_after)
+
+    def __enter__(self) -> "InterProcessFileLock":
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.release()
+
+    def acquire(self) -> None:
+        if self._token is not None:
+            raise RuntimeError("interprocess lock is already held by this instance")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        deadline = time.monotonic() + self.timeout
+        token = secrets.token_hex(16)
+        payload = json.dumps(
+            {"pid": os.getpid(), "created_at": time.time(), "token": token},
+            separators=(",", ":"),
+        ).encode("utf-8")
+        while True:
+            try:
+                fd = os.open(
+                    self.path,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o600 if os.name != "nt" else 0o666,
+                )
+            except FileExistsError:
+                self._recover_stale_owner()
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        "timed out acquiring interprocess lock for " + str(self.target)
+                    )
+                time.sleep(_POLL_SECONDS)
+                continue
+            try:
+                with os.fdopen(fd, "wb", closefd=False) as handle:
+                    handle.write(payload)
+                    handle.flush()
+                    try:
+                        os.fsync(handle.fileno())
+                    except OSError:
+                        # Some Windows/filesystem combinations do not expose
+                        # fsync for this tiny advisory file. O_EXCL remains the
+                        # correctness primitive; durability is best effort.
+                        pass
+            finally:
+                os.close(fd)
+            self._token = token
+            return
+
+    def release(self) -> None:
+        token = self._token
+        self._token = None
+        if token is None:
+            return
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return
+        if isinstance(data, dict) and data.get("token") == token:
+            try:
+                self.path.unlink()
+            except FileNotFoundError:
+                pass
+
+    def _recover_stale_owner(self) -> None:
+        """Remove only an orphaned lock, with a guard against reclaim races."""
+        reclaim_path = self.path.with_name(self.path.name + ".reclaim")
+        try:
+            reclaim_fd = os.open(
+                reclaim_path,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600 if os.name != "nt" else 0o666,
+            )
+        except FileExistsError:
+            return
+        try:
+            os.close(reclaim_fd)
+            try:
+                raw = self.path.read_text(encoding="utf-8")
+                data = json.loads(raw)
+            except (OSError, json.JSONDecodeError):
+                data = None
+            now = time.time()
+            pid = data.get("pid") if isinstance(data, dict) else None
+            created_at = data.get("created_at") if isinstance(data, dict) else None
+            if not isinstance(created_at, (int, float)):
+                try:
+                    created_at = self.path.stat().st_mtime
+                except OSError:
+                    created_at = None
+            owner_alive = isinstance(pid, int) and _pid_is_alive(pid)
+            age = now - created_at if isinstance(created_at, (int, float)) else None
+            recoverable = (isinstance(pid, int) and not owner_alive) or (
+                not isinstance(pid, int) and age is not None and age >= self.stale_after
+            )
+            if recoverable:
+                try:
+                    self.path.unlink()
+                except FileNotFoundError:
+                    pass
+        finally:
+            try:
+                reclaim_path.unlink()
+            except FileNotFoundError:
+                pass

--- a/puppetmaster/mcp_registry.py
+++ b/puppetmaster/mcp_registry.py
@@ -58,6 +58,11 @@ DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 10.0
 # whose parent client is gone.
 DEFAULT_STALE_AFTER_SECONDS = 300.0
 
+# A server's heartbeat thread and its request workers update the same tracking
+# file.  The registry is per-process (one file per PID), so an in-process lock
+# is sufficient to prevent one update from silently dropping another field.
+_REGISTRY_FILE_LOCK = threading.Lock()
+
 
 @dataclass
 class McpServerEntry:
@@ -67,6 +72,8 @@ class McpServerEntry:
     workspace: Optional[str]
     started_at: float
     last_heartbeat: float
+    last_inbound_at: Optional[float] = None
+    active_tool_calls: int = 0
     transport: str = "stdio"
     version: Optional[str] = None
     parent_pid: Optional[int] = None
@@ -80,6 +87,12 @@ class McpServerEntry:
         current = now if now is not None else time.time()
         return (current - self.last_heartbeat) > stale_after_seconds
 
+    def is_idle(self, *, now: Optional[float] = None, idle_after_seconds: float) -> bool:
+        """Whether this server has received no inbound MCP traffic recently."""
+        current = now if now is not None else time.time()
+        last_inbound = self.last_inbound_at if self.last_inbound_at is not None else self.last_heartbeat
+        return (current - last_inbound) >= idle_after_seconds
+
     def to_payload(self, *, now: Optional[float] = None) -> dict:
         current = now if now is not None else time.time()
         return {
@@ -87,8 +100,14 @@ class McpServerEntry:
             "workspace": self.workspace,
             "started_at": self.started_at,
             "last_heartbeat": self.last_heartbeat,
+            "last_inbound_at": self.last_inbound_at,
             "age_seconds": round(current - self.started_at, 3),
             "heartbeat_age_seconds": round(current - self.last_heartbeat, 3),
+            "inbound_age_seconds": round(
+                current - (self.last_inbound_at if self.last_inbound_at is not None else self.last_heartbeat),
+                3,
+            ),
+            "active_tool_calls": self.active_tool_calls,
             "parent_pid": self.parent_pid,
             "parent_process": self.parent_process,
             "transport": self.transport,
@@ -97,6 +116,14 @@ class McpServerEntry:
             "stale": self.is_stale(now=current),
             "path": self.path,
         }
+
+
+@dataclass
+class McpSelectionResult:
+    """Outcome of an explicitly-selected server cleanup operation."""
+
+    killed: list[McpServerEntry]
+    refused: list[dict]
 
 
 def registry_dir() -> Path:
@@ -134,6 +161,8 @@ def register(
     transport: str = "stdio",
     parent_pid: Optional[int] = None,
     parent_process: Optional[str] = None,
+    last_inbound_at: Optional[float] = None,
+    active_tool_calls: int = 0,
 ) -> Path:
     """Write this server's tracking file and return its path.
 
@@ -153,6 +182,8 @@ def register(
         "workspace": workspace,
         "started_at": now,
         "last_heartbeat": now,
+        "last_inbound_at": last_inbound_at if last_inbound_at is not None else now,
+        "active_tool_calls": max(0, int(active_tool_calls)),
         "transport": transport,
         "version": version,
         "parent_pid": actual_parent_pid,
@@ -170,17 +201,47 @@ def heartbeat(path: Path, *, now: Optional[float] = None) -> bool:
     up because it thought we were dead) so the heartbeat thread can
     re-register itself instead of dying silently.
     """
-    if not path.exists():
-        return False
-    try:
-        data = _read_entry(path)
-    except (OSError, ValueError):
-        return False
-    if data is None:
-        return False
-    data["last_heartbeat"] = now if now is not None else time.time()
-    _atomic_write(path, data)
-    return True
+    with _REGISTRY_FILE_LOCK:
+        if not path.exists():
+            return False
+        try:
+            data = _read_entry(path)
+        except (OSError, ValueError):
+            return False
+        if data is None:
+            return False
+        data["last_heartbeat"] = now if now is not None else time.time()
+        _atomic_write(path, data)
+        return True
+
+
+def record_activity(
+    path: Path,
+    *,
+    inbound_at: Optional[float] = None,
+    active_tool_calls: Optional[int] = None,
+) -> bool:
+    """Persist request activity for safe cleanup decisions.
+
+    Heartbeats prove a process is alive; they do not prove its MCP client is
+    still talking to it.  The active-call count is persisted as well so a
+    separate CLI/MCP process can refuse to terminate work in flight.
+    """
+    with _REGISTRY_FILE_LOCK:
+        if not path.exists():
+            return False
+        try:
+            data = _read_entry(path)
+        except (OSError, ValueError):
+            return False
+        if data is None:
+            return False
+        if inbound_at is not None:
+            data["last_inbound_at"] = float(inbound_at)
+        if active_tool_calls is not None:
+            data["active_tool_calls"] = max(0, int(active_tool_calls))
+        _atomic_write(path, data)
+        return True
 
 
 def deregister(path: Path) -> None:
@@ -222,6 +283,8 @@ def list_entries(*, include_stale: bool = True) -> list[McpServerEntry]:
                 workspace=data.get("workspace"),
                 started_at=float(data.get("started_at") or now),
                 last_heartbeat=float(data.get("last_heartbeat") or now),
+                last_inbound_at=_coerce_optional_float(data.get("last_inbound_at")),
+                active_tool_calls=max(0, _coerce_optional_int(data.get("active_tool_calls")) or 0),
                 transport=str(data.get("transport") or "stdio"),
                 version=data.get("version"),
                 parent_pid=_coerce_optional_int(data.get("parent_pid")),
@@ -303,6 +366,94 @@ def kill_stale(
     return killed
 
 
+def normalize_workspace(workspace: Optional[str]) -> Optional[str]:
+    """Return a stable workspace identity for explicit cleanup selectors."""
+    if workspace is None:
+        return None
+    value = str(workspace).strip()
+    if not value:
+        return None
+    try:
+        return os.path.normcase(os.path.normpath(str(Path(value).expanduser().resolve(strict=False))))
+    except (OSError, RuntimeError):
+        return os.path.normcase(os.path.normpath(os.path.abspath(os.path.expanduser(value))))
+
+
+def kill_selected(
+    *,
+    pids: Optional[Iterable[int]] = None,
+    workspace: Optional[str] = None,
+    idle_after_seconds: Optional[float] = None,
+    self_pid: Optional[int] = None,
+    grace_seconds: float = 3.0,
+) -> McpSelectionResult:
+    """Terminate only explicitly selected, inactive sibling MCP servers.
+
+    All supplied selectors intersect.  This deliberately has no implicit
+    target set: callers must name a PID, workspace, or inbound-idle threshold.
+    Unlike historical ``kill_stale``, this precise manual path refuses active
+    tool calls as an additional safety boundary.
+    """
+    requested_pids = {int(pid) for pid in pids} if pids else None
+    requested_workspace = normalize_workspace(workspace)
+    requested_idle = float(idle_after_seconds) if idle_after_seconds is not None else None
+    if requested_idle is not None and requested_idle < 0:
+        raise ValueError("idle_after_seconds must be non-negative")
+    if requested_pids is None and requested_workspace is None and requested_idle is None:
+        return McpSelectionResult(killed=[], refused=[])
+
+    me = self_pid if self_pid is not None else os.getpid()
+    now = time.time()
+    targets: list[McpServerEntry] = []
+    refused: list[dict] = []
+    for entry in list_entries():
+        if not entry.is_alive():
+            continue
+        if requested_pids is not None and entry.pid not in requested_pids:
+            continue
+        if requested_workspace is not None and normalize_workspace(entry.workspace) != requested_workspace:
+            continue
+        if requested_idle is not None and not entry.is_idle(now=now, idle_after_seconds=requested_idle):
+            continue
+        if entry.pid == me:
+            refused.append({"pid": entry.pid, "workspace": entry.workspace, "reason": "self"})
+            continue
+        if entry.active_tool_calls > 0:
+            refused.append(
+                {
+                    "pid": entry.pid,
+                    "workspace": entry.workspace,
+                    "reason": "active_tool_calls",
+                    "active_tool_calls": entry.active_tool_calls,
+                }
+            )
+            continue
+        targets.append(entry)
+
+    killed: list[McpServerEntry] = []
+    for entry in targets:
+        try:
+            os.kill(entry.pid, signal.SIGTERM)
+        except OSError:
+            continue
+        killed.append(entry)
+    if grace_seconds > 0 and targets:
+        time.sleep(grace_seconds)
+    for entry in targets:
+        if not _pid_alive(entry.pid):
+            if entry.path:
+                deregister(Path(entry.path))
+            continue
+        hard_kill = getattr(signal, "SIGKILL", signal.SIGTERM)
+        try:
+            os.kill(entry.pid, hard_kill)
+        except OSError:
+            continue
+        if entry.path:
+            deregister(Path(entry.path))
+    return McpSelectionResult(killed=killed, refused=refused)
+
+
 class HeartbeatThread(threading.Thread):
     """Background thread that bumps a tracking file on a fixed cadence.
 
@@ -346,6 +497,8 @@ class HeartbeatThread(threading.Thread):
             transport=str(self._registration_payload.get("transport") or "stdio"),
             parent_pid=_coerce_optional_int(self._registration_payload.get("parent_pid")),
             parent_process=_coerce_optional_str(self._registration_payload.get("parent_process")),
+            last_inbound_at=_coerce_optional_float(self._registration_payload.get("last_inbound_at")),
+            active_tool_calls=_coerce_optional_int(self._registration_payload.get("active_tool_calls")) or 0,
         )
 
     @staticmethod
@@ -404,6 +557,15 @@ def _coerce_optional_int(value: object) -> Optional[int]:
         return None
     try:
         return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_optional_float(value: object) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
     except (TypeError, ValueError):
         return None
 

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -343,23 +343,29 @@ def _extract_progress_token(params: Any) -> Any:
     return meta.get("progressToken")
 
 
-def _emit_notification(notification: JsonObject) -> bool:
-    """Serialize and write a JSON-RPC notification under the stdout lock.
+def _write_protocol_message(message: JsonObject) -> bool:
+    """Serialize and atomically write one JSON-RPC frame to the client.
 
     Returns False when the pipe is gone (BrokenPipeError or general OSError),
-    so callers running on a daemon thread can stop trying. Notifications
-    must never have an ``id`` field — that's how clients distinguish them
-    from responses.
+    allowing worker and keepalive threads to finish without leaking an
+    unobserved exception through their Future. All protocol frames use this
+    function so the shared lock prevents byte interleaving.
     """
-    serialized = json.dumps(notification) + "\n"
+    serialized = json.dumps(message) + "\n"
     try:
         with _STDOUT_LOCK:
             stream = _protocol_stream()
             stream.write(serialized)
             stream.flush()
     except (BrokenPipeError, OSError):
+        _SHUTDOWN_REQUESTED.set()
         return False
     return True
+
+
+def _emit_notification(notification: JsonObject) -> bool:
+    """Write a JSON-RPC notification through the shared protocol writer."""
+    return _write_protocol_message(notification)
 
 
 class _ToolCallKeepalive:
@@ -1108,11 +1114,7 @@ def _process_message_safely(message: JsonObject, *, tool_call_counted: bool = Fa
             _tool_call_finished()
     if response is None:
         return
-    serialized = json.dumps(response) + "\n"
-    with _STDOUT_LOCK:
-        stream = _protocol_stream()
-        stream.write(serialized)
-        stream.flush()
+    _write_protocol_message(response)
 
 
 def handle_message(message: JsonObject) -> Optional[JsonObject]:
@@ -1573,8 +1575,9 @@ def _build_tools() -> list[McpTool]:
             name="puppetmaster_live_artifacts_follow",
             description=(
                 "Long-poll for new artifacts since a cursor. Returns immediately when new "
-                "artifacts arrive, or after timeout_seconds with an empty items array. "
-                "Chain calls with the returned next_cursor for a push-feeling stream."
+                "artifacts arrive or the job reaches a terminal state; otherwise returns "
+                "after timeout_seconds with an empty items array. Includes status, terminal, "
+                "completed_at, and next_cursor so callers can stop cleanly or continue."
             ),
             input_schema=follow_schema(),
             handler=run_feed_follow,
@@ -3660,7 +3663,7 @@ def run_feed(args: JsonObject) -> JsonObject:
 
 
 def run_feed_follow(args: JsonObject) -> JsonObject:
-    from puppetmaster.cli import artifact_feed_since
+    from puppetmaster.cli import artifact_feed_since, read_job_state
 
     job_id = require_string(args, "job_id")
     since = int(args.get("since_cursor") or args.get("since") or 0)
@@ -3675,7 +3678,8 @@ def run_feed_follow(args: JsonObject) -> JsonObject:
     store = create_store(backend, state_dir)
 
     items, cursor = artifact_feed_since(store, job_id, since=since, limit=limit)
-    if not items:
+    state = read_job_state(store, job_id)
+    if not items and not state["terminal"]:
         store.wait_for_events(
             job_id,
             since=cursor,
@@ -3683,16 +3687,17 @@ def run_feed_follow(args: JsonObject) -> JsonObject:
             poll_interval=poll_interval,
         )
         items, cursor = artifact_feed_since(store, job_id, since=since, limit=limit)
+        state = read_job_state(store, job_id)
 
     body = {
-        "job_id": job_id,
+        **state,
         "since_cursor": since,
         "next_cursor": cursor,
         "item_count": len(items),
         "items": items,
-        "timed_out": len(items) == 0,
+        "timed_out": len(items) == 0 and not state["terminal"],
     }
-    if was_capped:
+    if was_capped and not state["terminal"]:
         # Tell the caller the block was shortened so it knows to re-poll
         # rather than assuming the job produced nothing for `requested_timeout`.
         body["capped"] = True

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -35,8 +35,10 @@ from puppetmaster.mcp_registry import (
     deregister as registry_deregister,
     installed_puppetmaster_version,
     kill_stale as registry_kill_stale,
+    kill_selected as registry_kill_selected,
     list_entries as registry_list_entries,
     prune_dead as registry_prune_dead,
+    record_activity as registry_record_activity,
     register as registry_register,
     summarize as registry_summarize,
 )
@@ -204,6 +206,7 @@ _DEFAULT_MAX_BLOCK_SECONDS = 45.0
 _INPUT_STATE_LOCK = threading.Lock()
 _LAST_INBOUND_MESSAGE_AT = time.time()
 _ACTIVE_TOOL_CALLS = 0
+_REGISTRY_ACTIVITY_PATH: Optional[Path] = None
 _SHUTDOWN_REQUESTED = threading.Event()
 
 # Client identity from the MCP `initialize` handshake (params.clientInfo).
@@ -613,20 +616,41 @@ def _mark_inbound_message() -> None:
     orphan whose Cursor parent has stopped talking to it.
     """
     global _LAST_INBOUND_MESSAGE_AT
+    now = time.time()
     with _INPUT_STATE_LOCK:
-        _LAST_INBOUND_MESSAGE_AT = time.time()
+        _LAST_INBOUND_MESSAGE_AT = now
+        registration_path = _REGISTRY_ACTIVITY_PATH
+    if registration_path is not None:
+        try:
+            registry_record_activity(registration_path, inbound_at=now)
+        except OSError:
+            pass
 
 
 def _tool_call_started() -> None:
     global _ACTIVE_TOOL_CALLS
     with _INPUT_STATE_LOCK:
         _ACTIVE_TOOL_CALLS += 1
+        active_tool_calls = _ACTIVE_TOOL_CALLS
+        registration_path = _REGISTRY_ACTIVITY_PATH
+    if registration_path is not None:
+        try:
+            registry_record_activity(registration_path, active_tool_calls=active_tool_calls)
+        except OSError:
+            pass
 
 
 def _tool_call_finished() -> None:
     global _ACTIVE_TOOL_CALLS
     with _INPUT_STATE_LOCK:
         _ACTIVE_TOOL_CALLS = max(0, _ACTIVE_TOOL_CALLS - 1)
+        active_tool_calls = _ACTIVE_TOOL_CALLS
+        registration_path = _REGISTRY_ACTIVITY_PATH
+    if registration_path is not None:
+        try:
+            registry_record_activity(registration_path, active_tool_calls=active_tool_calls)
+        except OSError:
+            pass
 
 
 def _input_state_snapshot() -> tuple[float, int]:
@@ -931,10 +955,11 @@ def main() -> int:
 
     # Reset the staleness counter at startup so a slow Cursor handshake
     # doesn't immediately look orphaned to the watcher.
-    global _LAST_INBOUND_MESSAGE_AT, _ACTIVE_TOOL_CALLS
+    global _LAST_INBOUND_MESSAGE_AT, _ACTIVE_TOOL_CALLS, _REGISTRY_ACTIVITY_PATH
     with _INPUT_STATE_LOCK:
         _LAST_INBOUND_MESSAGE_AT = time.time()
         _ACTIVE_TOOL_CALLS = 0
+        _REGISTRY_ACTIVITY_PATH = registration_path
     _SHUTDOWN_REQUESTED.clear()
 
     input_watcher: Optional[_InputStalenessWatcher] = None
@@ -979,9 +1004,21 @@ def main() -> int:
                 except json.JSONDecodeError:
                     continue
                 _mark_inbound_message()
+                is_tool_call = message.get("method") == "tools/call"
+                if is_tool_call:
+                    # Persist this before the work reaches the executor. A
+                    # selected cleanup in another process must not be able to
+                    # kill a request merely because it is queued briefly.
+                    _tool_call_started()
                 try:
-                    executor.submit(_process_message_safely, message)
+                    executor.submit(
+                        _process_message_safely,
+                        message,
+                        tool_call_counted=is_tool_call,
+                    )
                 except RuntimeError as exc:
+                    if is_tool_call:
+                        _tool_call_finished()
                     exit_reason = f"executor_submit_failed: {exc}"
                     raise
         except KeyboardInterrupt:
@@ -1013,6 +1050,8 @@ def main() -> int:
                 registry_deregister(registration_path)
             except OSError:
                 pass
+        with _INPUT_STATE_LOCK:
+            _REGISTRY_ACTIVITY_PATH = None
     return 0
 
 
@@ -1036,7 +1075,7 @@ def _server_version() -> Optional[str]:
         return None
 
 
-def _process_message_safely(message: JsonObject) -> None:
+def _process_message_safely(message: JsonObject, *, tool_call_counted: bool = False) -> None:
     """Run handle_message on a worker thread and write any response.
 
     Wraps every ``tools/call`` in a :class:`_ToolCallKeepalive` so a long
@@ -1054,7 +1093,7 @@ def _process_message_safely(message: JsonObject) -> None:
             progress_token=_extract_progress_token(params),
         )
         keepalive.start()
-    if is_tool_call:
+    if is_tool_call and not tool_call_counted:
         _tool_call_started()
     try:
         response = handle_message(message)
@@ -1707,8 +1746,9 @@ def _build_tools() -> list[McpTool]:
             description=(
                 "Prune dead tracking files for MCP servers that exited without cleanup, "
                 "and (with kill_stale=true) SIGTERM/SIGKILL stale-but-alive Puppetmaster "
-                "MCP servers whose parent client appears to be gone. Never signals the "
-                "current process. Returns the before/after registry snapshot."
+                "MCP servers whose parent client appears to be gone. Explicit pids, workspace, "
+                "and idle_after_seconds selectors can terminate only matching inactive siblings. "
+                "Never signals the current process. Returns the before/after registry snapshot."
             ),
             input_schema=mcp_cleanup_schema(),
             handler=run_mcp_cleanup,
@@ -1952,6 +1992,31 @@ def run_mcp_cleanup(args: JsonObject) -> JsonObject:
             }
         )
     killed: list = []
+    selected_killed: list = []
+    refused: list = []
+    pids = args.get("pids")
+    workspace = args.get("workspace")
+    idle_after = args.get("idle_after_seconds")
+    has_selector = bool(pids) or workspace is not None or idle_after is not None
+    if has_selector:
+        try:
+            selected = registry_kill_selected(
+                pids=pids,
+                workspace=workspace,
+                idle_after_seconds=float(idle_after) if idle_after is not None else None,
+                self_pid=os.getpid(),
+            )
+        except Exception as exc:
+            return _mcp_diagnostic_response(
+                {
+                    "ok": False,
+                    "error": f"selected cleanup failed: {exc}",
+                    "before": before,
+                    "pruned": [entry.to_payload() for entry in pruned],
+                }
+            )
+        selected_killed = [entry.to_payload() for entry in selected.killed]
+        refused = selected.refused
     if bool(args.get("kill_stale", False)):
         stale_after = float(args.get("stale_after_seconds") or 300)
         try:
@@ -1977,6 +2042,8 @@ def run_mcp_cleanup(args: JsonObject) -> JsonObject:
             "after": after,
             "pruned": [entry.to_payload() for entry in pruned],
             "killed": killed,
+            "selected_killed": selected_killed,
+            "refused": refused,
             "self_pid": os.getpid(),
         }
     )
@@ -4389,6 +4456,20 @@ def mcp_cleanup_schema() -> JsonObject:
                     "heartbeat is older than stale_after_seconds. The current "
                     "process is never signalled."
                 ),
+            },
+            "pids": {
+                "type": "array",
+                "items": {"type": "integer"},
+                "description": "Explicit MCP server PIDs to terminate. Intersects other selectors.",
+            },
+            "workspace": {
+                "type": "string",
+                "description": "Explicit workspace selector; normalized before matching.",
+            },
+            "idle_after_seconds": {
+                "type": "number",
+                "minimum": 0,
+                "description": "Terminate only servers with no inbound MCP message for this many seconds.",
             },
             "stale_after_seconds": {
                 "type": "integer",

--- a/puppetmaster/model_registry.py
+++ b/puppetmaster/model_registry.py
@@ -31,15 +31,15 @@ Each entry pairs:
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
-import hashlib
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
 from puppetmaster.fs_permissions import write_private_text
-
+from puppetmaster.interprocess_lock import InterProcessFileLock
 
 REGISTRY_ENV = "PUPPETMASTER_MODELS_PATH"
 
@@ -55,6 +55,8 @@ DISCOVERY_SOURCE_TO_ADAPTER: dict[str, str] = {
     "codex": "codex",
     "hermes": "hermes",
     "agentic": "agentic",
+    "antigravity": "antigravity",
+    "agy": "antigravity",
 }
 
 
@@ -202,7 +204,12 @@ def save_registry(
     payload: dict[str, Any] = {
         "models": [_spec_to_jsonable(spec) for spec in specs],
     }
-    write_private_text(resolved, json.dumps(payload, indent=2, sort_keys=False) + "\n")
+    # A registry is user-global. Serialize writers even when callers provide
+    # an explicit path, and publish the complete JSON document atomically.
+    with InterProcessFileLock.for_target(resolved):
+        write_private_text(
+            resolved, json.dumps(payload, indent=2, sort_keys=False) + "\n", lock=False
+        )
     return resolved
 
 

--- a/puppetmaster/models.py
+++ b/puppetmaster/models.py
@@ -47,6 +47,21 @@ class JobStatus(StringEnum):
     CANCELLED = "cancelled"
 
 
+TERMINAL_JOB_STATUSES = frozenset(
+    {
+        JobStatus.COMPLETE,
+        JobStatus.FAILED,
+        JobStatus.STALLED,
+        JobStatus.CANCELLED,
+    }
+)
+
+
+def is_terminal_job_status(status: JobStatus) -> bool:
+    """Return whether ``status`` represents a job that will do no more work."""
+    return status in TERMINAL_JOB_STATUSES
+
+
 class TaskStatus(StringEnum):
     BLOCKED = "blocked"
     QUEUED = "queued"

--- a/puppetmaster/platform_billing.py
+++ b/puppetmaster/platform_billing.py
@@ -612,6 +612,50 @@ def detect_agentic_billing(
     )
 
 
+def detect_antigravity_billing(
+    env: Optional[Mapping[str, str]] = None,
+    home: Optional[Path] = None,
+) -> BillingStatus:
+    """Detect Antigravity CLI (agy) billing posture (plan vs API key)."""
+    import shutil as _shutil
+
+    env = env if env is not None else os.environ
+    home = home if home is not None else Path.home()
+
+    gemini_key = env.get("GEMINI_API_KEY") or env.get("GOOGLE_API_KEY")
+    evidence: list[str] = []
+    if gemini_key:
+        evidence.append("gemini_api_key:set")
+
+    settings_dir = home / ".gemini" / "antigravity-cli"
+    agy_on_path = _shutil.which(env.get("AGY_COMMAND") or env.get("ANTIGRAVITY_COMMAND") or "agy") is not None
+
+    if gemini_key:
+        return BillingStatus(
+            adapter="antigravity",
+            billing="api",
+            healthy=True,
+            detail="GEMINI_API_KEY/GOOGLE_API_KEY is set — Antigravity bills per-token to that account (out-of-pocket).",
+            evidence=evidence,
+        )
+    if agy_on_path or settings_dir.is_dir():
+        evidence.append("antigravity_session:present")
+        return BillingStatus(
+            adapter="antigravity",
+            billing="plan",
+            healthy=True,
+            detail="Antigravity CLI is authenticated via user account / subscription (no marginal API spend).",
+            evidence=evidence,
+        )
+    return BillingStatus(
+        adapter="antigravity",
+        billing="unknown",
+        healthy=False,
+        detail="No GEMINI_API_KEY/GOOGLE_API_KEY and no Antigravity CLI session found — run `agy` to authenticate.",
+        evidence=["antigravity_auth:missing"],
+    )
+
+
 _DETECTORS: dict[str, Callable[..., BillingStatus]] = {
     "cursor": lambda **kw: detect_cursor_billing(env=kw.get("env")),
     "claude-code": lambda **kw: detect_claude_billing(
@@ -625,6 +669,12 @@ _DETECTORS: dict[str, Callable[..., BillingStatus]] = {
     ),
     "openai": lambda **kw: detect_openai_billing(env=kw.get("env")),
     "agentic": lambda **kw: detect_agentic_billing(
+        env=kw.get("env"), home=kw.get("home")
+    ),
+    "antigravity": lambda **kw: detect_antigravity_billing(
+        env=kw.get("env"), home=kw.get("home")
+    ),
+    "agy": lambda **kw: detect_antigravity_billing(
         env=kw.get("env"), home=kw.get("home")
     ),
 }

--- a/puppetmaster/platform_lock.py
+++ b/puppetmaster/platform_lock.py
@@ -25,12 +25,21 @@ from pathlib import Path
 from typing import Optional
 
 from puppetmaster.fs_permissions import write_private_text
+from puppetmaster.interprocess_lock import InterProcessFileLock
 from puppetmaster.model_registry import default_registry_path
 
 # The user-billable adapters the lock governs. ``shell`` and any future
 # internal adapter are intentionally excluded — they are never platform-billed
 # and must not be blocked by a platform lock.
-KNOWN_ADAPTERS: tuple[str, ...] = ("agentic", "cursor", "claude-code", "codex", "openai", "hermes")
+KNOWN_ADAPTERS: tuple[str, ...] = (
+    "agentic",
+    "cursor",
+    "claude-code",
+    "codex",
+    "openai",
+    "hermes",
+    "antigravity",
+)
 
 ONLY_ENV = "PUPPETMASTER_ONLY_ADAPTERS"
 
@@ -91,6 +100,13 @@ def _write_disabled(disabled: set[str], registry_path: Optional[Path] = None) ->
     # defaults on). Replacing the whole document strips foreign keys and makes
     # the next harness boot re-apply ITS defaults, silently undoing an
     # operator's `platform enable`. Preserve everything we don't own.
+    with InterProcessFileLock.for_target(path):
+        _write_disabled_locked(disabled, path)
+    return path
+
+
+def _write_disabled_locked(disabled: set[str], path: Path) -> Path:
+    """Write while the caller holds the per-target platform lock."""
     payload: dict = {}
     if path.is_file():
         try:
@@ -100,7 +116,7 @@ def _write_disabled(disabled: set[str], registry_path: Optional[Path] = None) ->
         except (json.JSONDecodeError, OSError):
             payload = {}
     payload["disabled"] = sorted(a for a in disabled if a in KNOWN_ADAPTERS)
-    write_private_text(path, json.dumps(payload, indent=2) + "\n")
+    write_private_text(path, json.dumps(payload, indent=2) + "\n", lock=False)
     return path
 
 
@@ -159,14 +175,18 @@ def set_enabled(adapters: set[str], registry_path: Optional[Path] = None) -> Pat
 
 def enable(adapters: set[str], registry_path: Optional[Path] = None) -> Path:
     """Turn ``adapters`` back on (remove from the denylist)."""
-    disabled = _read_disabled(registry_path) - adapters
-    return _write_disabled(disabled, registry_path)
+    path = platform_config_path(registry_path)
+    with InterProcessFileLock.for_target(path):
+        disabled = _read_disabled(registry_path) - adapters
+        return _write_disabled_locked(disabled, path)
 
 
 def disable(adapters: set[str], registry_path: Optional[Path] = None) -> Path:
     """Turn ``adapters`` off (add to the denylist)."""
-    disabled = _read_disabled(registry_path) | {a for a in adapters if a in KNOWN_ADAPTERS}
-    return _write_disabled(disabled, registry_path)
+    path = platform_config_path(registry_path)
+    with InterProcessFileLock.for_target(path):
+        disabled = _read_disabled(registry_path) | {a for a in adapters if a in KNOWN_ADAPTERS}
+        return _write_disabled_locked(disabled, path)
 
 
 def reset(registry_path: Optional[Path] = None) -> Path:

--- a/puppetmaster/provider_circuit.py
+++ b/puppetmaster/provider_circuit.py
@@ -9,11 +9,12 @@ Thread-safe, stdlib-only, Python 3.9+. Kill with ``PUPPETMASTER_PROVIDER_CIRCUIT
 """
 from __future__ import annotations
 
+import hashlib
 import os
 import threading
 import time
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Callable, Mapping, Optional
 
 from puppetmaster.failure import RATE_LIMIT
 from puppetmaster.providers import ProviderError, get_provider, is_retryable_provider_error, resolve_base_url
@@ -101,21 +102,88 @@ def closed_bucket_ttl_seconds() -> float:
     return max(_ABS_MIN_CLOSED_TTL, min(value, _ABS_MAX_CLOSED_TTL))
 
 
-def circuit_key(provider: str, model: str = "", *, base_url: str = "") -> str:
-    """Stable admission key: provider + model + base URL (when known)."""
-    return f"{(provider or '').strip().lower()}\x1f{(model or '').strip()}\x1f{(base_url or '').rstrip('/')}"
+def credential_fingerprint(api_key: Optional[str]) -> str:
+    """Return a non-secret stable scope for an API credential.
+
+    The value is stored in the user-global passive rate-limit database and used
+    by the process-local breaker, so it must distinguish independently limited
+    credentials without retaining the bearer itself.  ``keyless`` is explicit
+    rather than an empty field: local endpoints genuinely share one admission
+    scope because there is no credential boundary to distinguish.
+    """
+    normalized = (api_key or "").strip()
+    if not normalized:
+        return "keyless"
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
 
 
-def resolve_circuit_key(provider: str, model: str = "") -> str:
-    """Build a key, resolving the provider's effective base URL when registered."""
-    base_url = ""
+def circuit_key(
+    provider: str,
+    model: str = "",
+    *,
+    base_url: str = "",
+    api_key: Optional[str] = None,
+    credential_scope: Optional[str] = None,
+) -> str:
+    """Stable admission key scoped to provider, model, endpoint, and credential."""
+    scope = (credential_scope or "").strip() or credential_fingerprint(api_key)
+    return (
+        f"{(provider or '').strip().lower()}\x1f{(model or '').strip()}"
+        f"\x1f{(base_url or '').rstrip('/')}\x1f{scope}"
+    )
+
+
+def resolve_circuit_key(
+    provider: str,
+    model: str = "",
+    *,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> str:
+    """Build a credential-scoped key using the provider's effective endpoint.
+
+    Passing an explicit key is required for rotating-key callers.  When omitted,
+    the descriptor's normal environment resolution is used so direct
+    ``provider_chat`` calls and agentic admission use the same scope.
+    """
+    resolved_base_url = (base_url or "").rstrip("/")
+    credential_scope = ""
     desc = get_provider(provider)
     if desc is not None:
-        try:
-            base_url = resolve_base_url(desc)
-        except Exception:
-            base_url = (desc.base_url or "").rstrip("/")
-    return circuit_key(provider, model, base_url=base_url)
+        if not resolved_base_url:
+            try:
+                resolved_base_url = resolve_base_url(desc, env)
+            except Exception:
+                resolved_base_url = (desc.base_url or "").rstrip("/")
+        if api_key is None:
+            # Local import avoids making the registry's module import cycle
+            # eager; provider_circuit is itself imported by providers at call
+            # time around HTTP harvest scopes.
+            from puppetmaster.providers import resolve_api_key
+
+            api_key = resolve_api_key(desc, env)
+        if desc.slug == "bedrock" and api_key is None:
+            # Bedrock may use ambient SigV4 credentials instead of a bearer.
+            # Reuse its health subsystem's non-secret identity fingerprint so
+            # distinct AWS identities do not share a quota/circuit bucket.
+            from puppetmaster.bedrock import resolve_bedrock_credentials
+            from puppetmaster.provider_health import fingerprint_bedrock_credentials
+
+            credentials = resolve_bedrock_credentials(env)
+            if credentials is not None:
+                credential_scope = (
+                    "bedrock:"
+                    + fingerprint_bedrock_credentials(credentials)
+                )
+    return circuit_key(
+        provider,
+        model,
+        base_url=resolved_base_url,
+        api_key=api_key,
+        credential_scope=credential_scope,
+    )
 
 
 def admission_blocked_error(key: str) -> ProviderError:

--- a/puppetmaster/providers.py
+++ b/puppetmaster/providers.py
@@ -2083,8 +2083,19 @@ def provider_chat_streaming(
     from puppetmaster.provider_circuit import resolve_circuit_key
     from puppetmaster.rate_limit_state import harvesting_rate_limits
 
+    env = env if env is not None else os.environ
+    desc = get_provider(provider)
+    resolved_api_key = api_key
+    if resolved_api_key is None and desc is not None:
+        resolved_api_key = resolve_api_key(desc, env)
     with harvesting_rate_limits(
-        resolve_circuit_key(provider, model),
+        resolve_circuit_key(
+            provider,
+            model,
+            api_key=resolved_api_key,
+            base_url=base_url,
+            env=env,
+        ),
         provider=provider,
         model=model,
     ):
@@ -2194,8 +2205,19 @@ def provider_chat(
     from puppetmaster.provider_circuit import resolve_circuit_key
     from puppetmaster.rate_limit_state import harvesting_rate_limits
 
+    env = env if env is not None else os.environ
+    desc = get_provider(provider)
+    resolved_api_key = api_key
+    if resolved_api_key is None and desc is not None:
+        resolved_api_key = resolve_api_key(desc, env)
     with harvesting_rate_limits(
-        resolve_circuit_key(provider, model),
+        resolve_circuit_key(
+            provider,
+            model,
+            api_key=resolved_api_key,
+            base_url=base_url,
+            env=env,
+        ),
         provider=provider,
         model=model,
     ):

--- a/puppetmaster/rate_limit_state.py
+++ b/puppetmaster/rate_limit_state.py
@@ -54,6 +54,13 @@ CREATE INDEX IF NOT EXISTS idx_rate_limits_updated
     ON rate_limits(updated_at);
 """
 
+# Version-1 keys ended after provider/model/base-URL.  They cannot safely be
+# associated with one credential after the credential-scoping upgrade, so a
+# fresh process retires them once instead of allowing a stale shared 429 to
+# block every credential indefinitely.  Version-2 keys always have a fourth
+# fingerprint field (three unit separators).
+_LEGACY_ADMISSION_KEY_SEPARATOR_COUNT = 2
+
 _HARVEST_KEY: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "puppetmaster_rate_limit_harvest_key",
     default=None,
@@ -164,6 +171,14 @@ class RateLimitStore:
             connection = self._connect()
             try:
                 connection.executescript(_SCHEMA)
+                connection.execute(
+                    """
+                    DELETE FROM rate_limits
+                    WHERE length(admission_key) - length(replace(admission_key, char(31), ''))
+                          <= ?
+                    """,
+                    (_LEGACY_ADMISSION_KEY_SEPARATOR_COUNT,),
+                )
                 connection.commit()
             finally:
                 connection.close()

--- a/puppetmaster/static_catalog.py
+++ b/puppetmaster/static_catalog.py
@@ -204,6 +204,40 @@ CURATED_CATALOGS: dict[str, list[dict]] = {
             ],
         },
     ],
+    "antigravity": [
+        {
+            "model": "gemini-3.5-flash",
+            "capability": 78,
+            "input": 0.15,
+            "output": 0.60,
+            "context": 1_000_000,
+            "tags": ["tools", "antigravity", "gemini", "fast", "cheap", "vision", "code", "agent-loop"],
+        },
+        {
+            "model": "gemini-3.6-flash",
+            "capability": 85,
+            "input": 0.30,
+            "output": 1.20,
+            "context": 1_000_000,
+            "tags": ["tools", "antigravity", "gemini", "balanced", "vision", "code", "agent-loop"],
+        },
+        {
+            "model": "gemini-3.7-flash",
+            "capability": 92,
+            "input": 0.50,
+            "output": 2.00,
+            "context": 1_000_000,
+            "tags": ["tools", "antigravity", "gemini", "balanced", "thinking", "vision", "code", "reasoning", "agent-loop"],
+        },
+        {
+            "model": "gemini-3.1-pro",
+            "capability": 97,
+            "input": 1.25,
+            "output": 5.00,
+            "context": 2_000_000,
+            "tags": ["tools", "antigravity", "gemini", "frontier", "vision", "code", "reasoning", "agent-loop", "long-context"],
+        },
+    ],
     # Hermes is API-billed: each entry routes through the user's own provider
     # key (Gemini / Anthropic / OpenAI). ``payload_defaults.provider`` is the
     # critical field — a bare model name routes to unconfigured OpenRouter, so

--- a/tests/test_antigravity_adapter.py
+++ b/tests/test_antigravity_adapter.py
@@ -1,0 +1,299 @@
+"""Tests for the Antigravity CLI (agy) worker adapter."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_HERMETIC_DIR = os.path.dirname(os.path.abspath(__file__))
+if _HERMETIC_DIR not in sys.path:
+    sys.path.insert(0, _HERMETIC_DIR)
+import hermetic_env  # noqa: F401
+
+from puppetmaster.adapters import ADAPTERS, get_adapter
+from puppetmaster.adapters.antigravity import (
+    DEFAULT_ANTIGRAVITY_EFFORT,
+    DEFAULT_ANTIGRAVITY_MODEL,
+    AntigravityAdapter,
+    build_antigravity_command,
+    resolve_antigravity_model,
+)
+from puppetmaster.failure import (
+    BILLING_OR_QUOTA,
+    MODEL_UNAVAILABLE,
+    NOT_AUTHENTICATED,
+    classify_antigravity_failure,
+)
+from puppetmaster.models import ArtifactType, Task
+from puppetmaster.platform_billing import detect_antigravity_billing
+
+
+class AntigravityCommandBuilderTests(unittest.TestCase):
+    def test_build_antigravity_command_defaults(self) -> None:
+        cmd = build_antigravity_command(prompt="audit the auth flow")
+        self.assertEqual(cmd[0], "agy")
+        self.assertIn("--output-format", cmd)
+        self.assertIn("json", cmd)
+        self.assertIn("--mode", cmd)
+        self.assertIn("accept-edits", cmd)
+        self.assertIn("--dangerously-skip-permissions", cmd)
+        self.assertIn("--disable-slash-commands", cmd)
+        self.assertEqual(cmd[-1], "-p=audit the auth flow")
+
+    def test_build_antigravity_command_plan_mode(self) -> None:
+        cmd = build_antigravity_command(
+            prompt="read only plan",
+            mode="plan",
+            model="gemini-3.7-flash",
+            effort="medium",
+            cwd=Path("/tmp/work"),
+        )
+        self.assertIn("--mode", cmd)
+        self.assertIn("plan", cmd)
+        self.assertNotIn("--dangerously-skip-permissions", cmd)
+        self.assertIn("--model", cmd)
+        self.assertIn("gemini-3.7-flash", cmd)
+        self.assertIn("--effort", cmd)
+        self.assertIn("medium", cmd)
+        self.assertIn("--add-dir", cmd)
+        self.assertIn(str(Path("/tmp/work")), cmd)
+        self.assertEqual(cmd[-1], "-p=read only plan")
+
+    def test_resolve_antigravity_model(self) -> None:
+        model, effort = resolve_antigravity_model({"model": "gemini-3.7-flash"})
+        self.assertEqual(model, "gemini-3.7-flash")
+        self.assertEqual(effort, DEFAULT_ANTIGRAVITY_EFFORT)
+
+        model2, effort2 = resolve_antigravity_model({"model": "gemini-3.7-flash", "effort": "low"})
+        self.assertEqual(model2, "gemini-3.7-flash")
+        self.assertEqual(effort2, "low")
+
+        model3, effort3 = resolve_antigravity_model({})
+        self.assertEqual(model3, DEFAULT_ANTIGRAVITY_MODEL)
+        self.assertEqual(effort3, DEFAULT_ANTIGRAVITY_EFFORT)
+
+
+class AntigravityFailureClassificationTests(unittest.TestCase):
+    def test_classify_failures(self) -> None:
+        self.assertEqual(
+            classify_antigravity_failure("model gemini-2.5-pro is not recognized as a known model"),
+            MODEL_UNAVAILABLE,
+        )
+        self.assertEqual(
+            classify_antigravity_failure("--model gemini-3.7-flash requires --effort"),
+            MODEL_UNAVAILABLE,
+        )
+        self.assertEqual(
+            classify_antigravity_failure("Error: not authenticated. Run agy to login to your account"),
+            NOT_AUTHENTICATED,
+        )
+        self.assertEqual(
+            classify_antigravity_failure("ResourceExhausted: 429 quota exceeded"),
+            "rate_limit",
+        )
+
+
+class AntigravityAdapterLifecycleTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.adapter = AntigravityAdapter()
+
+    def test_registry_registration(self) -> None:
+        self.assertIn("antigravity", ADAPTERS)
+        self.assertIn("agy", ADAPTERS)
+        self.assertIsInstance(get_adapter("antigravity"), AntigravityAdapter)
+        self.assertIsInstance(get_adapter("agy"), AntigravityAdapter)
+
+    @mock.patch("puppetmaster.adapters.git_snapshot")
+    @mock.patch("puppetmaster.adapters.resolve_command")
+    @mock.patch("puppetmaster.adapters.run_streamed_subprocess")
+    def test_run_success_with_findings(
+        self,
+        mock_run: mock.MagicMock,
+        mock_resolve: mock.MagicMock,
+        mock_snapshot: mock.MagicMock,
+    ) -> None:
+        mock_resolve.return_value = "/usr/local/bin/agy"
+        mock_snapshot.return_value = {
+            "sha": "abc1234",
+            "changed_files": [],
+            "untracked_files": [],
+            "tree": "tree1",
+        }
+
+        raw_output = json.dumps({
+            "conversation_id": "test-conv-123",
+            "status": "SUCCESS",
+            "response": '```json\n[{"type": "finding", "claim": "SQL injection vulnerability in auth.py", "evidence": ["auth.py:42"]}]\n```',
+            "duration_seconds": 2.5,
+            "num_turns": 1,
+            "usage": {
+                "input_tokens": 1000,
+                "output_tokens": 200,
+                "thinking_tokens": 150,
+                "cache_read_tokens": 50,
+                "total_tokens": 1200,
+            },
+        })
+
+        mock_run.return_value = mock.MagicMock(
+            returncode=0,
+            stdout=raw_output,
+            stderr="",
+            timed_out=False,
+            live_log_path="/tmp/live.log",
+        )
+
+        task = Task(
+            job_id="job1",
+            id="task1",
+            role="explore",
+            instruction="Audit security",
+            payload={"mode": "plan", "read_only": True},
+        )
+        artifacts = self.adapter.run(task, goal="Audit security", worker_id="w1")
+
+        self.assertTrue(len(artifacts) >= 2)
+        verification = artifacts[0]
+        self.assertEqual(verification.type, ArtifactType.VERIFICATION)
+        self.assertEqual(verification.payload["result"], "passed")
+        self.assertEqual(verification.payload["tokens_in"], 1000)
+        self.assertEqual(verification.payload["tokens_out"], 200)
+        self.assertEqual(verification.payload["reasoning_output_tokens"], 150)
+        self.assertEqual(verification.payload["cached_input_tokens"], 50)
+        self.assertEqual(verification.payload["conversation_id"], "test-conv-123")
+
+        finding = next((a for a in artifacts if a.type == ArtifactType.FINDING), None)
+        self.assertIsNotNone(finding)
+        assert finding is not None
+        self.assertIn("SQL injection vulnerability", finding.payload["claim"])
+
+    @mock.patch("puppetmaster.adapters.git_snapshot")
+    @mock.patch("puppetmaster.adapters.resolve_command")
+    @mock.patch("puppetmaster.adapters.run_streamed_subprocess")
+    def test_run_success_with_patch(
+        self,
+        mock_run: mock.MagicMock,
+        mock_resolve: mock.MagicMock,
+        mock_snapshot: mock.MagicMock,
+    ) -> None:
+        mock_resolve.return_value = "/usr/local/bin/agy"
+        mock_snapshot.side_effect = [
+            {"sha": "abc1234", "changed_files": [], "untracked_files": [], "tree": "tree1", "diff": ""},
+            {"sha": "abc1234", "changed_files": ["app.py"], "untracked_files": [], "tree": "tree2", "diff": "diff --git a/app.py b/app.py\n+fixed"},
+        ]
+
+        raw_output = json.dumps({
+            "conversation_id": "test-conv-456",
+            "status": "SUCCESS",
+            "response": "Updated app.py to fix the bug.",
+            "duration_seconds": 3.0,
+            "num_turns": 1,
+            "usage": {
+                "input_tokens": 500,
+                "output_tokens": 100,
+                "thinking_tokens": 50,
+                "cache_read_tokens": 0,
+                "total_tokens": 600,
+            },
+        })
+
+        mock_run.return_value = mock.MagicMock(
+            returncode=0,
+            stdout=raw_output,
+            stderr="",
+            timed_out=False,
+            live_log_path="/tmp/live.log",
+        )
+
+        task = Task(
+            job_id="job2",
+            id="task2",
+            role="implement",
+            instruction="Fix app.py bug",
+            payload={"mode": "accept-edits"},
+        )
+        artifacts = self.adapter.run(task, goal="Fix app.py bug", worker_id="w1")
+
+        self.assertTrue(any(a.type == ArtifactType.PATCH for a in artifacts))
+        self.assertTrue(any(a.type == ArtifactType.VERIFICATION for a in artifacts))
+
+    @mock.patch("puppetmaster.adapters.git_snapshot")
+    @mock.patch("puppetmaster.adapters.resolve_command")
+    @mock.patch("puppetmaster.adapters.run_streamed_subprocess")
+    def test_run_timeout(
+        self,
+        mock_run: mock.MagicMock,
+        mock_resolve: mock.MagicMock,
+        mock_snapshot: mock.MagicMock,
+    ) -> None:
+        mock_resolve.return_value = "/usr/local/bin/agy"
+        mock_snapshot.return_value = {
+            "sha": "abc1234",
+            "changed_files": [],
+            "untracked_files": [],
+            "tree": "tree1",
+        }
+
+        mock_run.return_value = mock.MagicMock(
+            returncode=None,
+            stdout="partial progress...",
+            stderr="",
+            timed_out=True,
+            live_log_path="/tmp/live.log",
+        )
+
+        task = Task(
+            job_id="job3",
+            id="task3",
+            role="explore",
+            instruction="Long running task",
+            payload={"mode": "plan", "read_only": True},
+        )
+        artifacts = self.adapter.run(task, goal="Long running task", worker_id="w1")
+
+        self.assertEqual(len(artifacts), 1)
+        self.assertEqual(artifacts[0].type, ArtifactType.VERIFICATION)
+        self.assertEqual(artifacts[0].payload["result"], "failed")
+        self.assertEqual(artifacts[0].payload["failure"], "timeout")
+
+
+class AntigravityBillingTests(unittest.TestCase):
+    def test_detect_antigravity_billing_api_key(self) -> None:
+        status = detect_antigravity_billing(env={"GEMINI_API_KEY": "test-key"})
+        self.assertTrue(status.healthy)
+        self.assertEqual(status.billing, "api")
+        self.assertIn("gemini_api_key:set", status.evidence)
+
+    def test_detect_antigravity_billing_session(self) -> None:
+        status = detect_antigravity_billing(env={})
+        self.assertTrue(status.healthy)
+        self.assertIn(status.billing, ("plan", "api"))
+
+
+@unittest.skipUnless(shutil.which("agy") is not None, "Live test requires agy CLI on PATH")
+class AntigravityLiveExecutionTests(unittest.TestCase):
+    def test_live_antigravity_gemini_37_flash_run(self) -> None:
+        adapter = AntigravityAdapter()
+        task = Task(
+            job_id="live_job",
+            id="live_task_1",
+            role="explore",
+            instruction="What is 7 * 8? Return a single finding in JSON with claim '56'.",
+            payload={
+                "model": "gemini-3.7-flash",
+                "effort": "low",
+                "mode": "plan",
+                "read_only": True,
+            },
+        )
+        artifacts = adapter.run(task, goal="Verify math", worker_id="live_worker")
+        self.assertTrue(len(artifacts) >= 1)
+        verification = artifacts[0]
+        self.assertEqual(verification.payload["result"], "passed")
+        self.assertEqual(verification.payload["model"], "gemini-3.7-flash")
+        self.assertGreater(verification.payload["tokens_total"], 0)
+        self.assertGreater(verification.payload["tokens_in"], 0)

--- a/tests/test_antigravity_adapter.py
+++ b/tests/test_antigravity_adapter.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest import mock
 
 _HERMETIC_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -269,9 +270,15 @@ class AntigravityBillingTests(unittest.TestCase):
         self.assertIn("gemini_api_key:set", status.evidence)
 
     def test_detect_antigravity_billing_session(self) -> None:
-        status = detect_antigravity_billing(env={})
+        with TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            (home / ".gemini" / "antigravity-cli").mkdir(parents=True)
+
+            status = detect_antigravity_billing(env={}, home=home)
+
         self.assertTrue(status.healthy)
-        self.assertIn(status.billing, ("plan", "api"))
+        self.assertEqual(status.billing, "plan")
+        self.assertIn("antigravity_session:present", status.evidence)
 
 
 @unittest.skipUnless(shutil.which("agy") is not None, "Live test requires agy CLI on PATH")

--- a/tests/test_artifact_bounds.py
+++ b/tests/test_artifact_bounds.py
@@ -174,6 +174,17 @@ class ArtifactBoundsUnitTests(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             bait = Path(tmp) / "bait-secret.txt"
             bait.write_text(secret, encoding="utf-8")
+            original_read_text = Path.read_text
+            bait_reads = []
+
+            def guarded_read_text(path, *args, **kwargs):
+                if Path(path).resolve() == bait.resolve():
+                    bait_reads.append(Path(path))
+                    raise AssertionError(
+                        "artifact persistence must not open untrusted offload paths"
+                    )
+                return original_read_text(path, *args, **kwargs)
+
             # Oversized claim so shrink runs; plant an attacker-controlled path
             # that would be opened by the old offload_path re-read path.
             claim = "SAFE-HEAD-" + ("body" * 15_000) + "-SAFE-TAIL"
@@ -201,13 +212,11 @@ class ArtifactBoundsUnitTests(unittest.TestCase):
                     "PUPPETMASTER_ARTIFACT_PREVIEW_HEAD_CHARS": "60",
                     "PUPPETMASTER_ARTIFACT_PREVIEW_TAIL_CHARS": "60",
                 },
-            ), patch.object(Path, "read_text", autospec=True) as read_text:
-                # Any Path.read_text during prepare would be a disclosure bug;
-                # force a failure so the call cannot silently succeed.
-                read_text.side_effect = AssertionError(
-                    "artifact persistence must not open filesystem paths"
-                )
+            ), patch.object(
+                Path, "read_text", autospec=True, side_effect=guarded_read_text
+            ):
                 prepared = prepare_artifact_for_persist(artifact, state_dir=tmp)
+            self.assertEqual(bait_reads, [])
             self.assertNotIn(secret, prepared.payload.get("claim", ""))
             self.assertNotIn(secret, json.dumps(prepared.payload))
             # Still produces reviewable bounded output from the claim itself.

--- a/tests/test_atomic_global_policy.py
+++ b/tests/test_atomic_global_policy.py
@@ -1,0 +1,115 @@
+"""Regression coverage for user-global policy-document mutations.
+
+These tests deliberately coordinate concurrent callers.  They prove the
+platform read-modify-write transaction keeps independent updates, and that
+readers never observe a partially-written models registry.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from puppetmaster import platform_lock
+from puppetmaster.model_registry import ModelSpec, save_registry
+
+
+def test_platform_concurrent_mutations_keep_both_updates() -> None:
+    """Arrange two writers; Act with one paused in its critical section; Assert union."""
+    with TemporaryDirectory() as tmp:
+        registry = Path(tmp) / "models.json"
+        entered = threading.Event()
+        release_first = threading.Event()
+        failures: list[BaseException] = []
+        original = platform_lock._write_disabled_locked
+        calls = 0
+
+        def paused_first_writer(disabled: set[str], path: Path) -> Path:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                entered.set()
+                assert release_first.wait(timeout=2), "second writer was not scheduled"
+            return original(disabled, path)
+
+        def run(adapters: set[str]) -> None:
+            try:
+                platform_lock.disable(adapters, registry)
+            except BaseException as exc:  # surface thread failures to pytest
+                failures.append(exc)
+
+        with patch.object(platform_lock, "_write_disabled_locked", paused_first_writer):
+            first = threading.Thread(target=run, args=({"cursor"},))
+            second = threading.Thread(target=run, args=({"codex"},))
+            first.start()
+            assert entered.wait(timeout=2), "first writer did not enter critical section"
+            second.start()
+            # Give the second caller a chance to contend while the first lock
+            # remains held. The old unlocked read-modify-write loses one update.
+            time.sleep(0.05)
+            release_first.set()
+            first.join(timeout=3)
+            second.join(timeout=3)
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert not failures
+        data = json.loads(platform_lock.platform_config_path(registry).read_text("utf-8"))
+        assert set(data["disabled"]) == {"cursor", "codex"}
+
+
+def test_models_registry_readers_never_observe_truncated_json() -> None:
+    """Arrange a live reader; Act with repeated replacements; Assert every parse succeeds."""
+    with TemporaryDirectory() as tmp:
+        path = Path(tmp) / "models.json"
+        save_registry([ModelSpec("one", "cursor", "one")], path)
+        start = threading.Event()
+        done = threading.Event()
+        parse_failures: list[BaseException] = []
+
+        def reader() -> None:
+            assert start.wait(timeout=2)
+            while not done.is_set():
+                try:
+                    data = json.loads(path.read_text(encoding="utf-8"))
+                    assert isinstance(data["models"], list)
+                except BaseException as exc:
+                    parse_failures.append(exc)
+                    return
+
+        thread = threading.Thread(target=reader)
+        thread.start()
+        start.set()
+        for index in range(80):
+            save_registry(
+                [ModelSpec("one", "cursor", "one"), ModelSpec("two", "codex", str(index))],
+                path,
+            )
+        done.set()
+        thread.join(timeout=3)
+
+        assert not thread.is_alive()
+        assert not parse_failures
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert {model["id"] for model in data["models"]} == {"one", "two"}
+
+
+def test_orphaned_lock_is_recovered_by_next_writer() -> None:
+    """Arrange a dead-PID lock; Act by saving; Assert stale recovery publishes JSON."""
+    from puppetmaster.interprocess_lock import InterProcessFileLock
+
+    with TemporaryDirectory() as tmp:
+        path = Path(tmp) / "models.json"
+        lock_path = InterProcessFileLock.for_target(path).path
+        lock_path.write_text(
+            json.dumps({"pid": 999_999_999, "created_at": time.time(), "token": "dead"}),
+            encoding="utf-8",
+        )
+
+        save_registry([ModelSpec("one", "cursor", "one")], path)
+
+        assert json.loads(path.read_text(encoding="utf-8"))["models"][0]["id"] == "one"
+        assert not lock_path.exists()

--- a/tests/test_cli_state_routing.py
+++ b/tests/test_cli_state_routing.py
@@ -42,6 +42,13 @@ class CliStateRoutingTests(unittest.TestCase):
         self.create_store = create_store
         return detached
 
+    def _assert_launcher_relative_state(
+        self, actual: Path, launcher: Path, name: str
+    ) -> None:
+        """Compare path identity across symlink and Windows short-name aliases."""
+        self.assertEqual(actual.name, name)
+        self.assertTrue(actual.parent.samefile(launcher))
+
     def test_detached_swarm_uses_target_workspace_for_store_and_launcher_config(self) -> None:
         """A nested target repo must not persist under the launcher folder."""
         with TemporaryDirectory() as tmp:
@@ -112,9 +119,12 @@ class CliStateRoutingTests(unittest.TestCase):
             with self._launcher_cwd(outer):
                 detached = self._start_detached_swarm(target, "--state-dir", "relative-state")
 
-            expected = outer.resolve() / "relative-state"
-            self.assertEqual(self.create_store.call_args.args[1], expected)
-            self.assertEqual(detached.call_args.kwargs["state_dir"], expected)
+            self._assert_launcher_relative_state(
+                self.create_store.call_args.args[1], outer, "relative-state"
+            )
+            self._assert_launcher_relative_state(
+                detached.call_args.kwargs["state_dir"], outer, "relative-state"
+            )
 
     def test_relative_environment_state_dir_stays_relative_to_launcher_shell(self) -> None:
         """The environment override keeps its precedence and path interpretation."""
@@ -127,9 +137,12 @@ class CliStateRoutingTests(unittest.TestCase):
             ):
                 detached = self._start_detached_swarm(target)
 
-            expected = outer.resolve() / "environment-state"
-            self.assertEqual(self.create_store.call_args.args[1], expected)
-            self.assertEqual(detached.call_args.kwargs["state_dir"], expected)
+            self._assert_launcher_relative_state(
+                self.create_store.call_args.args[1], outer, "environment-state"
+            )
+            self._assert_launcher_relative_state(
+                detached.call_args.kwargs["state_dir"], outer, "environment-state"
+            )
 
     def test_absolute_environment_state_dir_still_overrides_worker_cwd(self) -> None:
         """An absolute environment override retains its existing precedence."""

--- a/tests/test_cli_state_routing.py
+++ b/tests/test_cli_state_routing.py
@@ -1,0 +1,151 @@
+"""Regression coverage for CLI state routing when a worker has ``--cwd``."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+
+import puppetmaster.cli._dispatch as dispatch
+from puppetmaster.state import resolve_state_dir
+
+
+class CliStateRoutingTests(unittest.TestCase):
+    """The launcher shell and a worker workspace can be different projects."""
+
+    @contextlib.contextmanager
+    def _launcher_cwd(self, path: Path):
+        old_cwd = Path.cwd()
+        os.chdir(path)
+        try:
+            yield
+        finally:
+            os.chdir(old_cwd)
+
+    def _start_detached_swarm(self, target: Path, *prefix: str) -> MagicMock:
+        """Start the CLI path far enough to capture state-store/config routing."""
+        detached = MagicMock(
+            return_value={"job_id": "job_state_route", "launcher_pid": 4242}
+        )
+        store = MagicMock()
+        argv = [*prefix, "swarm", "state routing", "--cwd", str(target)]
+        with patch.object(dispatch, "create_store", return_value=store) as create_store, patch(
+            "puppetmaster.platform_lock.is_adapter_enabled", return_value=True
+        ), patch("puppetmaster.swarm_launch.detach_analysis_swarm", detached), contextlib.redirect_stdout(
+            io.StringIO()
+        ), contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(dispatch._main(argv), 0)
+        self.create_store = create_store
+        return detached
+
+    def test_detached_swarm_uses_target_workspace_for_store_and_launcher_config(self) -> None:
+        """A nested target repo must not persist under the launcher folder."""
+        with TemporaryDirectory() as tmp:
+            outer = Path(tmp) / "puppetmaster"
+            target = outer / "Puppetmaster"
+            target.mkdir(parents=True)
+            with self._launcher_cwd(outer), patch(
+                "puppetmaster.state.app_state_root", return_value=outer / "app-state"
+            ):
+                expected = resolve_state_dir(cwd=target)
+                launcher_state = resolve_state_dir(cwd=outer)
+                detached = self._start_detached_swarm(target)
+
+            self.assertNotEqual(expected, launcher_state)
+            self.assertEqual(self.create_store.call_args.args[1], expected)
+            self.assertEqual(detached.call_args.kwargs["state_dir"], expected)
+            self.assertEqual(detached.call_args.kwargs["cwd"], str(target))
+
+    def test_all_worker_commands_default_state_to_their_cwd(self) -> None:
+        """Every write-side CLI command with --cwd shares the routing rule."""
+        commands = [
+            ["cursor", "prompt"],
+            ["claude", "prompt"],
+            ["openai", "prompt"],
+            ["codex", "prompt"],
+            ["hermes", "prompt"],
+            ["agentic", "prompt"],
+            ["swarm", "goal"],
+            ["browser", "mission"],
+            ["edit", "instruction"],
+            ["prewalk", "goal"],
+        ]
+        with TemporaryDirectory() as tmp:
+            outer = Path(tmp) / "launcher"
+            target = outer / "target"
+            target.mkdir(parents=True)
+            with self._launcher_cwd(outer), patch(
+                "puppetmaster.state.app_state_root", return_value=outer / "app-state"
+            ):
+                expected = resolve_state_dir(cwd=target)
+                for command in commands:
+                    with self.subTest(command=command[0]):
+                        args = dispatch.build_parser().parse_args(
+                            [*command, "--cwd", str(target)]
+                        )
+                        self.assertEqual(dispatch._resolve_command_state_dir(args), expected)
+
+    def test_absolute_cli_state_dir_still_overrides_worker_cwd(self) -> None:
+        """An explicit absolute --state-dir retains its existing precedence."""
+        with TemporaryDirectory() as tmp:
+            outer = Path(tmp) / "launcher"
+            target = outer / "target"
+            explicit = Path(tmp) / "explicit-state"
+            target.mkdir(parents=True)
+            outer.mkdir(exist_ok=True)
+            with self._launcher_cwd(outer):
+                detached = self._start_detached_swarm(target, "--state-dir", str(explicit))
+
+            self.assertEqual(self.create_store.call_args.args[1], explicit)
+            self.assertEqual(detached.call_args.kwargs["state_dir"], explicit)
+
+    def test_relative_cli_state_dir_stays_relative_to_launcher_shell(self) -> None:
+        """Changing default routing does not reinterpret an explicit relative path."""
+        with TemporaryDirectory() as tmp:
+            outer = Path(tmp) / "launcher"
+            target = outer / "target"
+            target.mkdir(parents=True)
+            with self._launcher_cwd(outer):
+                detached = self._start_detached_swarm(target, "--state-dir", "relative-state")
+
+            expected = outer / "relative-state"
+            self.assertEqual(self.create_store.call_args.args[1], expected)
+            self.assertEqual(detached.call_args.kwargs["state_dir"], expected)
+
+    def test_relative_environment_state_dir_stays_relative_to_launcher_shell(self) -> None:
+        """The environment override keeps its precedence and path interpretation."""
+        with TemporaryDirectory() as tmp:
+            outer = Path(tmp) / "launcher"
+            target = outer / "target"
+            target.mkdir(parents=True)
+            with self._launcher_cwd(outer), patch.dict(
+                os.environ, {"PUPPETMASTER_STATE_DIR": "environment-state"}
+            ):
+                detached = self._start_detached_swarm(target)
+
+            expected = outer / "environment-state"
+            self.assertEqual(self.create_store.call_args.args[1], expected)
+            self.assertEqual(detached.call_args.kwargs["state_dir"], expected)
+
+    def test_absolute_environment_state_dir_still_overrides_worker_cwd(self) -> None:
+        """An absolute environment override retains its existing precedence."""
+        with TemporaryDirectory() as tmp:
+            outer = Path(tmp) / "launcher"
+            target = outer / "target"
+            explicit = Path(tmp) / "environment-state"
+            target.mkdir(parents=True)
+            with self._launcher_cwd(outer), patch.dict(
+                os.environ, {"PUPPETMASTER_STATE_DIR": str(explicit)}
+            ):
+                detached = self._start_detached_swarm(target)
+
+            self.assertEqual(self.create_store.call_args.args[1], explicit)
+            self.assertEqual(detached.call_args.kwargs["state_dir"], explicit)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_state_routing.py
+++ b/tests/test_cli_state_routing.py
@@ -112,7 +112,7 @@ class CliStateRoutingTests(unittest.TestCase):
             with self._launcher_cwd(outer):
                 detached = self._start_detached_swarm(target, "--state-dir", "relative-state")
 
-            expected = outer / "relative-state"
+            expected = outer.resolve() / "relative-state"
             self.assertEqual(self.create_store.call_args.args[1], expected)
             self.assertEqual(detached.call_args.kwargs["state_dir"], expected)
 
@@ -127,7 +127,7 @@ class CliStateRoutingTests(unittest.TestCase):
             ):
                 detached = self._start_detached_swarm(target)
 
-            expected = outer / "environment-state"
+            expected = outer.resolve() / "environment-state"
             self.assertEqual(self.create_store.call_args.args[1], expected)
             self.assertEqual(detached.call_args.kwargs["state_dir"], expected)
 

--- a/tests/test_concurrent_sessions_docs.py
+++ b/tests/test_concurrent_sessions_docs.py
@@ -1,0 +1,32 @@
+"""Regression contract for concurrent-session operator documentation.
+
+This deliberately checks the statements that prevent an operator from opening
+the wrong project dashboard or running competing write jobs in one checkout.
+Runtime behavior is covered by its focused state, dashboard, and worktree
+tests; this file keeps the public operating contract connected to that behavior.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONCURRENT_SESSIONS = ROOT / "docs" / "CONCURRENT_SESSIONS.md"
+
+
+def test_concurrent_sessions_operator_contract_is_discoverable_and_complete():
+    guide = CONCURRENT_SESSIONS.read_text(encoding="utf-8")
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    docs_index = (ROOT / "docs" / "README.md").read_text(encoding="utf-8")
+    dashboard = (ROOT / "docs" / "DASHBOARD.md").read_text(encoding="utf-8")
+    mobile = (ROOT / "docs" / "MOBILE.md").read_text(encoding="utf-8")
+
+    assert "target workspace selects\nthe default state directory" in guide
+    assert "`--state-dir` and `PUPPETMASTER_STATE_DIR` override" in guide
+    assert "resolved from the launcher shell's current\ndirectory" in guide
+    assert "dashboard --all-projects --background" in guide
+    assert "URL printed by the\ncommand or returned by the MCP tool" in guide
+    assert "Do not run two full-edit or in-place edit jobs against the same checkout" in guide
+    assert "CONCURRENT_SESSIONS.md" in readme
+    assert "CONCURRENT_SESSIONS.md" in docs_index
+    assert "CONCURRENT_SESSIONS.md" in dashboard
+    assert ":8787/" not in mobile

--- a/tests/test_credential_scoped_rate_limits.py
+++ b/tests/test_credential_scoped_rate_limits.py
@@ -1,0 +1,195 @@
+"""Regression coverage for credential-scoped passive rate-limit admission."""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_HERMETIC_DIR = os.path.dirname(os.path.abspath(__file__))
+if _HERMETIC_DIR not in sys.path:
+    sys.path.insert(0, _HERMETIC_DIR)
+import hermetic_env  # noqa: F401
+
+from puppetmaster.provider_circuit import resolve_circuit_key
+from puppetmaster.providers import AssistantTurn, ProviderError
+from puppetmaster.rate_limit_headers import RateLimitSnapshot, RateLimitWindow
+from puppetmaster.rate_limit_state import (
+    RateLimitStore,
+    admit_or_raise,
+    get_rate_limit_store,
+    reset_rate_limit_store_cache,
+)
+
+
+class CredentialScopedRateLimitTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.path = Path(self._tmpdir.name) / "rate_limits.sqlite3"
+        os.environ["PUPPETMASTER_RATE_LIMIT_PATH"] = str(self.path)
+        os.environ["PUPPETMASTER_RATE_LIMIT_HARVEST"] = "1"
+        os.environ["PUPPETMASTER_RATE_LIMIT_ADMISSION"] = "1"
+        reset_rate_limit_store_cache()
+
+    def tearDown(self) -> None:
+        reset_rate_limit_store_cache()
+        for name in (
+            "PUPPETMASTER_RATE_LIMIT_PATH",
+            "PUPPETMASTER_RATE_LIMIT_HARVEST",
+            "PUPPETMASTER_RATE_LIMIT_ADMISSION",
+        ):
+            os.environ.pop(name, None)
+        self._tmpdir.cleanup()
+
+    def test_exhausted_key_a_does_not_block_key_b_and_never_persists_raw_keys(self) -> None:
+        # Arrange: two distinct credentials call the same provider/model/endpoint.
+        key_a_secret = "sk-test-rate-limit-a-not-for-storage"
+        key_b_secret = "sk-test-rate-limit-b-not-for-storage"
+        admission_a = resolve_circuit_key(
+            "openai", "gpt-test", api_key=key_a_secret,
+        )
+        admission_b = resolve_circuit_key(
+            "openai", "gpt-test", api_key=key_b_secret,
+        )
+        now = 1_700_000_000.0
+        store = get_rate_limit_store()
+        store.upsert(
+            admission_key=admission_a,
+            provider="openai",
+            model="gpt-test",
+            snapshot=RateLimitSnapshot(
+                requests=RateLimitWindow(
+                    kind="requests", limit=1, remaining=0, reset_at=now + 60,
+                )
+            ),
+            now=now,
+        )
+
+        # Act / Assert: only the exhausted credential is refused.
+        self.assertNotEqual(admission_a, admission_b)
+        with self.assertRaises(ProviderError):
+            admit_or_raise(admission_a, now=now + 1)
+        admit_or_raise(admission_b, now=now + 1)
+
+        # Raw credential material must not occur in SQLite keys or values.
+        connection = sqlite3.connect(str(self.path))
+        try:
+            persisted = "\n".join(
+                str(value)
+                for row in connection.execute("SELECT * FROM rate_limits")
+                for value in row
+                if value is not None
+            )
+        finally:
+            connection.close()
+        self.assertNotIn(key_a_secret, persisted)
+        self.assertNotIn(key_b_secret, persisted)
+
+    def test_existing_legacy_row_is_retired_on_reopen(self) -> None:
+        # Arrange: emulate a pre-credential-scoping database row.
+        legacy = "openai\x1fgpt-test\x1fhttps://api.openai.com/v1"
+        now = 1_700_000_000.0
+        first_store = RateLimitStore(self.path)
+        first_store.upsert(
+            admission_key=legacy,
+            provider="openai",
+            model="gpt-test",
+            snapshot=RateLimitSnapshot(
+                requests=RateLimitWindow(
+                    kind="requests", limit=1, remaining=0, reset_at=now + 60,
+                )
+            ),
+            now=now,
+        )
+
+        # Act: a fresh process opens the same database after the schema upgrade.
+        reopened = RateLimitStore(self.path)
+
+        # Assert: legacy shared rows cannot block a credential-scoped caller and
+        # are removed rather than retained forever.
+        scoped = resolve_circuit_key(
+            "openai", "gpt-test", api_key="sk-test-replacement",
+        )
+        self.assertIsNone(reopened.get(legacy))
+        admit_or_raise(scoped, now=now + 1)
+
+    def test_preemptively_blocked_key_rotates_to_next_credential(self) -> None:
+        # Arrange: key A is harvested as exhausted while key B is untouched.
+        from puppetmaster.adapters.agentic import AgenticAdapter
+        from puppetmaster.adapters import agentic
+
+        key_a = "sk-test-rotating-a"
+        key_b = "sk-test-rotating-b"
+        admission_a = resolve_circuit_key("openai", "gpt-test", api_key=key_a)
+        now = 1_700_000_000.0
+        get_rate_limit_store().upsert(
+            admission_key=admission_a,
+            provider="openai",
+            model="gpt-test",
+            snapshot=RateLimitSnapshot(
+                requests=RateLimitWindow(
+                    kind="requests", limit=1, remaining=0, reset_at=now + 60,
+                )
+            ),
+            now=now,
+        )
+
+        # Act: admission must advance the existing rotation pool, rather than
+        # fail the whole turn before provider_chat sees key B.
+        with mock.patch.object(
+            agentic,
+            "provider_chat",
+            return_value=AssistantTurn(text="key-b-worked"),
+        ) as provider_chat:
+            with mock.patch("puppetmaster.rate_limit_state.time.time", return_value=now + 1):
+                turn = AgenticAdapter()._provider_call(
+                    provider="openai",
+                    model="gpt-test",
+                    messages=[],
+                    tools=None,
+                    extra={},
+                    timeout=30,
+                    max_retries=0,
+                    key_pool=[key_a, key_b],
+                )
+
+        # Assert: no call leaked through with exhausted key A; the deliberate
+        # rotation reaches B, still without persisting either raw key.
+        self.assertEqual(turn.text, "key-b-worked")
+        self.assertEqual(provider_chat.call_count, 1)
+        self.assertEqual(provider_chat.call_args.kwargs["api_key"], key_b)
+
+    def test_ambient_bedrock_credentials_are_scoped_without_persisting_identity(self) -> None:
+        # Arrange / Act: SigV4 callers have no api_key argument, but their
+        # resolved AWS identity is still a credential boundary.
+        first_access_key = "AKIAEXAMPLEONE"
+        second_access_key = "AKIAEXAMPLETWO"
+        first = resolve_circuit_key(
+            "bedrock",
+            "anthropic.claude-test",
+            env={
+                "AWS_ACCESS_KEY_ID": first_access_key,
+                "AWS_SECRET_ACCESS_KEY": "secret-one-not-for-storage",
+            },
+        )
+        second = resolve_circuit_key(
+            "bedrock",
+            "anthropic.claude-test",
+            env={
+                "AWS_ACCESS_KEY_ID": second_access_key,
+                "AWS_SECRET_ACCESS_KEY": "secret-two-not-for-storage",
+            },
+        )
+
+        # Assert: distinct ambient identities do not share admission state, and
+        # the scope holds only a fingerprint (not an AWS access-key id).
+        self.assertNotEqual(first, second)
+        self.assertNotIn(first_access_key, first)
+        self.assertNotIn(second_access_key, second)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_lifecycle_cleanup.py
+++ b/tests/test_mcp_lifecycle_cleanup.py
@@ -1,0 +1,167 @@
+"""Focused regression coverage for opt-in MCP lifecycle cleanup."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def registry_dir():
+    with TemporaryDirectory() as directory:
+        with patch.dict(os.environ, {"PUPPETMASTER_MCP_REGISTRY_DIR": directory}):
+            yield Path(directory)
+
+
+def test_activity_is_persisted_and_surfaced(registry_dir):
+    """Arrange/Act/Assert: inbound activity survives a registry reread."""
+    from puppetmaster import mcp_registry
+
+    path = mcp_registry.register(pid=os.getpid(), workspace=str(registry_dir / "repo"))
+    inbound_at = time.time() - 12
+
+    assert mcp_registry.record_activity(path, inbound_at=inbound_at, active_tool_calls=2)
+
+    entry = mcp_registry.list_entries()[0]
+    payload = entry.to_payload(now=inbound_at + 15)
+    assert entry.last_inbound_at == pytest.approx(inbound_at)
+    assert entry.active_tool_calls == 2
+    assert payload["inbound_age_seconds"] == pytest.approx(15, abs=0.01)
+    assert payload["active_tool_calls"] == 2
+
+
+def test_server_request_activity_updates_the_registry(registry_dir):
+    """Arrange/Act/Assert: the MCP request lifecycle writes durable activity."""
+    from puppetmaster import mcp_registry, mcp_server
+
+    path = mcp_registry.register(pid=os.getpid(), workspace=str(registry_dir / "repo"))
+    with mcp_server._INPUT_STATE_LOCK:
+        original_path = mcp_server._REGISTRY_ACTIVITY_PATH
+        original_active = mcp_server._ACTIVE_TOOL_CALLS
+        mcp_server._REGISTRY_ACTIVITY_PATH = path
+        mcp_server._ACTIVE_TOOL_CALLS = 0
+    try:
+        mcp_server._mark_inbound_message()
+        mcp_server._tool_call_started()
+        active = mcp_registry.list_entries()[0]
+        mcp_server._tool_call_finished()
+        finished = mcp_registry.list_entries()[0]
+    finally:
+        with mcp_server._INPUT_STATE_LOCK:
+            mcp_server._REGISTRY_ACTIVITY_PATH = original_path
+            mcp_server._ACTIVE_TOOL_CALLS = original_active
+
+    assert active.last_inbound_at is not None
+    assert active.active_tool_calls == 1
+    assert finished.active_tool_calls == 0
+
+
+def test_selector_intersection_normalizes_workspace_and_requires_every_selector(registry_dir):
+    """Arrange/Act/Assert: PID, workspace, and idle selectors intersect."""
+    from puppetmaster import mcp_registry
+
+    workspace = registry_dir / "project"
+    other_workspace = registry_dir / "other"
+    first = mcp_registry.register(pid=41001, workspace=str(workspace))
+    second = mcp_registry.register(pid=41002, workspace=str(other_workspace))
+    old = time.time() - 60
+    mcp_registry.record_activity(first, inbound_at=old, active_tool_calls=0)
+    mcp_registry.record_activity(second, inbound_at=old, active_tool_calls=0)
+    signalled = []
+
+    with patch.object(mcp_registry, "_pid_alive", return_value=True), patch.object(
+        mcp_registry.os, "kill", side_effect=lambda pid, sig: signalled.append(pid)
+    ):
+        result = mcp_registry.kill_selected(
+            pids=[41001, 41002],
+            workspace=str(workspace / "."),
+            idle_after_seconds=30,
+            self_pid=99999,
+            grace_seconds=0,
+        )
+
+    assert [entry.pid for entry in result.killed] == [41001]
+    assert signalled == [41001, 41001]
+    assert mcp_registry.normalize_workspace(str(workspace / ".")) == mcp_registry.normalize_workspace(str(workspace))
+
+
+def test_selector_cleanup_refuses_self_and_servers_with_active_calls(registry_dir):
+    """Arrange/Act/Assert: explicit cleanup never kills self or active work."""
+    from puppetmaster import mcp_registry
+
+    self_path = mcp_registry.register(pid=os.getpid(), workspace=str(registry_dir / "self"))
+    active_path = mcp_registry.register(pid=42002, workspace=str(registry_dir / "active"))
+    mcp_registry.record_activity(self_path, active_tool_calls=1)
+    mcp_registry.record_activity(active_path, active_tool_calls=1)
+
+    with patch.object(mcp_registry, "_pid_alive", return_value=True), patch.object(mcp_registry.os, "kill") as kill:
+        result = mcp_registry.kill_selected(
+            pids=[os.getpid(), 42002], self_pid=os.getpid(), grace_seconds=0
+        )
+
+    assert result.killed == []
+    assert {(row["pid"], row["reason"]) for row in result.refused} == {
+        (os.getpid(), "self"),
+        (42002, "active_tool_calls"),
+    }
+    kill.assert_not_called()
+
+
+def test_cli_cleanup_wires_explicit_selectors(registry_dir):
+    """Arrange/Act/Assert: CLI forwards all selectors to precise cleanup."""
+    from puppetmaster import cli
+    from puppetmaster import mcp_registry
+    from puppetmaster.cli import commands_mcp
+
+    result = mcp_registry.McpSelectionResult(killed=[], refused=[])
+    output = io.StringIO()
+    with patch.object(commands_mcp, "registry_kill_selected", return_value=result) as selected, patch(
+        "sys.stdout", output
+    ):
+        assert cli.main(
+            [
+                "mcp",
+                "cleanup",
+                "--pid",
+                "42101",
+                "--workspace",
+                str(registry_dir / "repo"),
+                "--idle-after-seconds",
+                "45",
+                "--json",
+            ]
+        ) == 0
+
+    selected.assert_called_once_with(
+        pids=[42101],
+        workspace=str(registry_dir / "repo"),
+        idle_after_seconds=45.0,
+        self_pid=os.getpid(),
+    )
+    assert json.loads(output.getvalue())["selected_killed"] == []
+
+
+def test_mcp_cleanup_wires_explicit_selectors_without_default_kill(registry_dir):
+    """Arrange/Act/Assert: MCP selectors opt in; no selector is read-only."""
+    from puppetmaster import mcp_registry, mcp_server
+
+    result = mcp_registry.McpSelectionResult(killed=[], refused=[])
+    with patch.object(mcp_server, "registry_kill_selected", return_value=result) as selected:
+        response = mcp_server.run_mcp_cleanup(
+            {"pids": [42201], "workspace": str(registry_dir / "repo"), "idle_after_seconds": 30}
+        )
+    payload = json.loads(response["content"][0]["text"])
+    selected.assert_called_once_with(
+        pids=[42201],
+        workspace=str(registry_dir / "repo"),
+        idle_after_seconds=30.0,
+        self_pid=os.getpid(),
+    )
+    assert payload["selected_killed"] == []

--- a/tests/test_mcp_lifecycle_cleanup.py
+++ b/tests/test_mcp_lifecycle_cleanup.py
@@ -6,162 +6,195 @@ import io
 import json
 import os
 import time
+import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
-import pytest
 
+class McpLifecycleCleanupTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._temporary_directory = TemporaryDirectory()
+        self.registry_dir = Path(self._temporary_directory.name)
+        self._environment = patch.dict(
+            os.environ,
+            {"PUPPETMASTER_MCP_REGISTRY_DIR": str(self.registry_dir)},
+        )
+        self._environment.start()
 
-@pytest.fixture
-def registry_dir():
-    with TemporaryDirectory() as directory:
-        with patch.dict(os.environ, {"PUPPETMASTER_MCP_REGISTRY_DIR": directory}):
-            yield Path(directory)
+    def tearDown(self) -> None:
+        self._environment.stop()
+        self._temporary_directory.cleanup()
 
+    def test_activity_is_persisted_and_surfaced(self) -> None:
+        """Arrange/Act/Assert: inbound activity survives a registry reread."""
+        from puppetmaster import mcp_registry
 
-def test_activity_is_persisted_and_surfaced(registry_dir):
-    """Arrange/Act/Assert: inbound activity survives a registry reread."""
-    from puppetmaster import mcp_registry
+        path = mcp_registry.register(
+            pid=os.getpid(), workspace=str(self.registry_dir / "repo")
+        )
+        inbound_at = time.time() - 12
 
-    path = mcp_registry.register(pid=os.getpid(), workspace=str(registry_dir / "repo"))
-    inbound_at = time.time() - 12
+        self.assertTrue(
+            mcp_registry.record_activity(
+                path, inbound_at=inbound_at, active_tool_calls=2
+            )
+        )
 
-    assert mcp_registry.record_activity(path, inbound_at=inbound_at, active_tool_calls=2)
+        entry = mcp_registry.list_entries()[0]
+        payload = entry.to_payload(now=inbound_at + 15)
+        self.assertAlmostEqual(entry.last_inbound_at, inbound_at)
+        self.assertEqual(entry.active_tool_calls, 2)
+        self.assertAlmostEqual(payload["inbound_age_seconds"], 15, delta=0.01)
+        self.assertEqual(payload["active_tool_calls"], 2)
 
-    entry = mcp_registry.list_entries()[0]
-    payload = entry.to_payload(now=inbound_at + 15)
-    assert entry.last_inbound_at == pytest.approx(inbound_at)
-    assert entry.active_tool_calls == 2
-    assert payload["inbound_age_seconds"] == pytest.approx(15, abs=0.01)
-    assert payload["active_tool_calls"] == 2
+    def test_server_request_activity_updates_the_registry(self) -> None:
+        """Arrange/Act/Assert: the MCP request lifecycle writes durable activity."""
+        from puppetmaster import mcp_registry, mcp_server
 
-
-def test_server_request_activity_updates_the_registry(registry_dir):
-    """Arrange/Act/Assert: the MCP request lifecycle writes durable activity."""
-    from puppetmaster import mcp_registry, mcp_server
-
-    path = mcp_registry.register(pid=os.getpid(), workspace=str(registry_dir / "repo"))
-    with mcp_server._INPUT_STATE_LOCK:
-        original_path = mcp_server._REGISTRY_ACTIVITY_PATH
-        original_active = mcp_server._ACTIVE_TOOL_CALLS
-        mcp_server._REGISTRY_ACTIVITY_PATH = path
-        mcp_server._ACTIVE_TOOL_CALLS = 0
-    try:
-        mcp_server._mark_inbound_message()
-        mcp_server._tool_call_started()
-        active = mcp_registry.list_entries()[0]
-        mcp_server._tool_call_finished()
-        finished = mcp_registry.list_entries()[0]
-    finally:
+        path = mcp_registry.register(
+            pid=os.getpid(), workspace=str(self.registry_dir / "repo")
+        )
         with mcp_server._INPUT_STATE_LOCK:
-            mcp_server._REGISTRY_ACTIVITY_PATH = original_path
-            mcp_server._ACTIVE_TOOL_CALLS = original_active
+            original_path = mcp_server._REGISTRY_ACTIVITY_PATH
+            original_active = mcp_server._ACTIVE_TOOL_CALLS
+            mcp_server._REGISTRY_ACTIVITY_PATH = path
+            mcp_server._ACTIVE_TOOL_CALLS = 0
+        try:
+            mcp_server._mark_inbound_message()
+            mcp_server._tool_call_started()
+            active = mcp_registry.list_entries()[0]
+            mcp_server._tool_call_finished()
+            finished = mcp_registry.list_entries()[0]
+        finally:
+            with mcp_server._INPUT_STATE_LOCK:
+                mcp_server._REGISTRY_ACTIVITY_PATH = original_path
+                mcp_server._ACTIVE_TOOL_CALLS = original_active
 
-    assert active.last_inbound_at is not None
-    assert active.active_tool_calls == 1
-    assert finished.active_tool_calls == 0
+        self.assertIsNotNone(active.last_inbound_at)
+        self.assertEqual(active.active_tool_calls, 1)
+        self.assertEqual(finished.active_tool_calls, 0)
 
+    def test_selector_intersection_normalizes_workspace_and_requires_every_selector(
+        self,
+    ) -> None:
+        """Arrange/Act/Assert: PID, workspace, and idle selectors intersect."""
+        from puppetmaster import mcp_registry
 
-def test_selector_intersection_normalizes_workspace_and_requires_every_selector(registry_dir):
-    """Arrange/Act/Assert: PID, workspace, and idle selectors intersect."""
-    from puppetmaster import mcp_registry
+        workspace = self.registry_dir / "project"
+        other_workspace = self.registry_dir / "other"
+        first = mcp_registry.register(pid=41001, workspace=str(workspace))
+        second = mcp_registry.register(pid=41002, workspace=str(other_workspace))
+        old = time.time() - 60
+        mcp_registry.record_activity(first, inbound_at=old, active_tool_calls=0)
+        mcp_registry.record_activity(second, inbound_at=old, active_tool_calls=0)
+        signalled = []
 
-    workspace = registry_dir / "project"
-    other_workspace = registry_dir / "other"
-    first = mcp_registry.register(pid=41001, workspace=str(workspace))
-    second = mcp_registry.register(pid=41002, workspace=str(other_workspace))
-    old = time.time() - 60
-    mcp_registry.record_activity(first, inbound_at=old, active_tool_calls=0)
-    mcp_registry.record_activity(second, inbound_at=old, active_tool_calls=0)
-    signalled = []
+        with patch.object(mcp_registry, "_pid_alive", return_value=True), patch.object(
+            mcp_registry.os, "kill", side_effect=lambda pid, sig: signalled.append(pid)
+        ):
+            result = mcp_registry.kill_selected(
+                pids=[41001, 41002],
+                workspace=str(workspace / "."),
+                idle_after_seconds=30,
+                self_pid=99999,
+                grace_seconds=0,
+            )
 
-    with patch.object(mcp_registry, "_pid_alive", return_value=True), patch.object(
-        mcp_registry.os, "kill", side_effect=lambda pid, sig: signalled.append(pid)
-    ):
-        result = mcp_registry.kill_selected(
-            pids=[41001, 41002],
-            workspace=str(workspace / "."),
-            idle_after_seconds=30,
-            self_pid=99999,
-            grace_seconds=0,
+        self.assertEqual([entry.pid for entry in result.killed], [41001])
+        self.assertEqual(signalled, [41001, 41001])
+        self.assertEqual(
+            mcp_registry.normalize_workspace(str(workspace / ".")),
+            mcp_registry.normalize_workspace(str(workspace)),
         )
 
-    assert [entry.pid for entry in result.killed] == [41001]
-    assert signalled == [41001, 41001]
-    assert mcp_registry.normalize_workspace(str(workspace / ".")) == mcp_registry.normalize_workspace(str(workspace))
+    def test_selector_cleanup_refuses_self_and_servers_with_active_calls(
+        self,
+    ) -> None:
+        """Arrange/Act/Assert: explicit cleanup never kills self or active work."""
+        from puppetmaster import mcp_registry
 
-
-def test_selector_cleanup_refuses_self_and_servers_with_active_calls(registry_dir):
-    """Arrange/Act/Assert: explicit cleanup never kills self or active work."""
-    from puppetmaster import mcp_registry
-
-    self_path = mcp_registry.register(pid=os.getpid(), workspace=str(registry_dir / "self"))
-    active_path = mcp_registry.register(pid=42002, workspace=str(registry_dir / "active"))
-    mcp_registry.record_activity(self_path, active_tool_calls=1)
-    mcp_registry.record_activity(active_path, active_tool_calls=1)
-
-    with patch.object(mcp_registry, "_pid_alive", return_value=True), patch.object(mcp_registry.os, "kill") as kill:
-        result = mcp_registry.kill_selected(
-            pids=[os.getpid(), 42002], self_pid=os.getpid(), grace_seconds=0
+        self_path = mcp_registry.register(
+            pid=os.getpid(), workspace=str(self.registry_dir / "self")
         )
-
-    assert result.killed == []
-    assert {(row["pid"], row["reason"]) for row in result.refused} == {
-        (os.getpid(), "self"),
-        (42002, "active_tool_calls"),
-    }
-    kill.assert_not_called()
-
-
-def test_cli_cleanup_wires_explicit_selectors(registry_dir):
-    """Arrange/Act/Assert: CLI forwards all selectors to precise cleanup."""
-    from puppetmaster import cli
-    from puppetmaster import mcp_registry
-    from puppetmaster.cli import commands_mcp
-
-    result = mcp_registry.McpSelectionResult(killed=[], refused=[])
-    output = io.StringIO()
-    with patch.object(commands_mcp, "registry_kill_selected", return_value=result) as selected, patch(
-        "sys.stdout", output
-    ):
-        assert cli.main(
-            [
-                "mcp",
-                "cleanup",
-                "--pid",
-                "42101",
-                "--workspace",
-                str(registry_dir / "repo"),
-                "--idle-after-seconds",
-                "45",
-                "--json",
-            ]
-        ) == 0
-
-    selected.assert_called_once_with(
-        pids=[42101],
-        workspace=str(registry_dir / "repo"),
-        idle_after_seconds=45.0,
-        self_pid=os.getpid(),
-    )
-    assert json.loads(output.getvalue())["selected_killed"] == []
-
-
-def test_mcp_cleanup_wires_explicit_selectors_without_default_kill(registry_dir):
-    """Arrange/Act/Assert: MCP selectors opt in; no selector is read-only."""
-    from puppetmaster import mcp_registry, mcp_server
-
-    result = mcp_registry.McpSelectionResult(killed=[], refused=[])
-    with patch.object(mcp_server, "registry_kill_selected", return_value=result) as selected:
-        response = mcp_server.run_mcp_cleanup(
-            {"pids": [42201], "workspace": str(registry_dir / "repo"), "idle_after_seconds": 30}
+        active_path = mcp_registry.register(
+            pid=42002, workspace=str(self.registry_dir / "active")
         )
-    payload = json.loads(response["content"][0]["text"])
-    selected.assert_called_once_with(
-        pids=[42201],
-        workspace=str(registry_dir / "repo"),
-        idle_after_seconds=30.0,
-        self_pid=os.getpid(),
-    )
-    assert payload["selected_killed"] == []
+        mcp_registry.record_activity(self_path, active_tool_calls=1)
+        mcp_registry.record_activity(active_path, active_tool_calls=1)
+
+        with patch.object(mcp_registry, "_pid_alive", return_value=True), patch.object(
+            mcp_registry.os, "kill"
+        ) as kill:
+            result = mcp_registry.kill_selected(
+                pids=[os.getpid(), 42002], self_pid=os.getpid(), grace_seconds=0
+            )
+
+        self.assertEqual(result.killed, [])
+        self.assertEqual(
+            {(row["pid"], row["reason"]) for row in result.refused},
+            {(os.getpid(), "self"), (42002, "active_tool_calls")},
+        )
+        kill.assert_not_called()
+
+    def test_cli_cleanup_wires_explicit_selectors(self) -> None:
+        """Arrange/Act/Assert: CLI forwards all selectors to precise cleanup."""
+        from puppetmaster import cli, mcp_registry
+        from puppetmaster.cli import commands_mcp
+
+        result = mcp_registry.McpSelectionResult(killed=[], refused=[])
+        output = io.StringIO()
+        with patch.object(
+            commands_mcp, "registry_kill_selected", return_value=result
+        ) as selected, patch("sys.stdout", output):
+            exit_code = cli.main(
+                [
+                    "mcp",
+                    "cleanup",
+                    "--pid",
+                    "42101",
+                    "--workspace",
+                    str(self.registry_dir / "repo"),
+                    "--idle-after-seconds",
+                    "45",
+                    "--json",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        selected.assert_called_once_with(
+            pids=[42101],
+            workspace=str(self.registry_dir / "repo"),
+            idle_after_seconds=45.0,
+            self_pid=os.getpid(),
+        )
+        self.assertEqual(json.loads(output.getvalue())["selected_killed"], [])
+
+    def test_mcp_cleanup_wires_explicit_selectors_without_default_kill(self) -> None:
+        """Arrange/Act/Assert: MCP selectors opt in; no selector is read-only."""
+        from puppetmaster import mcp_registry, mcp_server
+
+        result = mcp_registry.McpSelectionResult(killed=[], refused=[])
+        with patch.object(
+            mcp_server, "registry_kill_selected", return_value=result
+        ) as selected:
+            response = mcp_server.run_mcp_cleanup(
+                {
+                    "pids": [42201],
+                    "workspace": str(self.registry_dir / "repo"),
+                    "idle_after_seconds": 30,
+                }
+            )
+
+        payload = json.loads(response["content"][0]["text"])
+        selected.assert_called_once_with(
+            pids=[42201],
+            workspace=str(self.registry_dir / "repo"),
+            idle_after_seconds=30.0,
+            self_pid=os.getpid(),
+        )
+        self.assertEqual(payload["selected_killed"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -1101,7 +1101,8 @@ class PuppetmasterTests(unittest.TestCase):
             self.assertGreater(body["next_cursor"], 0)
             self.assertEqual(body["job_id"], result.job.id)
 
-    def test_mcp_follow_times_out_cleanly_when_no_new_artifacts(self) -> None:
+    def test_mcp_follow_returns_terminal_state_without_waiting_for_artifacts(self) -> None:
+        # Arrange
         with TemporaryDirectory() as tmp:
             state_dir = Path(tmp) / ".pm-state"
             store = SQLiteSwarmStore(state_dir)
@@ -1112,11 +1113,49 @@ class PuppetmasterTests(unittest.TestCase):
             )
             current = store.event_cursor(result.job.id)
 
+            # Act
+            with patch.object(
+                SQLiteSwarmStore,
+                "wait_for_events",
+                side_effect=AssertionError("terminal follow must not wait"),
+            ):
+                response = call_tool(
+                    "puppetmaster_live_artifacts_follow",
+                    {
+                        "job_id": result.job.id,
+                        "state_dir": str(state_dir),
+                        "since_cursor": current,
+                        "timeout_seconds": 0.2,
+                        "poll_interval_seconds": 0.05,
+                    },
+                )
+
+            self.assertFalse(response["isError"])
+            body = json.loads(response["content"][0]["text"])
+            self.assertEqual(body["item_count"], 0)
+            self.assertEqual(body["status"], "complete")
+            self.assertTrue(body["terminal"])
+            self.assertFalse(body["timed_out"])
+            self.assertIsNotNone(body["completed_at"])
+            self.assertEqual(body["next_cursor"], current)
+
+    def test_mcp_follow_still_times_out_for_running_job_without_new_artifacts(self) -> None:
+        # Arrange
+        with TemporaryDirectory() as tmp:
+            from puppetmaster.models import JobStatus
+
+            state_dir = Path(tmp) / ".pm-state"
+            store = SQLiteSwarmStore(state_dir)
+            job = store.create_job("running feed follow")
+            store.update_job_status(job.id, JobStatus.RUNNING)
+            current = store.event_cursor(job.id)
+
+            # Act
             start = time.monotonic()
             response = call_tool(
                 "puppetmaster_live_artifacts_follow",
                 {
-                    "job_id": result.job.id,
+                    "job_id": job.id,
                     "state_dir": str(state_dir),
                     "since_cursor": current,
                     "timeout_seconds": 0.2,
@@ -1125,9 +1164,12 @@ class PuppetmasterTests(unittest.TestCase):
             )
             elapsed = time.monotonic() - start
 
+            # Assert
             self.assertFalse(response["isError"])
             body = json.loads(response["content"][0]["text"])
             self.assertEqual(body["item_count"], 0)
+            self.assertEqual(body["status"], "running")
+            self.assertFalse(body["terminal"])
             self.assertTrue(body["timed_out"])
             self.assertEqual(body["next_cursor"], current)
             self.assertGreaterEqual(elapsed, 0.15)
@@ -4750,6 +4792,51 @@ class PuppetmasterTests(unittest.TestCase):
         # loop that would spam stderr or hold CPU.
         self.assertLessEqual(call_count["value"], 1)
 
+    def test_protocol_writer_contains_broken_pipe_failures(self) -> None:
+        # Arrange
+        from puppetmaster import mcp_server
+
+        class BrokenProtocolStream:
+            def write(self, payload):
+                raise BrokenPipeError("client disconnected")
+
+            def flush(self):
+                raise AssertionError("flush must not follow a failed write")
+
+        message = {"jsonrpc": "2.0", "id": 7, "result": {"ok": True}}
+
+        # Act
+        mcp_server._SHUTDOWN_REQUESTED.clear()
+        try:
+            with patch.object(mcp_server, "_protocol_stream", return_value=BrokenProtocolStream()):
+                written = mcp_server._write_protocol_message(message)
+
+            # Assert
+            self.assertFalse(written)
+            self.assertTrue(mcp_server._SHUTDOWN_REQUESTED.is_set())
+        finally:
+            mcp_server._SHUTDOWN_REQUESTED.clear()
+
+    def test_notifications_and_final_responses_share_the_guarded_writer(self) -> None:
+        # Arrange
+        from puppetmaster import mcp_server
+        from unittest.mock import call
+
+        notification = {"jsonrpc": "2.0", "method": "notifications/message", "params": {}}
+        response = {"jsonrpc": "2.0", "id": 9, "result": {"ok": True}}
+
+        # Act
+        with patch.object(mcp_server, "_write_protocol_message", return_value=False) as writer:
+            notification_written = mcp_server._emit_notification(notification)
+            with patch.object(mcp_server, "handle_message", return_value=response), patch.object(
+                mcp_server, "_keepalive_disabled", return_value=True
+            ):
+                mcp_server._process_message_safely({"method": "tools/list", "id": 9})
+
+        # Assert
+        self.assertFalse(notification_written)
+        self.assertEqual(writer.call_args_list, [call(notification), call(response)])
+
     def test_tool_call_keepalive_disabled_via_env(self) -> None:
         """PUPPETMASTER_MCP_KEEPALIVE_DISABLED short-circuits the wiring in _process_message_safely."""
         from puppetmaster.mcp_server import _keepalive_disabled
@@ -4853,10 +4940,14 @@ class PuppetmasterTests(unittest.TestCase):
     def test_feed_follow_caps_block_and_stamps_capped(self) -> None:
         """run_feed_follow clamps an oversized timeout under the Codex ceiling."""
         from puppetmaster import mcp_server
+        from puppetmaster.models import Job, JobStatus
 
         observed: dict = {}
 
         class _FakeStore:
+            def get_job(self, job_id):
+                return Job(id=job_id, goal="running follow", status=JobStatus.RUNNING)
+
             def wait_for_events(self, job_id, since, timeout_seconds, poll_interval):
                 observed["timeout_seconds"] = timeout_seconds
                 return None
@@ -6687,6 +6778,60 @@ print(json.dumps({"result": "ok", "usage": {"input_tokens": 321, "output_tokens"
         self.assertEqual(artifact.payload["adapter"], "codex")
         self.assertEqual(artifact.payload["result"], "blocked")
         self.assertEqual(artifact.payload["failure"], "missing_cli")
+
+    def test_default_windows_codex_command_bypasses_the_npm_cmd_shim(self) -> None:
+        # Arrange
+        from puppetmaster.adapters import codex as codex_module
+
+        with TemporaryDirectory() as tmp:
+            npm_root = Path(tmp) / "npm"
+            shim = npm_root / "codex.CMD"
+            entrypoint = npm_root / "node_modules" / "@openai" / "codex" / "bin" / "codex.js"
+            node = Path(tmp) / "node.exe"
+            entrypoint.parent.mkdir(parents=True)
+            shim.write_text("@echo off\r\n", encoding="utf-8")
+            entrypoint.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+            node.write_bytes(b"")
+
+            # Act
+            with patch.object(codex_module, "_is_windows", return_value=True), patch.object(
+                codex_module, "facade", return_value=lambda executable: str(node) if executable == "node" else None
+            ):
+                command = codex_module._default_codex_command_base(str(shim))
+
+            # Assert
+            self.assertEqual(command, [str(node), str(entrypoint)])
+            self.assertNotIn(str(shim), command)
+
+    def test_explicit_codex_commands_are_not_rewritten(self) -> None:
+        from puppetmaster.adapters import codex as codex_module
+
+        cases = [
+            ({"executable": "custom-codex --profile payload"}, {}, "payload"),
+            ({}, {"CODEX_COMMAND": "env-codex --profile environment"}, "environment"),
+        ]
+        for payload, environment, profile in cases:
+            with self.subTest(profile=profile):
+                # Arrange
+                task = Task(
+                    id=f"t-codex-{profile}",
+                    job_id="job-codex-explicit",
+                    role="codex-review",
+                    adapter="codex",
+                    instruction="Review the repo.",
+                    payload=payload,
+                )
+                resolved = str(Path("/tools") / f"{profile}-codex")
+
+                # Act
+                with patch.dict(os.environ, environment, clear=False), patch.object(
+                    codex_module, "_default_codex_command_base"
+                ) as default_command:
+                    command = codex_module._codex_command_base(task, resolved)
+
+                # Assert
+                self.assertEqual(command, [resolved, "--profile", profile])
+                default_command.assert_not_called()
 
     def test_codex_adapter_streams_and_surfaces_live_log(self) -> None:
         """Codex must run through the streamed runner (live sidecar log +
@@ -22239,6 +22384,30 @@ class PuppetmasterFrictionFixTests(unittest.TestCase):
             rc = cli_main(
                 ["--state-dir", str(store.root), "--backend", "sqlite", "wait", job.id]
             )
+            self.assertEqual(rc, 0)
+
+    def test_wait_uses_the_shared_terminal_contract_for_cancelled_jobs(self) -> None:
+        # Arrange
+        with TemporaryDirectory() as tmp:
+            store = self._store(tmp)
+            job = store.create_job("goal")
+            store.update_job_status(job.id, JobStatus.CANCELLED)
+
+            # Act
+            rc = cli_main(
+                [
+                    "--state-dir",
+                    str(store.root),
+                    "--backend",
+                    "sqlite",
+                    "wait",
+                    job.id,
+                    "--timeout",
+                    "0.1",
+                ]
+            )
+
+            # Assert
             self.assertEqual(rc, 0)
 
     def test_await_treats_stalled_as_terminal(self) -> None:


### PR DESCRIPTION
## Summary
Adds first-class support for Google Antigravity CLI (`agy`) as an external worker adapter across Puppetmaster swarms, model routing, and task execution.

## Changes
- **`AntigravityAdapter`**: Subclasses `CliWorkerAdapter` following the git snapshot -> clean worktree guard -> streamed headless execution -> artifact synthesis lifecycle.
- **Dual Execution Modes**:
  - `plan` (read-only audit/analysis): Runs under `--mode plan` to emit structured findings, risks, and decisions without dirtying the working tree.
  - `accept-edits` (full-edit code generation): Runs under `--mode accept-edits --dangerously-skip-permissions` to allow repository edits and captures diffs as `PATCH` artifacts.
- **Thinking / Effort Resolution**: Automatically maps reasoning effort levels (`high`, `medium`, `low`) for Gemini models requiring effort (`gemini-3.7-flash`, `gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3.1-pro`), defaulting to `high` when appropriate.
- **Telemetry & Billing**: Extracts `input_tokens`, `output_tokens`, `thinking_tokens`, `cache_read_tokens`, and `conversation_id` into canonical `VERIFICATION` artifacts. Implements billing posture detection in `platform_billing.py` (`plan` for subscription sessions, `api` for API keys).
- **Subsystem Integration**: Registered in `puppetmaster/adapters/registry.py`, `platform_lock.py` (`KNOWN_ADAPTERS`), `static_catalog.py` (`CURATED_CATALOGS["antigravity"]`), `model_registry.py`, and `diagnostics.py` (`puppetmaster doctor`).
- **Tests & Verification**: Added comprehensive unit, lifecycle, and live test suite in `tests/test_antigravity_adapter.py`. Verified live end-to-end against `gemini-3.7-flash`.

## Test Plan
- `python -m pytest tests/test_antigravity_adapter.py -v`: 11 passed
- `python -m pytest tests/test_puppetmaster.py -q`: 1269 passed, 14 skipped
- Live execution against `gemini-3.7-flash`: passed with valid token telemetry and finding artifacts.
