### PR TITLE
Extract build_cost_report for CLI, MCP, and Mari

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,17 @@
+## v1.22.18
+
+Leftover from the Marionette
+[#102](https://github.com/professorpalmer/marionette/issues/102) /
+[PR #103](https://github.com/professorpalmer/marionette/pull/103) absorb:
+the structured `puppetmaster cost <job_id> --json` payload is now one reusable
+function instead of living only inside the CLI handler.
+
+- **`puppetmaster.cost.build_cost_report(store, job_id, registry=None)`.** Same
+  JSON shape as before (`total_estimated_cost_usd`, `by_model`, `tasks`,
+  `actual_cost`, `counterfactual`, `estimate_drift`). CLI `--json`, MCP
+  `puppetmaster_job_cost`, and Mari all consume this function. No new economics
+  database and no kernel-contract change.
+
 ## v1.22.17
 
 Absorb of [@bsmi021](https://github.com/bsmi021) PR

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 The full documentation set. Start at the [project README](../README.md) for the 60-second tour and install; come here when you want depth.
 
-**Current release:** [v1.22.17](CHANGELOG.md#v12217) — safely resumable jobs and honest delivery verdicts; see [CHANGELOG.md](CHANGELOG.md) for the full line.
+**Current release:** [v1.22.18](CHANGELOG.md#v12218) — reusable `build_cost_report` for CLI / MCP / Mari; see [CHANGELOG.md](CHANGELOG.md) for the full line.
 
 ## Start here
 

--- a/puppetmaster/__init__.py
+++ b/puppetmaster/__init__.py
@@ -1,5 +1,5 @@
 """Puppetmaster: distributed agent workers with stitched shared memory."""
 
 __all__ = ["__version__"]
-__version__ = "1.22.17"
+__version__ = "1.22.18"
 

--- a/puppetmaster/cli/commands_gate.py
+++ b/puppetmaster/cli/commands_gate.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import dataclasses
 import json
 import subprocess
 import os
@@ -690,46 +689,10 @@ def _run_proxy_command(args) -> int:
     return 0
 
 def _routing_estimate_rows(artifacts) -> tuple[list[dict], dict[str, dict], float]:
-    """The pre-flight routing estimate: per-task rows + per-model rollup + total.
+    """Compatibility wrapper. Prefer ``puppetmaster.cost.routing_estimate_rows``."""
+    from puppetmaster.cost import routing_estimate_rows
 
-    Only the router's *initial* decision per task counts. Fallback/escalation
-    reroutes (created_by 'router-fallback' / 'router-escalation') emit their own
-    ROUTING artifacts; summing all of them double-counts a rerouted task. Dedup
-    by task_id mirrors ``savings.collect_routing_records``.
-    """
-    from puppetmaster.models import ArtifactType
-
-    rows: list[dict] = []
-    by_model: dict[str, dict] = {}
-    total = 0.0
-    seen_router_tasks: set = set()
-    for artifact in artifacts:
-        if artifact.type != ArtifactType.ROUTING or artifact.created_by != "router":
-            continue
-        task_id = artifact.task_id
-        if task_id:
-            if task_id in seen_router_tasks:
-                continue
-            seen_router_tasks.add(task_id)
-        payload = artifact.payload or {}
-        model_id = payload.get("model_id", "<unknown>")
-        cost = float(payload.get("estimated_cost_usd") or 0.0)
-        total += cost
-        rows.append(
-            {
-                "task_id": task_id,
-                "role": payload.get("role"),
-                "model_id": model_id,
-                "adapter": payload.get("adapter"),
-                "policy": payload.get("policy"),
-                "capability_needed": payload.get("capability_needed"),
-                "estimated_cost_usd": cost,
-            }
-        )
-        bucket = by_model.setdefault(model_id, {"calls": 0, "cost": 0.0})
-        bucket["calls"] += 1
-        bucket["cost"] += cost
-    return rows, by_model, round(total, 6)
+    return routing_estimate_rows(artifacts)
 
 
 def _run_cost_command(args, store) -> int:
@@ -750,83 +713,30 @@ def _run_cost_command(args, store) -> int:
     Cost no longer depends on a ROUTING artifact existing: a pinned run gets a
     priced ledger from its usage, not a "$0, didn't auto-route" dead end.
     """
-    from puppetmaster.cost import job_counterfactual, price_job
+    from puppetmaster.cost import build_cost_report
     from puppetmaster.model_registry import default_registry_path, load_registry
-    from puppetmaster.usage import aggregate_token_usage
 
     job_id = args.job_id
-    artifacts = store.list_artifacts(job_id)
-
     try:
         registry_path = _registry_path_from_args(args) or default_registry_path()
         registry = load_registry(registry_path)
     except Exception:
         registry = []
 
-    routing_rows, routing_by_model, routing_total = _routing_estimate_rows(artifacts)
-    job_cost = price_job(artifacts, registry)
-    counterfactual = job_counterfactual(job_cost, registry)
-
+    payload = build_cost_report(store, job_id, registry=registry)
     if args.json:
-        actual_by_model = {
-            mid: {
-                "calls": v["calls"],
-                "tokens_in": v["tokens_in"],
-                "tokens_out": v["tokens_out"],
-                "marginal_cost_usd": v["marginal_cost_usd"],
-                "billing": v["billing"],
-            }
-            for mid, v in job_cost.by_model.items()
-        }
-        payload = {
-            "job_id": job_id,
-            # Backward-compatible: the pre-flight routing estimate fields.
-            "cost_basis": "preflight_routing_estimate",
-            "total_estimated_cost_usd": routing_total,
-            "by_model": {
-                mid: {"calls": v["calls"], "estimated_cost_usd": round(v["cost"], 6)}
-                for mid, v in routing_by_model.items()
-            },
-            "token_usage": aggregate_token_usage(artifacts),
-            "estimate_drift": {
-                "route_estimated_tokens": job_cost.route_estimated_tokens,
-                "measured_usage_tokens": job_cost.measured_usage_tokens,
-                "token_ratio": job_cost.token_estimate_drift_ratio,
-                "route_nominal_cost_usd": job_cost.route_nominal_cost_usd,
-                "nominal_usage_cost_usd": job_cost.nominal_usage_cost_usd,
-                "nominal_cost_ratio": job_cost.nominal_cost_drift_ratio,
-            },
-            # The honest, routing-independent number.
-            "actual_cost": {
-                "cost_basis": "measured_usage_x_registry_price",
-                "total_marginal_cost_usd": job_cost.total_marginal_cost_usd,
-                "measured_cost_usd": job_cost.measured_cost_usd,
-                "estimated_cost_usd": job_cost.estimated_cost_usd,
-                "measured_runs": job_cost.measured_runs,
-                "estimated_runs": job_cost.estimated_runs,
-                "priced_tasks": job_cost.priced_tasks,
-                "unpriced_tasks": job_cost.unpriced_tasks,
-                "by_model": actual_by_model,
-                "tasks": [dataclasses.asdict(t) for t in job_cost.tasks],
-            },
-            "counterfactual": (
-                dataclasses.asdict(counterfactual) if counterfactual is not None else None
-            ),
-            # When the job auto-routed, the per-task routing rows; otherwise the
-            # priced-usage rows so the task breakdown is never empty for a run
-            # that actually consumed tokens.
-            "tasks": routing_rows if routing_rows else [dataclasses.asdict(t) for t in job_cost.tasks],
-        }
         print(json.dumps(payload, indent=2))
         return 0
 
-    has_usage = bool(job_cost.tasks)
+    artifacts = store.list_artifacts(job_id)
+    actual = payload.get("actual_cost") or {}
+    has_usage = bool(actual.get("tasks"))
     print(
         f"job {job_id}: actual measured spend = "
-        f"${job_cost.total_marginal_cost_usd:.6f}"
+        f"${float(actual.get('total_marginal_cost_usd') or 0.0):.6f}"
         + (
-            f"  ({job_cost.measured_cost_usd:.6f} measured / "
-            f"{job_cost.estimated_cost_usd:.6f} from estimated tokens)"
+            f"  ({float(actual.get('measured_cost_usd') or 0.0):.6f} measured / "
+            f"{float(actual.get('estimated_cost_usd') or 0.0):.6f} from estimated tokens)"
             if has_usage
             else ""
         )
@@ -834,17 +744,18 @@ def _run_cost_command(args, store) -> int:
     if has_usage:
         print()
         print(f"  {'MODEL':<28}  {'CALLS':>5}  {'TOKENS':>14}  {'COST':>12}")
+        by_model = actual.get("by_model") or {}
         for mid, v in sorted(
-            job_cost.by_model.items(), key=lambda kv: -kv[1]["marginal_cost_usd"]
+            by_model.items(), key=lambda kv: -kv[1]["marginal_cost_usd"]
         ):
             tokens = v["tokens_in"] + v["tokens_out"]
             print(
                 f"  {mid[:28]:<28}  {v['calls']:>5}  {tokens:>14,}  "
                 f"${v['marginal_cost_usd']:>10.6f}"
             )
-        if job_cost.unpriced_tasks:
+        if actual.get("unpriced_tasks"):
             print(
-                f"\n  note: {job_cost.unpriced_tasks} task(s) ran on a model not in "
+                f"\n  note: {actual['unpriced_tasks']} task(s) ran on a model not in "
                 "your registry, so their spend could not be priced (tokens still counted)."
             )
     else:
@@ -853,14 +764,20 @@ def _run_cost_command(args, store) -> int:
             "(the job may still be running, or produced no worker artifacts)."
         )
 
-    if counterfactual is not None and counterfactual.reference_priced:
+    counterfactual = payload.get("counterfactual")
+    if counterfactual is not None and counterfactual.get("reference_priced"):
         print()
         print(
-            f"  counterfactual: this volume on {counterfactual.reference_model_id} "
-            f"at metered rates ≈ ${counterfactual.naive_cost_usd:.6f}; you paid "
-            f"${counterfactual.actual_cost_usd:.6f} → avoided ${counterfactual.avoided_usd:.6f}."
+            f"  counterfactual: this volume on {counterfactual['reference_model_id']} "
+            f"at metered rates ≈ ${counterfactual['naive_cost_usd']:.6f}; you paid "
+            f"${counterfactual['actual_cost_usd']:.6f} → avoided ${counterfactual['avoided_usd']:.6f}."
         )
 
+    routing_rows = [
+        row for row in (payload.get("tasks") or [])
+        if isinstance(row, dict) and "estimated_cost_usd" in row and "role" in row
+    ]
+    routing_total = float(payload.get("total_estimated_cost_usd") or 0.0)
     if routing_rows:
         print()
         print(f"  pre-flight routing estimate (relative model cost) = ${routing_total:.6f}")

--- a/puppetmaster/cost.py
+++ b/puppetmaster/cost.py
@@ -19,11 +19,15 @@ reference model (resolved by :mod:`puppetmaster.savings`) so "what would this
 have cost on the flagship at metered rates?" is answerable post-hoc — again,
 pinned or not. On a plan-billed setup the actual marginal cost is ~$0, so the
 avoided figure ≈ the naive figure.
+
+``build_cost_report`` is the structured payload behind
+``puppetmaster cost <job_id> --json``. CLI, MCP ``puppetmaster_job_cost``, and
+Marionette all consume that one function. It does not invent a second ledger.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Iterable, Optional
+from dataclasses import asdict, dataclass, field
+from typing import Any, Iterable, Optional
 
 from puppetmaster.models import Artifact, ArtifactType
 from puppetmaster.savings import (
@@ -334,3 +338,116 @@ def job_counterfactual(job_cost: JobCost, registry: list) -> Optional[Counterfac
         avoided_usd=round(naive - actual, 6),
         tasks=len(job_cost.tasks),
     )
+
+
+
+def routing_estimate_rows(artifacts: Iterable[Artifact]) -> tuple[list[dict], dict[str, dict], float]:
+    """The pre-flight routing estimate: per-task rows + per-model rollup + total.
+
+    Only the router's *initial* decision per task counts. Fallback/escalation
+    reroutes (created_by 'router-fallback' / 'router-escalation') emit their own
+    ROUTING artifacts; summing all of them double-counts a rerouted task. Dedup
+    by task_id mirrors ``savings.collect_routing_records``.
+    """
+    rows: list[dict] = []
+    by_model: dict[str, dict] = {}
+    total = 0.0
+    seen_router_tasks: set = set()
+    for artifact in artifacts:
+        if artifact.type != ArtifactType.ROUTING or artifact.created_by != "router":
+            continue
+        task_id = artifact.task_id
+        if task_id:
+            if task_id in seen_router_tasks:
+                continue
+            seen_router_tasks.add(task_id)
+        payload = artifact.payload or {}
+        model_id = payload.get("model_id", "<unknown>")
+        cost = float(payload.get("estimated_cost_usd") or 0.0)
+        total += cost
+        rows.append(
+            {
+                "task_id": task_id,
+                "role": payload.get("role"),
+                "model_id": model_id,
+                "adapter": payload.get("adapter"),
+                "policy": payload.get("policy"),
+                "capability_needed": payload.get("capability_needed"),
+                "estimated_cost_usd": cost,
+            }
+        )
+        bucket = by_model.setdefault(model_id, {"calls": 0, "cost": 0.0})
+        bucket["calls"] += 1
+        bucket["cost"] += cost
+    return rows, by_model, round(total, 6)
+
+
+def build_cost_report(store: Any, job_id: str, registry: Optional[list] = None) -> dict:
+    """Structured report behind ``puppetmaster cost <job_id> --json``.
+
+    Shared by the CLI, the MCP ``puppetmaster_job_cost`` tool, and Marionette.
+    Prices against the current registry; does not invent a second economics DB.
+    """
+    from puppetmaster.usage import aggregate_token_usage
+
+    artifacts = store.list_artifacts(job_id) if store is not None else []
+    if registry is None:
+        try:
+            from puppetmaster.model_registry import default_registry_path, load_registry
+
+            registry = load_registry(default_registry_path()) or []
+        except Exception:
+            registry = []
+
+    routing_rows, routing_by_model, routing_total = routing_estimate_rows(artifacts)
+    job_cost = price_job(artifacts, registry)
+    counterfactual = job_counterfactual(job_cost, registry)
+    actual_by_model = {
+        mid: {
+            "calls": v["calls"],
+            "tokens_in": v["tokens_in"],
+            "tokens_out": v["tokens_out"],
+            "marginal_cost_usd": v["marginal_cost_usd"],
+            "billing": v["billing"],
+        }
+        for mid, v in job_cost.by_model.items()
+    }
+    return {
+        "job_id": job_id,
+        # Backward-compatible: the pre-flight routing estimate fields.
+        "cost_basis": "preflight_routing_estimate",
+        "total_estimated_cost_usd": routing_total,
+        "by_model": {
+            mid: {"calls": v["calls"], "estimated_cost_usd": round(v["cost"], 6)}
+            for mid, v in routing_by_model.items()
+        },
+        "token_usage": aggregate_token_usage(artifacts),
+        "estimate_drift": {
+            "route_estimated_tokens": job_cost.route_estimated_tokens,
+            "measured_usage_tokens": job_cost.measured_usage_tokens,
+            "token_ratio": job_cost.token_estimate_drift_ratio,
+            "route_nominal_cost_usd": job_cost.route_nominal_cost_usd,
+            "nominal_usage_cost_usd": job_cost.nominal_usage_cost_usd,
+            "nominal_cost_ratio": job_cost.nominal_cost_drift_ratio,
+        },
+        # The honest, routing-independent number.
+        "actual_cost": {
+            "cost_basis": "measured_usage_x_registry_price",
+            "total_marginal_cost_usd": job_cost.total_marginal_cost_usd,
+            "measured_cost_usd": job_cost.measured_cost_usd,
+            "estimated_cost_usd": job_cost.estimated_cost_usd,
+            "measured_runs": job_cost.measured_runs,
+            "estimated_runs": job_cost.estimated_runs,
+            "priced_tasks": job_cost.priced_tasks,
+            "unpriced_tasks": job_cost.unpriced_tasks,
+            "by_model": actual_by_model,
+            "tasks": [asdict(t) for t in job_cost.tasks],
+        },
+        "counterfactual": (
+            asdict(counterfactual) if counterfactual is not None else None
+        ),
+        # When the job auto-routed, the per-task routing rows; otherwise the
+        # priced-usage rows so the task breakdown is never empty for a run
+        # that actually consumed tokens.
+        "tasks": routing_rows if routing_rows else [asdict(t) for t in job_cost.tasks],
+    }

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -1352,9 +1352,7 @@ def _build_tools() -> list[McpTool]:
                 "Puppetmaster does not call a billing API."
             ),
             input_schema=job_schema(required=True),
-            handler=lambda args: run_cli(
-                ["cost", require_job_id(args), "--json"], args
-            ),
+            handler=run_job_cost,
         ),
         McpTool(
             name="puppetmaster_job_receipt",
@@ -3186,6 +3184,43 @@ def run_route_task(args: JsonObject) -> JsonObject:
     payload["registry_path"] = str(registry_path)
     return {
         "content": [{"type": "text", "text": json.dumps(payload, indent=2)}],
+        "isError": False,
+    }
+
+
+def run_job_cost(args: JsonObject) -> JsonObject:
+    """Return the structured cost report via ``build_cost_report``.
+
+    Envelope matches the previous CLI-subprocess tool so hosts that parse
+    ``stdout`` still see ``puppetmaster cost <job_id> --json``.
+    """
+    from puppetmaster.cost import build_cost_report
+    from puppetmaster.model_registry import default_registry_path, load_registry
+
+    job_id = require_job_id(args)
+    backend = str(args.get("backend") or "sqlite")
+    state_dir = mcp_state_dir(args)
+    store = create_store(backend, state_dir)
+    registry_path_arg = args.get("registry_path")
+    try:
+        registry_path = (
+            Path(str(registry_path_arg)).expanduser()
+            if registry_path_arg
+            else default_registry_path()
+        )
+        registry = load_registry(registry_path)
+    except Exception:
+        registry = []
+    report = build_cost_report(store, job_id, registry=registry)
+    body = {
+        "command": f"python -m puppetmaster cost {job_id} --json",
+        "cwd": cwd(args),
+        "returncode": 0,
+        "stdout": json.dumps(report, indent=2) + "\n",
+        "stderr": "",
+    }
+    return {
+        "content": [{"type": "text", "text": json.dumps(body, indent=2)}],
         "isError": False,
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "puppetmaster-ai"
-version = "1.22.17"
+version = "1.22.18"
 description = "Gunicorn-style agent swarms with Redis-like shared memory and artifact stitching. (Imported as `puppetmaster`; published as `puppetmaster-ai` because the bare PyPI name is held by an abandoned 2019 project, name-reassignment pending.)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_cost_report.py
+++ b/tests/test_cost_report.py
@@ -1,0 +1,176 @@
+"""Focused coverage for the reusable ``build_cost_report`` extract."""
+from __future__ import annotations
+
+import os
+import sys
+
+_HERMETIC_DIR = os.path.dirname(os.path.abspath(__file__))
+if _HERMETIC_DIR not in sys.path:
+    sys.path.insert(0, _HERMETIC_DIR)
+import hermetic_env  # noqa: F401
+
+import contextlib
+import inspect
+import io
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from puppetmaster.cli import main as cli_main
+from puppetmaster.model_registry import ModelSpec, save_registry
+from puppetmaster.models import Artifact, ArtifactType
+from puppetmaster.store_factory import create_store
+
+
+def _registry():
+    return [
+        ModelSpec(
+            id="mid-model",
+            adapter="claude-code",
+            adapter_model_name="mid-v1",
+            capability_score=80,
+            input_per_mtok_usd=3.0,
+            output_per_mtok_usd=15.0,
+            billing="api",
+        ),
+        ModelSpec(
+            id="flagship-model",
+            adapter="claude-code",
+            adapter_model_name="flagship-v1",
+            capability_score=99,
+            input_per_mtok_usd=15.0,
+            output_per_mtok_usd=75.0,
+            billing="api",
+        ),
+    ]
+
+
+def _usage_verification(job_id: str) -> Artifact:
+    return Artifact(
+        job_id=job_id,
+        task_id="task-1",
+        type=ArtifactType.VERIFICATION,
+        created_by="worker-1",
+        confidence=0.9,
+        evidence=["adapter:test"],
+        payload={
+            "adapter": "test",
+            "check": "do the thing",
+            "result": "passed",
+            "model": "mid-v1",
+            "tokens_in": 1_000_000,
+            "tokens_out": 1_000_000,
+            "tokens_estimated": False,
+        },
+    )
+
+
+class BuildCostReportTests(unittest.TestCase):
+    def test_build_cost_report_matches_mari_signature(self) -> None:
+        from puppetmaster.cost import build_cost_report
+
+        params = inspect.signature(build_cost_report).parameters
+        self.assertEqual(list(params)[:2], ["store", "job_id"])
+        self.assertIn("registry", params)
+
+    def test_cli_json_matches_build_cost_report(self) -> None:
+        from puppetmaster.cost import build_cost_report
+
+        with TemporaryDirectory() as tmp:
+            registry_path = Path(tmp) / "models.json"
+            save_registry(_registry(), registry_path)
+            state_dir = Path(tmp) / ".puppetmaster"
+            store = create_store("file", state_dir)
+            store.init()
+            job = store.create_job("cost extract")
+            store.save_artifacts([_usage_verification(job.id)])
+            report = build_cost_report(store, job.id, registry=_registry())
+            self.assertEqual(report["job_id"], job.id)
+            self.assertIn("actual_cost", report)
+            self.assertIn("counterfactual", report)
+            self.assertIn("estimate_drift", report)
+            self.assertAlmostEqual(
+                report["actual_cost"]["total_marginal_cost_usd"], 18.0, places=6
+            )
+
+            prior = os.environ.get("PUPPETMASTER_MODELS_PATH")
+            os.environ["PUPPETMASTER_MODELS_PATH"] = str(registry_path)
+            try:
+                stdout = io.StringIO()
+                with contextlib.redirect_stdout(stdout):
+                    code = cli_main(
+                        [
+                            "--state-dir",
+                            str(state_dir),
+                            "--backend",
+                            "file",
+                            "cost",
+                            job.id,
+                            "--json",
+                        ]
+                    )
+            finally:
+                if prior is None:
+                    os.environ.pop("PUPPETMASTER_MODELS_PATH", None)
+                else:
+                    os.environ["PUPPETMASTER_MODELS_PATH"] = prior
+            self.assertEqual(code, 0)
+            self.assertEqual(json.loads(stdout.getvalue()), report)
+
+    def test_cli_and_mcp_call_build_cost_report(self) -> None:
+        from puppetmaster import mcp_server
+        from puppetmaster.cli.commands_gate import _run_cost_command
+
+        with TemporaryDirectory() as tmp:
+            registry_path = Path(tmp) / "models.json"
+            save_registry(_registry(), registry_path)
+            state_dir = Path(tmp) / ".puppetmaster"
+            store = create_store("file", state_dir)
+            store.init()
+            job = store.create_job("cost wiring")
+            store.save_artifacts([_usage_verification(job.id)])
+            sentinel = {
+                "job_id": job.id,
+                "cost_basis": "preflight_routing_estimate",
+                "total_estimated_cost_usd": 0.0,
+                "actual_cost": {"total_marginal_cost_usd": 18.0},
+            }
+
+            class Args:
+                pass
+            Args.json = True
+            Args.job_id = job.id
+            Args.registry_path = str(registry_path)
+
+            with patch(
+                "puppetmaster.cost.build_cost_report", return_value=sentinel
+            ) as mocked:
+                out = io.StringIO()
+                with contextlib.redirect_stdout(out):
+                    rc = _run_cost_command(Args(), store)
+                self.assertEqual(rc, 0)
+                mocked.assert_called_once()
+                self.assertEqual(json.loads(out.getvalue()), sentinel)
+
+            with patch(
+                "puppetmaster.cost.build_cost_report", return_value=sentinel
+            ) as mocked:
+                result = mcp_server.run_job_cost(
+                    {
+                        "job_id": job.id,
+                        "state_dir": str(state_dir),
+                        "backend": "file",
+                        "registry_path": str(registry_path),
+                        "cwd": tmp,
+                    }
+                )
+                mocked.assert_called_once()
+                self.assertFalse(result.get("isError"))
+                body = json.loads(result["content"][0]["text"])
+                self.assertEqual(json.loads(body["stdout"]), sentinel)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extracts the structured `puppetmaster cost <job_id> --json` payload from `puppetmaster.cli.commands_gate._run_cost_command` into `puppetmaster.cost.build_cost_report(store, job_id, registry=None)`.
- CLI `--json` and MCP `puppetmaster_job_cost` both call that function. JSON shape is unchanged (`total_estimated_cost_usd`, `by_model`, `tasks`, `actual_cost`, `counterfactual`, `estimate_drift`).
- Leftover from the Marionette [professorpalmer/marionette#102](https://github.com/professorpalmer/marionette/issues/102) / [PR #103](https://github.com/professorpalmer/marionette/pull/103) absorb. Mari already prefers this function when it exists. No new economics DB and no kernel-contract change.

## Test plan
- [x] `python -m unittest tests.test_cost_report -q`
- [x] Existing `cost` CLI + `price_job` tests in `ModelRouterTests`
- [ ] Confirm `puppetmaster cost <job_id> --json` matches a direct `build_cost_report(store, job_id)` call
- [ ] Confirm MCP `puppetmaster_job_cost` returns the same report in `stdout`