### PR TITLE
Improve model routing quality and governance

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,29 @@
+## Unreleased
+
+**BREAKING — Feature: quality-aware, reproducible model routing.**
+
+Routing roles and tool-loop requirements now come from a packaged, versioned
+taxonomy instead of Python tables. Role aliases normalize to canonical roles,
+and routing evidence records the taxonomy and registry authority used for each
+decision. Selection accounts for enriched request size, context-window safety,
+qualified role scorecards, and estimate calibration. The `cheap` policy is now
+the cheapest sufficient model; the previous capability-agnostic behavior is
+available only through the explicit `absolute-cheapest` policy.
+
+- Requested review fails closed when no adequate independent judge runs, and
+  successful review evidence identifies the judge, evaluator, and reviewed
+  artifact. This intentionally replaces the prior pass-on-unavailable behavior.
+- Model registries validate identities and adapters, preserve retired-model
+  quarantine across discovery, expose a deterministic digest, and revalidate
+  pins and escalation authority before dispatch.
+- Recovery follows the newest failure and current registry authority. Audit
+  feedback attributes rejected outputs to their producing models and separates
+  qualified, role-specific objective outcomes by evaluation epoch.
+- A versioned paired-routing evaluation corpus and runner compare balanced
+  routing with strongest-eligible pinned baselines using deterministic grading,
+  uncertainty-aware non-inferiority reporting, and opt-in non-interfering shadow
+  decisions.
+
 ## v1.22.17
 
 Absorb of [@bsmi021](https://github.com/bsmi021) PR

--- a/docs/MODEL_ROUTING.md
+++ b/docs/MODEL_ROUTING.md
@@ -33,6 +33,11 @@ alternatives with the reason each was rejected — all stored as an
 `puppetmaster artifacts <job_id>` to see why each task went where,
 or `puppetmaster cost <job_id>` to sum spend across the run.
 
+Routing artifacts explain a selection; structural artifact presence is process
+health evidence, not semantic quality. For provider-neutral paired grading,
+strongest-eligible baselines, uncertainty, bounded non-inferiority claims, and
+opt-in shadow evidence, see [Routing-quality evaluation](routing-quality-evaluation.md).
+
 ## Role scorecards (v1.22.8+)
 
 `capability_score` is still the explicit **manual fallback**. Optional
@@ -274,6 +279,7 @@ python -m puppetmaster artifacts <job_id> | jq '.[] | select(.type=="routing") |
 | `payload.max_cost_usd` (float) | Hard cap on estimated per-call USD cost. Models over budget are excluded with a clear rejection reason. |
 | `payload.required_tags` (list) | Only consider models whose `tags` include ALL of these.                |
 | `payload.routing_policy` (str) | One of `balanced` (default), `cheap`, `quality`, `escalating`.         |
+| `payload.shadow_policy` (str) | Opt-in counterfactual policy recorded on the ROUTING artifact; never changes the production model, adapter, or policy. |
 | `payload.registry_path` (str)  | Use a different registry file for this task.                           |
 | `payload.min_confidence` (float) | Confidence floor for mid-run escalation (0..1). Below it, the task is re-run one capability tier up. Off unless set (or `$PUPPETMASTER_ESCALATE_CONFIDENCE`). |
 

--- a/docs/routing-quality-evaluation.md
+++ b/docs/routing-quality-evaluation.md
@@ -1,0 +1,36 @@
+# Routing-quality evaluation
+
+Puppetmaster's paired evaluator compares `balanced` routing with the strongest
+eligible pinned baseline on the same versioned cases, packaged snapshot files,
+canonical immutable snapshot digests, and repetitions. Each executor receipt
+must attest the observed digest; missing or mismatched snapshot proof fails the
+run. Arm order is reproducibly randomized from an explicit seed. Execution is
+injected, so the harness can use Codex, Claude Code, Hermes, Antigravity, or
+deterministic local fixtures without calling the OpenAI API directly.
+
+The deterministic grader measures acceptance pass rate, criterion score,
+unintended files, catastrophic failures, correction cycles, elapsed time,
+retries, tokens, and nominal and marginal cost. Seeded failures are executable
+negative vectors that must fail the same grader, and expected answers are not
+disclosed in task instructions. Reports include paired deltas and uncertainty;
+bounded finite-sample quality intervals do not collapse to zero merely because
+a small sample tied. A configured non-inferiority margin can produce one of
+three bounded results: noninferior, inferior, or inconclusive.
+
+These are corpus-scoped measurements. A non-inferiority result supports only
+the stated margin, corpus version, repetitions, and interval. An inconclusive
+result supports no quality-preservation claim. Neither result proves that
+routing improves quality without measured paired evidence.
+
+Structural artifact presence remains useful process-health evidence, not semantic quality,
+and cannot establish that an answer, finding, or patch is correct. Semantic
+conclusions come only from the case's deterministic
+acceptance criteria and observed results.
+
+Shadow routing is opt-in. It records the production selection and a
+counterfactual policy/model while explicitly recording
+`production_selection_changed: false`; it never replaces the model dispatched
+by the production policy. Auto-routed workers enable it with
+`payload.shadow_policy` (for example, `quality`); the existing ROUTING artifact
+then persists the counterfactual evidence alongside the unchanged production
+selection.

--- a/puppetmaster/api_discovery.py
+++ b/puppetmaster/api_discovery.py
@@ -217,30 +217,41 @@ def merge_api_catalog_into_registry(
     in the catalog — we only *add* newly-discovered ones and refresh overlays.
     Non-matching adapters and hand-tuned entries are preserved untouched."""
     discovered = catalog_to_specs(adapter, billing, catalog, existing)
-    discovered_by_name = {s.adapter_model_name: s for s in discovered}
-
-    existing_names = {
-        s.adapter_model_name for s in existing if s.adapter == adapter
+    discovered_by_identity = {
+        normalize_model_token(s.adapter_model_name): s for s in discovered
     }
-    added = sorted(discovered_by_name.keys() - existing_names)
+
+    existing_identities = {
+        normalize_model_token(s.adapter_model_name)
+        for s in existing
+        if s.adapter == adapter
+    }
+    added = sorted(
+        spec.adapter_model_name
+        for identity, spec in discovered_by_identity.items()
+        if identity not in existing_identities
+    )
 
     merged: list[ModelSpec] = []
     seen: set[str] = set()
     for spec in existing:
-        if spec.adapter == adapter and spec.adapter_model_name in discovered_by_name:
-            merged.append(discovered_by_name[spec.adapter_model_name])
-            seen.add(spec.adapter_model_name)
+        identity = normalize_model_token(spec.adapter_model_name)
+        if spec.adapter == adapter and identity in discovered_by_identity:
+            merged.append(discovered_by_identity[identity])
+            seen.add(identity)
         else:
             merged.append(spec)
-    for name, spec in discovered_by_name.items():
-        if name not in seen:
+    for identity, spec in discovered_by_identity.items():
+        if identity not in seen:
             merged.append(spec)
 
     report = {
         "adapter": adapter,
         "discovered_count": len(discovered),
         "added": added,
-        "refreshed": sorted(seen),
+        "refreshed": sorted(
+            discovered_by_identity[identity].adapter_model_name for identity in seen
+        ),
         "preserved": len([s for s in existing if s.adapter != adapter]),
     }
     return merged, report

--- a/puppetmaster/audit.py
+++ b/puppetmaster/audit.py
@@ -1,6 +1,4 @@
-"""Routing self-audit: turn the artifacts you already store into a
-"here's how your routing actually behaved, here's where it looks mis-scored"
-report — plus a *suggested* models.json diff you apply by hand.
+"""Objective, role-specific routing audit over durable run artifacts.
 
 Design stance (deliberate): this **recommends**, it does not silently
 autopilot. The signals available (model self-reported confidence, escalation
@@ -9,11 +7,11 @@ feedback ratchets that only ever raise cost — the opposite of the point. So:
 
 * The aggregator (:func:`build_audit_report`) is a pure function over records
   the caller collects from the store. Same input, same output.
-* It only proposes a score change for the one defensible case:
-  **an under-delivering model** (it keeps getting picked, then escalated away
-  from or finishing with low confidence). Lowering its score reserves the
-  harder work for a stronger model and stops the cheap-then-expensive
-  double-run.
+* Self-confidence and ordinary escalation remain visible diagnostics, but they
+  never authorize a score change.
+* Objective evaluator outcomes may recommend a role card change only inside a
+  compatible registry/classifier/adapter/evaluator epoch. They never lower the
+  model's global manual score.
 * "Over-used" (a strong model doing trivial work) is **flagged but never
   auto-adjusted** — proving a cheaper model would have sufficed needs a
   counterfactual (a shadow run), which this audit does not perform.
@@ -22,7 +20,10 @@ feedback ratchets that only ever raise cost — the opposite of the point. So:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
 from typing import Callable, Optional
+
+from puppetmaster.scorecards import MAX_CALIBRATION_AGE_DAYS
 
 # Confidence at or above this is "fine"; below it counts toward low-confidence.
 LOW_CONFIDENCE_BAR = 0.6
@@ -38,6 +39,23 @@ SEVERE_RATE = 0.6
 # A model whose typical task needed this much less capability than its score is
 # "possibly over-used" (informational only).
 OVER_USE_GAP = 20
+
+
+@dataclass(frozen=True)
+class ObjectiveAuditOutcome:
+    """One completed objective evaluation attributed to its producing model."""
+
+    model_id: str
+    predicted_quality: Optional[float]
+    objective_quality: Optional[float]
+    passed: bool
+    source: str = ""
+    registry_digest: str = ""
+    classifier_version: str = ""
+    taxonomy_version: str = ""
+    adapter_version: str = ""
+    evaluator_revision: str = ""
+    evaluated_at: str = ""
 
 
 @dataclass(frozen=True)
@@ -71,6 +89,29 @@ class TaskAuditRecord:
     attempts: int = 0
     fallback_attempts: int = 0
     escalation_attempts: int = 0
+    # Reroute attribution is kept per mechanism.  A fallback or independent
+    # review rejection belongs to the model that produced the rejected run,
+    # not to the stronger model that eventually completed the task.
+    fallback_from: Optional[str] = None
+    review_escalated_from: Optional[str] = None
+    fallback_from_models: tuple[str, ...] = ()
+    review_escalated_from_models: tuple[str, ...] = ()
+    # Prediction-versus-outcome evidence.  ``confidence`` above remains the
+    # worker's weak self-report; these fields are populated only from routing
+    # provenance and objective gate/evaluator artifacts.
+    predicted_quality: Optional[float] = None
+    objective_quality: Optional[float] = None
+    objective_passed: Optional[bool] = None
+    objective_source: Optional[str] = None
+    objective_model_id: Optional[str] = None
+    # Historical audit samples are comparable only inside one complete epoch.
+    registry_digest: str = ""
+    classifier_version: str = ""
+    taxonomy_version: str = ""
+    adapter_version: str = ""
+    evaluator_revision: str = ""
+    evaluated_at: str = ""
+    objective_outcomes: tuple[ObjectiveAuditOutcome, ...] = ()
 
     @property
     def has_actuals(self) -> bool:
@@ -113,6 +154,11 @@ class ModelAudit:
     timeout_or_failed_rate: float = 0.0
     degraded_rate: float = 0.0
     roles: dict = field(default_factory=dict)
+    review_escalated_away: int = 0
+    runs_with_objective_outcomes: int = 0
+    objective_pass_rate: Optional[float] = None
+    mean_predicted_quality: Optional[float] = None
+    mean_objective_quality: Optional[float] = None
     flags: list[str] = field(default_factory=list)
     suggested_score: Optional[int] = None
     rationale: Optional[str] = None
@@ -135,6 +181,7 @@ class AuditReport:
     # including ones with no actuals, so it must not anchor the ratio).
     total_est_spend_reconciled_usd: float = 0.0
     role_scorecard_suggestions: list[dict] = field(default_factory=list)
+    epoch_count: int = 0
 
     @property
     def token_drift_ratio(self) -> Optional[float]:
@@ -175,10 +222,117 @@ def _verification_label(result: Optional[str]) -> str:
     return result.strip().lower()
 
 
+def _optional_unit_float(value: object) -> Optional[float]:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    number = float(value)
+    return number if 0.0 <= number <= 1.0 else None
+
+
+def _record_objective_outcomes(
+    record: TaskAuditRecord,
+) -> tuple[ObjectiveAuditOutcome, ...]:
+    if record.objective_outcomes:
+        return record.objective_outcomes
+    if record.objective_passed is None:
+        return ()
+    return (
+        ObjectiveAuditOutcome(
+            model_id=record.objective_model_id or record.model_id,
+            predicted_quality=record.predicted_quality,
+            objective_quality=record.objective_quality,
+            passed=record.objective_passed,
+            source=record.objective_source or "",
+            registry_digest=record.registry_digest,
+            classifier_version=record.classifier_version,
+            taxonomy_version=record.taxonomy_version,
+            adapter_version=record.adapter_version,
+            evaluator_revision=record.evaluator_revision,
+            evaluated_at=record.evaluated_at,
+        ),
+    )
+
+
+def _complete_epoch(outcome: ObjectiveAuditOutcome) -> bool:
+    # Classifier logic is governed by the external taxonomy; either explicit
+    # classifier version or taxonomy version is accepted, while every other
+    # reproducibility dimension is mandatory.
+    complete = all(
+        (
+            outcome.registry_digest,
+            outcome.classifier_version or outcome.taxonomy_version,
+            outcome.adapter_version,
+            outcome.evaluator_revision,
+        )
+    )
+    if not complete:
+        return False
+    if not outcome.evaluated_at:
+        return False
+    evaluated_on = _evaluated_on(outcome.evaluated_at)
+    if evaluated_on is None:
+        return False
+    age_days = (date.today() - evaluated_on).days
+    return 0 <= age_days <= MAX_CALIBRATION_AGE_DAYS
+
+
+def _evaluated_on(value: str) -> Optional[date]:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        try:
+            return date.fromisoformat(value)
+        except (ValueError, TypeError):
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).date()
+
+
+def _epoch_keys(records: list[TaskAuditRecord]) -> set[tuple[str, str, str, str, str]]:
+    keys: set[tuple[str, str, str, str, str]] = set()
+    for record in records:
+        outcomes = _record_objective_outcomes(record)
+        if outcomes:
+            keys.update(
+                (
+                    outcome.registry_digest,
+                    outcome.classifier_version,
+                    outcome.taxonomy_version,
+                    outcome.adapter_version,
+                    outcome.evaluator_revision,
+                )
+                for outcome in outcomes
+            )
+        else:
+            keys.add(
+                (
+                    record.registry_digest,
+                    record.classifier_version,
+                    record.taxonomy_version,
+                    record.adapter_version,
+                    record.evaluator_revision,
+                )
+            )
+    return keys
+
+
 def _record_failed(record: TaskAuditRecord) -> bool:
     if _verification_label(record.verification_result) in _FAILED_RESULTS:
         return True
     return record.gate_passed is False
+
+
+def _fallback_sources(record: TaskAuditRecord) -> tuple[str, ...]:
+    if record.fallback_from_models:
+        return record.fallback_from_models
+    return (record.fallback_from,) if record.fallback_from else ()
+
+
+def _review_escalation_sources(record: TaskAuditRecord) -> tuple[str, ...]:
+    if record.review_escalated_from_models:
+        return record.review_escalated_from_models
+    return (record.review_escalated_from,) if record.review_escalated_from else ()
 
 
 def _record_degraded(record: TaskAuditRecord) -> bool:
@@ -194,7 +348,11 @@ def _role_counts(
         if role:
             counts[role] = counts.get(role, 0) + 1
     for record in records:
-        if record.escalated and record.escalated_from == model_id:
+        if (
+            (record.escalated and record.escalated_from == model_id)
+            or model_id in _fallback_sources(record)
+            or model_id in _review_escalation_sources(record)
+        ):
             role = record.role or ""
             if role:
                 counts[role] = counts.get(role, 0) + 1
@@ -206,45 +364,41 @@ def _role_scorecard_suggestions(
     registry_scores: dict[str, int],
     min_sample: int,
 ) -> list[dict]:
-    """Recommendation-only per-role card hints. Never written by --apply."""
-    groups: dict[tuple, list[TaskAuditRecord]] = {}
+    """Objective, epoch-local role-card hints. Never mutate a global score.
+
+    Each epoch is evaluated independently.  Suggestions with the same
+    model/adapter/role are deduplicated only after one complete epoch has met
+    the sample floor, so incompatible historical samples can never manufacture
+    authority by pooling.
+    """
+    groups: dict[tuple, list[ObjectiveAuditOutcome]] = {}
     for record in records:
         role = record.role or ""
         if not role:
             continue
-        key = (record.model_id, record.adapter, role)
-        groups.setdefault(key, []).append(record)
+        for outcome in _record_objective_outcomes(record):
+            if not _complete_epoch(outcome):
+                continue
+            key = (
+                outcome.model_id,
+                record.adapter,
+                role,
+                outcome.registry_digest,
+                outcome.classifier_version,
+                outcome.taxonomy_version,
+                outcome.adapter_version,
+                outcome.evaluator_revision,
+            )
+            groups.setdefault(key, []).append(outcome)
 
-    suggestions: list[dict] = []
-    for (model_id, adapter, role), recs in sorted(groups.items()):
+    candidates: dict[tuple[str, str, str], tuple[tuple, dict]] = {}
+    for group_key, recs in sorted(groups.items()):
+        model_id, adapter, role = group_key[:3]
         n = len(recs)
         if n < min_sample:
             continue
-        elapsed_vals = [r.elapsed_seconds for r in recs if r.elapsed_seconds is not None]
-        mean_elapsed = _mean(elapsed_vals)
-        failed_rate = sum(1 for r in recs if _record_failed(r)) / n
-        degraded_rate = sum(1 for r in recs if _record_degraded(r)) / n
-
-        peer_means: list[float] = []
-        for (other_id, _adapter, other_role), other_recs in groups.items():
-            if other_role != role or other_id == model_id:
-                continue
-            other_elapsed = [
-                r.elapsed_seconds for r in other_recs if r.elapsed_seconds is not None
-            ]
-            other_mean = _mean(other_elapsed)
-            if other_mean is not None:
-                peer_means.append(other_mean)
-        high_elapsed = False
-        if mean_elapsed is not None and peer_means:
-            peer_median = sorted(peer_means)[len(peer_means) // 2]
-            if peer_median > 0 and mean_elapsed >= 2.0 * peer_median:
-                high_elapsed = True
-        high_fail = (
-            failed_rate >= UNDER_PROVISIONED_RATE
-            or degraded_rate >= UNDER_PROVISIONED_RATE
-        )
-        if not high_elapsed and not high_fail:
+        failed_rate = sum(1 for outcome in recs if not outcome.passed) / n
+        if failed_rate < UNDER_PROVISIONED_RATE:
             continue
         from_cap = registry_scores.get(model_id)
         if from_cap is None:
@@ -252,32 +406,46 @@ def _role_scorecard_suggestions(
         to_cap = max(MIN_SCORE_FLOOR, from_cap - 5)
         if to_cap >= from_cap:
             continue
-        reasons: list[str] = []
-        if high_elapsed:
-            reasons.append(
-                f"mean elapsed {mean_elapsed:.1f}s is much higher than peer "
-                f"models for role={role}"
-            )
-        if high_fail:
-            reasons.append(
-                f"failed/timeout rate {failed_rate:.0%} / degraded rate "
-                f"{degraded_rate:.0%} over {n} {role} runs"
-            )
-        suggestions.append(
-            {
-                "model_id": model_id,
-                "adapter": adapter,
-                "role": role,
-                "from_capability": from_cap,
-                "to_capability": to_cap,
-                "rationale": (
-                    "; ".join(reasons)
-                    + "; recommendation-only role card, not applied to capability_score."
-                ),
-                "sample_count": n,
-            }
+        identity = (model_id, adapter, role)
+        evidence_dates = [
+            evaluated
+            for outcome in recs
+            if outcome.evaluated_at
+            and (evaluated := _evaluated_on(outcome.evaluated_at)) is not None
+        ]
+        last_calibrated = (
+            max(evidence_dates).isoformat()
+            if evidence_dates
+            else ""
         )
-    return suggestions
+        if not last_calibrated:
+            continue
+        suggestion = {
+            "model_id": model_id,
+            "adapter": adapter,
+            "role": role,
+            "from_capability": from_cap,
+            "to_capability": to_cap,
+            "rationale": (
+                f"objective evaluator failure rate {failed_rate:.0%} over "
+                f"{n} {role} runs in one compatible epoch; recommendation-only "
+                "role card, not applied to capability_score."
+            ),
+            "sample_count": n,
+            "last_calibrated": last_calibrated,
+            "epoch": {
+                "registry_digest": group_key[3],
+                "classifier_version": group_key[4],
+                "taxonomy_version": group_key[5],
+                "adapter_version": group_key[6],
+                "evaluator_revision": group_key[7],
+            },
+        }
+        rank = (last_calibrated, *group_key[3:])
+        previous = candidates.get(identity)
+        if previous is None or rank > previous[0]:
+            candidates[identity] = (rank, suggestion)
+    return [candidates[identity][1] for identity in sorted(candidates)]
 
 
 def build_audit_report(
@@ -301,26 +469,66 @@ def build_audit_report(
     """
     model_ids = set(registry_scores) | {r.model_id for r in records}
     model_ids |= {r.escalated_from for r in records if r.escalated_from}
+    model_ids |= {
+        source for record in records for source in _fallback_sources(record)
+    }
+    model_ids |= {
+        source
+        for record in records
+        for source in _review_escalation_sources(record)
+    }
 
     # escalated-away counts keyed by the model the task escalated OFF of.
     escalated_away: dict[str, int] = {}
     for r in records:
         if r.escalated and r.escalated_from:
             escalated_away[r.escalated_from] = escalated_away.get(r.escalated_from, 0) + 1
+    fallback_away: dict[str, int] = {}
+    review_escalated_away: dict[str, int] = {}
+    for r in records:
+        for source in _fallback_sources(r):
+            fallback_away[source] = fallback_away.get(source, 0) + 1
+        for source in _review_escalation_sources(r):
+            review_escalated_away[source] = review_escalated_away.get(source, 0) + 1
 
     audits: list[ModelAudit] = []
     for model_id in sorted(model_ids):
         retained = [r for r in records if r.model_id == model_id]
         away = escalated_away.get(model_id, 0)
+        fallback_away_count = fallback_away.get(model_id, 0)
+        review_away_count = review_escalated_away.get(model_id, 0)
         # A model was the initial pick if it either retained the task (no
         # escalation) or the task escalated away from it.
-        retained_initial = [r for r in retained if not r.escalated]
-        selections = len(retained_initial) + away
+        retained_initial = [
+            r
+            for r in retained
+            if not r.escalated
+            and not _fallback_sources(r)
+            and not _review_escalation_sources(r)
+        ]
+        selections = (
+            len(retained_initial) + away + fallback_away_count + review_away_count
+        )
 
         confidences = [r.confidence for r in retained if r.confidence is not None]
         low = [c for c in confidences if c < low_confidence_bar]
         spend = sum(r.est_cost_usd for r in retained)
-        fell_back_away = sum(1 for r in records if r.fell_back and r.escalated_from == model_id)
+        objective_outcomes = [
+            outcome
+            for r in records
+            for outcome in _record_objective_outcomes(r)
+            if outcome.model_id == model_id
+        ]
+        predicted = [
+            outcome.predicted_quality
+            for outcome in objective_outcomes
+            if outcome.predicted_quality is not None
+        ]
+        objective_quality = [
+            outcome.objective_quality
+            for outcome in objective_outcomes
+            if outcome.objective_quality is not None
+        ]
 
         score = registry_scores.get(model_id)
         escalated_away_rate = (away / selections) if selections else 0.0
@@ -351,7 +559,7 @@ def build_audit_report(
             low_confidence_rate=round(low_conf_rate, 3),
             escalated_away=away,
             escalated_away_rate=round(escalated_away_rate, 3),
-            fell_back_away=fell_back_away,
+            fell_back_away=fallback_away_count,
             est_spend_usd=round(spend, 6),
             runs_with_actuals=len(reconciled),
             measured_runs=measured_runs,
@@ -378,6 +586,23 @@ def build_audit_report(
                 3,
             ),
             roles=_role_counts(model_id, retained, records),
+            review_escalated_away=review_away_count,
+            runs_with_objective_outcomes=len(objective_outcomes),
+            objective_pass_rate=(
+                round(
+                    sum(1 for outcome in objective_outcomes if outcome.passed) /
+                    len(objective_outcomes),
+                    3,
+                )
+                if objective_outcomes
+                else None
+            ),
+            mean_predicted_quality=(
+                round(_mean(predicted), 3) if predicted else None
+            ),
+            mean_objective_quality=(
+                round(_mean(objective_quality), 3) if objective_quality else None
+            ),
         )
         _classify(audit, retained, low_confidence_bar, min_sample)
         audits.append(audit)
@@ -406,6 +631,7 @@ def build_audit_report(
         role_scorecard_suggestions=_role_scorecard_suggestions(
             records, registry_scores, min_sample
         ),
+        epoch_count=len(_epoch_keys(records)),
     )
 
 
@@ -416,9 +642,8 @@ def _classify(
     min_sample: int,
 ) -> None:
     """Attach flags + (only when defensible) a suggested score to ``audit``."""
-    # Under-provisioned: gets picked, then can't finish confidently. Lower the
-    # score so harder work routes to a stronger model. Defensible — there's a
-    # real failure signal (escalation / low confidence), not a guess.
+    # Confidence/escalation is retained as a weak diagnostic, never as routing
+    # authority.  Objective failures are handled by epoch-local role cards.
     under = (
         audit.selections >= min_sample
         and (
@@ -426,19 +651,13 @@ def _classify(
             or audit.low_confidence_rate >= 0.5
         )
     )
-    if under and audit.score is not None:
-        audit.flags.append("under-provisioned")
-        severe = (
-            audit.escalated_away_rate >= SEVERE_RATE
-            or audit.low_confidence_rate >= 0.7
-        )
-        step = 10 if severe else 5
-        audit.suggested_score = max(MIN_SCORE_FLOOR, audit.score - step)
+    if under:
+        audit.flags.append("weak-self-signal")
         audit.rationale = (
             f"escalated away {audit.escalated_away_rate:.0%} of "
             f"{audit.selections} picks / low-confidence "
-            f"{audit.low_confidence_rate:.0%}; lower score so harder work "
-            f"routes to a stronger model."
+            f"{audit.low_confidence_rate:.0%}; diagnostic only, because worker "
+            "self-confidence is not objective routing authority."
         )
         return
 
@@ -502,7 +721,10 @@ def collect_records(store, *, window_days: Optional[float] = None) -> tuple[list
 
         # Initial routing picks and escalation/fallback events, per task.
         initial_by_task: dict[str, dict] = {}
+        routing_history_by_task: dict[str, list[tuple[str, dict]]] = {}
         escalated_from: dict[str, str] = {}
+        fallback_events: dict[str, list[tuple[str, str]]] = {}
+        review_escalation_events: dict[str, list[tuple[str, str]]] = {}
         fell_back: set[str] = set()
         latest_conf: dict[str, tuple[str, float]] = {}  # task_id -> (created_at, confidence)
         # task_id -> (created_at, tokens_in, tokens_out, estimated) for the latest
@@ -510,11 +732,17 @@ def collect_records(store, *, window_days: Optional[float] = None) -> tuple[list
         # carry a usage record contribute, so a task with no usage stays unknown.
         latest_usage: dict[str, tuple[str, int, int, bool]] = {}
         latest_verif_result: dict[str, tuple[str, object]] = {}
+        objective_events: dict[
+            str, list[tuple[str, bool, Optional[float], str, str]]
+        ] = {}
         gate_flags_by_task: dict[str, list[bool]] = {}
         for a in artifacts:
             payload = a.payload or {}
             kind = a.type.value
             if kind == "routing":
+                routing_history_by_task.setdefault(a.task_id, []).append(
+                    (a.created_at, payload)
+                )
                 if a.created_by == "router":
                     initial_by_task[a.task_id] = payload
                 elif a.created_by == "router-escalation":
@@ -523,6 +751,17 @@ def collect_records(store, *, window_days: Optional[float] = None) -> tuple[list
                         escalated_from[a.task_id] = frm
                 elif a.created_by == "router-fallback":
                     fell_back.add(a.task_id)
+                    frm = payload.get("fallback_from_model")
+                    if frm:
+                        fallback_events.setdefault(a.task_id, []).append(
+                            (a.created_at, str(frm))
+                        )
+                elif a.created_by == "router-review-escalation":
+                    frm = payload.get("review_escalated_from_model")
+                    if frm:
+                        review_escalation_events.setdefault(a.task_id, []).append(
+                            (a.created_at, str(frm))
+                        )
             elif kind == "verification":
                 prev = latest_conf.get(a.task_id)
                 if prev is None or a.created_at >= prev[0]:
@@ -544,8 +783,44 @@ def collect_records(store, *, window_days: Optional[float] = None) -> tuple[list
                             bool(payload.get("tokens_estimated")),
                         )
             elif kind == "gate" and "passed" in payload:
-                gate_flags_by_task.setdefault(a.task_id, []).append(
-                    bool(payload.get("passed"))
+                passed = bool(payload.get("passed"))
+                gate_flags_by_task.setdefault(a.task_id, []).append(passed)
+                review_status = str(payload.get("review_status") or "").lower()
+                if review_status in {
+                    "unavailable",
+                    "skipped",
+                    "independence_failed",
+                }:
+                    continue
+                raw_score = payload.get("objective_score")
+                objective_score: Optional[float] = None
+                if (
+                    not isinstance(raw_score, bool)
+                    and isinstance(raw_score, (int, float))
+                    and 0.0 <= float(raw_score) <= 1.0
+                ):
+                    objective_score = float(raw_score)
+                elif raw_score is None:
+                    objective_score = 1.0 if passed else 0.0
+                source = str(
+                    payload.get("evaluator_slot")
+                    or payload.get("kind")
+                    or payload.get("gate")
+                    or "gate"
+                )
+                evaluator_revision = str(
+                    payload.get("evaluator_revision")
+                    or payload.get("evaluator_version")
+                    or ""
+                )
+                objective_events.setdefault(a.task_id, []).append(
+                    (
+                        a.created_at,
+                        passed,
+                        objective_score,
+                        source,
+                        evaluator_revision,
+                    )
                 )
 
         for task_id, task in tasks.items():
@@ -557,6 +832,64 @@ def collect_records(store, *, window_days: Optional[float] = None) -> tuple[list
             conf = latest_conf.get(task_id)
             usage = latest_usage.get(task_id)
             verif = latest_verif_result.get(task_id)
+            objectives = sorted(
+                objective_events.get(task_id, []), key=lambda item: item[0]
+            )
+            objective = objectives[-1] if objectives else None
+            objective_routing = initial
+            fallback_sources = tuple(
+                model_id
+                for _, model_id in sorted(fallback_events.get(task_id, []))
+            )
+            review_escalation_sources = tuple(
+                model_id
+                for _, model_id in sorted(
+                    review_escalation_events.get(task_id, [])
+                )
+            )
+            if objective:
+                prior_routes = [
+                    item
+                    for item in routing_history_by_task.get(task_id, [])
+                    if item[0] <= objective[0]
+                ]
+                if prior_routes:
+                    objective_routing = max(prior_routes, key=lambda item: item[0])[1]
+            attributed_outcomes: list[ObjectiveAuditOutcome] = []
+            for event in objectives:
+                prior_routes = [
+                    item
+                    for item in routing_history_by_task.get(task_id, [])
+                    if item[0] <= event[0]
+                ]
+                event_routing = (
+                    max(prior_routes, key=lambda item: item[0])[1]
+                    if prior_routes
+                    else initial
+                )
+                attributed_outcomes.append(
+                    ObjectiveAuditOutcome(
+                        model_id=str(event_routing.get("model_id") or final_model),
+                        predicted_quality=_optional_unit_float(
+                            event_routing.get("predicted_quality")
+                        ),
+                        objective_quality=event[2],
+                        passed=event[1],
+                        source=event[3],
+                        registry_digest=str(event_routing.get("registry_digest") or ""),
+                        classifier_version=str(
+                            event_routing.get("classifier_version") or ""
+                        ),
+                        taxonomy_version=str(
+                            event_routing.get("taxonomy_version") or ""
+                        ),
+                        adapter_version=str(
+                            event_routing.get("adapter_version") or ""
+                        ),
+                        evaluator_revision=event[4],
+                        evaluated_at=event[0],
+                    )
+                )
             verification_result = verif[1] if verif else None
             if verification_result is not None and not isinstance(
                 verification_result, str
@@ -591,6 +924,48 @@ def collect_records(store, *, window_days: Optional[float] = None) -> tuple[list
                     attempts=int(getattr(task, "attempts", 0) or 0),
                     fallback_attempts=int(payload.get("fallback_attempts") or 0),
                     escalation_attempts=int(payload.get("escalation_attempts") or 0),
+                    fallback_from=(fallback_sources[-1] if fallback_sources else None),
+                    review_escalated_from=(
+                        review_escalation_sources[-1]
+                        if review_escalation_sources
+                        else None
+                    ),
+                    fallback_from_models=fallback_sources,
+                    review_escalated_from_models=review_escalation_sources,
+                    predicted_quality=_optional_unit_float(
+                        objective_routing.get("predicted_quality")
+                    ),
+                    objective_quality=objective[2] if objective else None,
+                    objective_passed=objective[1] if objective else None,
+                    objective_source=objective[3] if objective else None,
+                    objective_model_id=(
+                        str(objective_routing.get("model_id") or final_model)
+                        if objective
+                        else None
+                    ),
+                    registry_digest=str(
+                        objective_routing.get("registry_digest")
+                        or payload.get("router_registry_digest")
+                        or ""
+                    ),
+                    classifier_version=str(
+                        objective_routing.get("classifier_version")
+                        or payload.get("router_classifier_version")
+                        or ""
+                    ),
+                    taxonomy_version=str(
+                        objective_routing.get("taxonomy_version")
+                        or payload.get("router_taxonomy_version")
+                        or ""
+                    ),
+                    adapter_version=str(
+                        objective_routing.get("adapter_version")
+                        or payload.get("router_adapter_version")
+                        or ""
+                    ),
+                    evaluator_revision=(objective[4] if objective else ""),
+                    evaluated_at=(objective[0] if objective else ""),
+                    objective_outcomes=tuple(attributed_outcomes),
                 )
             )
     return records, jobs_considered

--- a/puppetmaster/baselines/routing-quality-corpus-v1.json
+++ b/puppetmaster/baselines/routing-quality-corpus-v1.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": 1,
+  "corpus_id": "puppetmaster-routing-quality",
+  "corpus_version": "2026-08-22.1",
+  "cases": [
+    {
+      "case_id": "implement-bounded-change",
+      "role": "implement",
+      "instruction": "Read the packaged authority and apply only its bounded fixture change.",
+      "snapshot_id": "implement-fixture-v1",
+      "snapshot_digest": "sha256:611989a5801d4a52de4022093e537c5710d66e1049f055de51f63668289a4101",
+      "snapshot_files": {
+        "fixtures/implement/authority.txt": "The accepted bounded-change result is IMPLEMENT_OK."
+      },
+      "min_capability": 60,
+      "estimated_tokens_in": 1200,
+      "estimated_tokens_out": 300,
+      "allowed_changed_files": ["fixtures/implement/target.txt"],
+      "criteria": [
+        {
+          "criterion_id": "implement-required-marker",
+          "description": "The bounded implementation success marker is present.",
+          "evaluator": {"kind": "contains", "expected": "IMPLEMENT_OK"}
+        }
+      ],
+      "seeded_failures": []
+    },
+    {
+      "case_id": "explore-source-finding",
+      "role": "explore",
+      "instruction": "Inspect the packaged authority and report its grounded fixture finding.",
+      "snapshot_id": "explore-fixture-v1",
+      "snapshot_digest": "sha256:dce42e4868d079db0480e3149b8f73b628c5fcbb6dee767eccb6a426b82cb111",
+      "snapshot_files": {
+        "fixtures/explore/authority.txt": "The grounded fixture finding is EXPLORE_FOUND."
+      },
+      "min_capability": 50,
+      "estimated_tokens_in": 1000,
+      "estimated_tokens_out": 250,
+      "allowed_changed_files": [],
+      "criteria": [
+        {
+          "criterion_id": "explore-grounded-marker",
+          "description": "The fixture-specific finding is present.",
+          "evaluator": {"kind": "contains", "expected": "EXPLORE_FOUND"}
+        }
+      ],
+      "seeded_failures": []
+    },
+    {
+      "case_id": "audit-seeded-defect",
+      "role": "audit",
+      "instruction": "Audit the packaged authority and identify its seeded fixture defect.",
+      "snapshot_id": "audit-fixture-v1",
+      "snapshot_digest": "sha256:42391b62e098df4a4a27b9d87e5e089d02f4c48beae0c9b0e2846459a6afbe5b",
+      "snapshot_files": {
+        "fixtures/audit/authority.txt": "The seeded defect identifier is AUDIT_DEFECT_FOUND."
+      },
+      "min_capability": 75,
+      "estimated_tokens_in": 1400,
+      "estimated_tokens_out": 350,
+      "allowed_changed_files": [],
+      "criteria": [
+        {
+          "criterion_id": "audit-detects-seeded-defect",
+          "description": "The seeded defect marker is identified.",
+          "evaluator": {"kind": "contains", "expected": "AUDIT_DEFECT_FOUND"}
+        }
+      ],
+      "seeded_failures": [
+        {
+          "failure_id": "plausible-but-misses-defect",
+          "description": "The response is structurally substantive but omits the seeded defect marker.",
+          "output_text": "The fixture appears internally consistent and no material defect was found.",
+          "changed_files": [],
+          "catastrophic": false
+        }
+      ]
+    },
+    {
+      "case_id": "plan-ordered-dependencies",
+      "role": "plan",
+      "instruction": "Use the packaged authority to produce the valid fixture dependency order.",
+      "snapshot_id": "plan-fixture-v1",
+      "snapshot_digest": "sha256:90563d30c786533f73ddb1b14420e22181b8308d58d21f4baa27200825230d86",
+      "snapshot_files": {
+        "fixtures/plan/authority.txt": "The valid dependency order result is PLAN_ORDER_VALID."
+      },
+      "min_capability": 65,
+      "estimated_tokens_in": 1100,
+      "estimated_tokens_out": 300,
+      "allowed_changed_files": [],
+      "criteria": [
+        {
+          "criterion_id": "plan-valid-order-marker",
+          "description": "The dependency order acceptance marker is present.",
+          "evaluator": {"kind": "contains", "expected": "PLAN_ORDER_VALID"}
+        }
+      ],
+      "seeded_failures": []
+    }
+  ]
+}

--- a/puppetmaster/cli/_parser.py
+++ b/puppetmaster/cli/_parser.py
@@ -157,8 +157,18 @@ def build_parser() -> argparse.ArgumentParser:
         )
         group.add_argument(
             "--routing-policy",
-            choices=["balanced", "cheap", "quality", "escalating"],
-            help="Routing policy when --auto-route is set. Default: balanced.",
+            choices=[
+                "balanced",
+                "cheap",
+                "absolute-cheapest",
+                "quality",
+                "escalating",
+            ],
+            help=(
+                "Routing policy when --auto-route is set: cheap selects the "
+                "cheapest sufficient model; absolute-cheapest explicitly "
+                "allows an insufficient lowest-cost model. Default: balanced."
+            ),
         )
         group.add_argument(
             "--max-cost-usd",
@@ -1580,7 +1590,7 @@ def build_parser() -> argparse.ArgumentParser:
     edit.add_argument(
         "--routing-policy",
         default="cheap",
-        choices=["cheap", "balanced", "quality", "escalating"],
+        choices=["cheap", "absolute-cheapest", "balanced", "quality", "escalating"],
         help="Router policy when not pinning --model (default: cheap).",
     )
     edit.add_argument(
@@ -1783,7 +1793,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     swarm.add_argument(
         "--routing-policy",
-        choices=["balanced", "cheap", "quality", "escalating"],
+        choices=["balanced", "cheap", "absolute-cheapest", "quality", "escalating"],
         help="Override per-role routing policy for all workers.",
     )
     swarm.add_argument(
@@ -1861,7 +1871,7 @@ def build_parser() -> argparse.ArgumentParser:
     browser.add_argument(
         "--routing-policy",
         default="balanced",
-        choices=["cheap", "balanced", "quality", "escalating"],
+        choices=["cheap", "absolute-cheapest", "balanced", "quality", "escalating"],
         help="Router policy above the capability floor (default: balanced).",
     )
     browser.add_argument(
@@ -2710,8 +2720,12 @@ def build_parser() -> argparse.ArgumentParser:
     route_cmd.add_argument(
         "--policy",
         default="balanced",
-        choices=["balanced", "cheap", "quality", "escalating"],
-        help="Routing policy. Default: balanced.",
+        choices=["balanced", "cheap", "absolute-cheapest", "quality", "escalating"],
+        help=(
+            "Routing policy: cheap selects the cheapest sufficient model; "
+            "absolute-cheapest explicitly selects the lowest-cost model even "
+            "when insufficient. Default: balanced."
+        ),
     )
     route_cmd.add_argument(
         "--min-capability",

--- a/puppetmaster/cli/commands_gate.py
+++ b/puppetmaster/cli/commands_gate.py
@@ -240,11 +240,10 @@ def _run_preflight_command(args) -> int:
     return 0 if result.ok else 1
 
 def _run_audit_command(args, store) -> int:
-    """Analyze past routing behavior and propose conservative score changes.
+    """Analyze routing behavior and propose qualified role-card changes.
 
-    Read-only by default: prints a per-model report (picks, mean confidence,
-    escalation rate, spend) plus a suggested models.json diff. ``--apply``
-    writes the suggested score changes; nothing is mutated otherwise.
+    Read-only by default. ``--apply`` writes objective, epoch-qualified role
+    cards; it never infers a global capability score from one role's outcomes.
     """
     import json as _json
     from dataclasses import asdict, replace
@@ -352,17 +351,10 @@ def _run_audit_command(args, store) -> int:
                     "  No token usage recorded yet — estimate-vs-actual drift will "
                     "populate once routed runs report usage."
                 )
-        if report.suggestions:
-            print("\nSuggested score changes (your assertion stays the source of truth):")
-            for s in report.suggestions:
-                print(f"  {s['model_id']}: {s['from_score']} -> {s['to_score']}")
-                print(f"      {s['rationale']}")
-        elif report.tasks_considered:
-            print("\nNo score changes suggested — routing looks well-calibrated.")
         if report.role_scorecard_suggestions:
             print(
                 "\nRole scorecard recommendations "
-                "(not applied; --apply only writes capability_score):"
+                "(--apply writes qualified role cards only):"
             )
             for sug in report.role_scorecard_suggestions:
                 print(
@@ -370,22 +362,43 @@ def _run_audit_command(args, store) -> int:
                     f"{sug['from_capability']} -> {sug['to_capability']}"
                 )
                 print(f"      {sug['rationale']}")
+        elif report.tasks_considered:
+            print("\nNo objective role-card changes suggested.")
 
     if args.apply:
-        if not report.suggestions:
+        if not report.role_scorecard_suggestions:
             print("\nNothing to apply.")
             return 0
+        from puppetmaster.scorecards import ROLE_CARD_SCALE
+
         by_id = {s.id: s for s in registry}
         changed = 0
-        for sug in report.suggestions:
+        for sug in report.role_scorecard_suggestions:
             spec = by_id.get(sug["model_id"])
             if spec is None:
                 continue
-            by_id[sug["model_id"]] = replace(spec, capability_score=sug["to_score"])
+            cards = {
+                str(role): dict(card)
+                for role, card in (spec.role_scorecards or {}).items()
+                if isinstance(card, dict)
+            }
+            cards[sug["role"]] = {
+                "capability": sug["to_capability"],
+                "sample_count": sug["sample_count"],
+                "last_calibrated": sug["last_calibrated"],
+                "scale": ROLE_CARD_SCALE,
+                "scale_version": "1",
+                "provenance": {
+                    "source": "local_audit",
+                    "version": "objective-epoch-v1",
+                    "epoch": dict(sug.get("epoch") or {}),
+                },
+            }
+            by_id[sug["model_id"]] = replace(spec, role_scorecards=cards)
             changed += 1
         if changed:
             save_registry(list(by_id.values()), registry_path)
-            print(f"\nApplied {changed} score change(s) to {registry_path}.")
+            print(f"\nApplied {changed} role-card change(s) to {registry_path}.")
     return 0
 
 def _run_savings_command(args, state_dir) -> int:

--- a/puppetmaster/cli/commands_models.py
+++ b/puppetmaster/cli/commands_models.py
@@ -185,6 +185,22 @@ def _updated_spec_for_assignment(spec, key: str, value: str):
         return _replace_model_spec(spec, payload_defaults=payload_defaults)
     raise ValueError(f"unknown models set key: {key}")
 
+
+_LIFECYCLE_ASSIGNMENTS = {
+    "enabled",
+    "disabled_reason",
+    "disabled_authority",
+    "retired",
+    "retirement_reason",
+    "retirement_authority",
+}
+
+
+def _lifecycle_assignment_value(key: str, value: str) -> Any:
+    if key in ("enabled", "retired"):
+        return _parse_bool_value(value)
+    return value
+
 def _run_models_set(args, path: Path) -> int:
     from puppetmaster.model_registry import load_registry, save_registry
 
@@ -201,11 +217,20 @@ def _run_models_set(args, path: Path) -> int:
     index = by_id[args.model_id]
     updated = specs[index]
     try:
+        lifecycle_updates: dict[str, Any] = {}
         for assignment in args.assignments:
             if "=" not in assignment:
                 raise ValueError(f"expected key=value assignment, got {assignment!r}")
             key, value = assignment.split("=", 1)
-            updated = _updated_spec_for_assignment(updated, key, value)
+            if key in _LIFECYCLE_ASSIGNMENTS:
+                lifecycle_updates[key] = _lifecycle_assignment_value(key, value)
+            else:
+                updated = _updated_spec_for_assignment(updated, key, value)
+        if lifecycle_updates:
+            # Lifecycle fields are one authority mutation.  Construct once so
+            # assignment ordering cannot create a transient invalid retirement
+            # (for example retired=true before its reason/authority fields).
+            updated = _replace_model_spec(updated, **lifecycle_updates)
     except (TypeError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/puppetmaster/cursor_discovery.py
+++ b/puppetmaster/cursor_discovery.py
@@ -335,6 +335,9 @@ def merge_catalog_into_registry(
     """
     discovered = catalog_to_specs(catalog, existing)
     discovered_model_names = {s.adapter_model_name for s in discovered}
+    discovered_identity_names = {
+        normalize_model_token(name) for name in discovered_model_names
+    }
 
     non_cursor = [s for s in existing if s.adapter != "cursor"]
     existing_cursor_names = {
@@ -350,7 +353,8 @@ def merge_catalog_into_registry(
             spec
             for spec in existing
             if spec.adapter == "cursor"
-            and spec.adapter_model_name not in discovered_model_names
+            and normalize_model_token(spec.adapter_model_name)
+            not in discovered_identity_names
         ]
         merged = non_cursor + discovered + preserved_cursor
     report = {

--- a/puppetmaster/gates.py
+++ b/puppetmaster/gates.py
@@ -35,8 +35,9 @@ Gate kinds (all opt-in via ``task.payload["gates"]`` or convenience flags):
                       would sign off on. The live judge call is opt-in behind
                       ``$PUPPETMASTER_REVIEW_GATE`` (it makes an extra model
                       call, so it's a deliberate, flagged spend); when the flag
-                      is off, or no adequate judge exists, the gate is a no-op
-                      rather than bricking every implement run.
+                      is off, or no adequate judge exists, an explicitly
+                      requested review fails closed. A review attached only by
+                      global policy remains optional and records why it skipped.
 
 Layering, cheap-to-expensive: ``require_diff`` (free) → ``ratchet`` (one
 command) → ``command`` (your test suite) → ``review`` (one judge call). Each
@@ -74,6 +75,7 @@ _REVIEW_ENABLE_ENV = "PUPPETMASTER_REVIEW_GATE"
 # The marker the judge model must emit so its verdict is machine-extractable
 # from free-form model output, regardless of which adapter ran it.
 _REVIEW_VERDICT_MARKER = "PUPPETMASTER_REVIEW_VERDICT"
+_DEFAULT_REVIEW_EVALUATOR_REVISION = "review-gate-v1"
 
 
 @dataclass
@@ -106,7 +108,16 @@ def task_gate_specs(task: Task) -> list[dict[str, Any]]:
     specs: list[dict[str, Any]] = []
     for raw in task.payload.get("gates", []) or []:
         if isinstance(raw, dict) and raw.get("kind"):
-            specs.append(dict(raw))
+            spec = dict(raw)
+            if spec.get("kind") == "review":
+                # Naming a review gate is an explicit request unless the caller
+                # deliberately marks it optional. Do not let an unavailable
+                # judge turn that request into a silent pass.
+                spec.setdefault("required", True)
+                spec.setdefault("requested", True)
+                if spec["requested"]:
+                    spec["required"] = True
+            specs.append(spec)
 
     # An implement (full-edit) task must produce a diff to reach COMPLETE — a
     # "completed" implement run with zero changes is the A3 silent-no-op failure
@@ -144,17 +155,34 @@ def task_gate_specs(task: Task) -> list[dict[str, Any]]:
     # enabled (``review=true`` on the task, or ``$PUPPETMASTER_REVIEW_GATE``
     # globally); opt a single task out with ``review=false`` / ``allow_unreviewed``.
     review = task.payload.get("review")
+    review_requested = review is True or isinstance(review, dict)
     review_globally_on = bool(os.environ.get(_REVIEW_ENABLE_ENV))
     implement_wants_review = (
         task.payload.get("mode") == "implement"
         and review is not False
         and not task.payload.get("allow_unreviewed", False)
-        and (review or review_globally_on)
+        and (review_requested or review_globally_on)
     )
-    if (review or implement_wants_review) and not any(s["kind"] == "review" for s in specs):
-        spec: dict[str, Any] = {"kind": "review"}
+    existing_review = next((s for s in specs if s["kind"] == "review"), None)
+    if review_requested and existing_review is not None:
+        # The task-level declaration is authoritative. Merge its configuration
+        # into an explicitly listed gate, but never let that gate weaken an
+        # independently explicit request into an optional skip.
+        if isinstance(review, dict):
+            existing_review.update(review)
+        existing_review["required"] = True
+        existing_review["requested"] = True
+    elif (review_requested or implement_wants_review) and existing_review is None:
+        spec: dict[str, Any] = {
+            "kind": "review",
+            "required": review_requested,
+            "requested": review_requested,
+        }
         if isinstance(review, dict):
             spec.update(review)
+        if review_requested:
+            spec["required"] = True
+            spec["requested"] = True
         specs.append(spec)
 
     return specs
@@ -181,7 +209,7 @@ def evaluate_task_gates(
     cwd = Path(cwd or task.payload.get("cwd") or ".").resolve()
     results: list[GateResult] = []
     for spec in specs:
-        results.append(_evaluate_one(spec, task, artifacts, store, cwd))
+        results.append(_evaluate_one(spec, task, artifacts, store, cwd, worker_id))
 
     gate_artifacts = [_gate_artifact(task, worker_id, result) for result in results]
     passed = all(result.passed for result in results)
@@ -194,6 +222,7 @@ def _evaluate_one(
     artifacts: list[Artifact],
     store: "SwarmStore",
     cwd: Path,
+    worker_id: Optional[str] = None,
 ) -> GateResult:
     kind = spec.get("kind")
     name = str(spec.get("name") or kind)
@@ -209,7 +238,7 @@ def _evaluate_one(
         if kind == "write_scope":
             return _gate_write_scope(name, spec, artifacts, cwd)
         if kind == "review":
-            return _gate_review(name, spec, task, artifacts, store, cwd)
+            return _gate_review(name, spec, task, artifacts, store, cwd, worker_id)
         return GateResult(name, str(kind), False, f"unknown gate kind: {kind!r}")
     except Exception as exc:  # a gate that crashes must FAIL closed, never pass
         return GateResult(name, str(kind), False, f"gate raised: {exc}")
@@ -414,11 +443,12 @@ class ReviewVerdict:
     """Outcome of an LLM-as-judge review of a task's diff.
 
     ``available`` distinguishes "a judge ran and reached a verdict" from "no
-    judge ran" (feature off, no eligible model, judge unreachable). Only an
-    *available* failing verdict fails the gate; an unavailable judge is a no-op
-    so an unconfigured environment is never bricked. A judge that ran but whose
-    answer couldn't be parsed is ``available=True, passed=False`` — fail-closed,
-    because a quality gate that can't read its oracle must not wave work through.
+    judge ran" (feature off, no eligible model, judge unreachable). The gate
+    decides whether unavailability blocks from its explicit ``required`` bit;
+    optional policy reviews may skip, while requested reviews fail closed. A
+    judge that ran but whose answer couldn't be parsed is always
+    ``available=True, passed=False`` because an unreadable oracle must not wave
+    work through.
     """
 
     available: bool
@@ -467,10 +497,39 @@ def _implementer_capability(task: Task, spec: dict[str, Any], registry: list) ->
         return int(explicit)
     model_id = (task.payload or {}).get("router_model_id")
     if model_id:
+        from puppetmaster.scorecards import effective_capability_score
+
         for model_spec in registry:
             if model_spec.id == model_id:
-                return model_spec.capability_score + 1
+                return effective_capability_score(model_spec, task.role) + 1
     return 0
+
+
+def _independence_constraints(spec: dict[str, Any]) -> set[str]:
+    """Normalize one or many independent-review constraints."""
+    raw = spec.get("independence")
+    if isinstance(raw, str):
+        return {raw.strip().lower()} if raw.strip() else set()
+    if isinstance(raw, (list, tuple, set)):
+        return {str(value).strip().lower() for value in raw if str(value).strip()}
+    return set()
+
+
+def _model_family(model: "ModelSpec") -> Optional[str]:
+    """Return the registry-declared model family, when one is authoritative.
+
+    Family independence is a safety constraint, so it deliberately does not
+    guess from mutable model names. Registries opt in with ``family:<name>``;
+    absent or conflicting declarations mean independence cannot be proven.
+    """
+    families = {
+        str(tag).split(":", 1)[1].strip().lower()
+        for tag in (model.tags or [])
+        if str(tag).lower().startswith("family:") and str(tag).split(":", 1)[1].strip()
+    }
+    if len(families) == 1:
+        return next(iter(families))
+    return None
 
 
 def resolve_judge_model(task: Task, spec: dict[str, Any]) -> Optional["ModelSpec"]:
@@ -479,25 +538,48 @@ def resolve_judge_model(task: Task, spec: dict[str, Any]) -> Optional["ModelSpec
     available model as a peer reviewer when nothing strictly clears the floor —
     but only if it is at least as capable as the implementer, otherwise there is
     no point and we return ``None`` (review becomes a no-op)."""
-    from puppetmaster.model_registry import default_registry_path, load_registry
     from puppetmaster.platform_lock import is_adapter_enabled
+    from puppetmaster.routing_authority import load_bound_registry
+    from puppetmaster.scorecards import effective_capability_score
 
+    _registry_path, bound_registry, _registry_digest = load_bound_registry(
+        task.payload or {}
+    )
     registry = [
         s
-        for s in load_registry(default_registry_path())
-        if s.enabled and is_adapter_enabled(s.adapter)
+        for s in bound_registry
+        if s.is_routable and is_adapter_enabled(s.adapter)
     ]
     if not registry:
         return None
 
     floor = _implementer_capability(task, spec, registry)
-    eligible = [s for s in registry if s.capability_score >= floor]
-    if eligible:
-        return min(eligible, key=lambda s: (s.capability_score, s.id))
+    candidates = registry
+    if "different_model_family" in _independence_constraints(spec):
+        implementer_id = str((task.payload or {}).get("router_model_id") or "")
+        implementer = next((model for model in registry if model.id == implementer_id), None)
+        implementer_family = _model_family(implementer) if implementer is not None else None
+        if implementer_family is None:
+            return None
+        candidates = [
+            model
+            for model in registry
+            if (family := _model_family(model)) is not None
+            and family != implementer_family
+        ]
+        if not candidates:
+            return None
 
-    strongest = max(registry, key=lambda s: s.capability_score)
+    def _judge_capability(model: "ModelSpec") -> int:
+        return effective_capability_score(model, "review")
+
+    eligible = [s for s in candidates if _judge_capability(s) >= floor]
+    if eligible:
+        return min(eligible, key=lambda s: (_judge_capability(s), s.id))
+
+    strongest = max(candidates, key=_judge_capability)
     implementer_floor = floor - 1 if not spec.get("min_judge_capability") else floor
-    if strongest.capability_score >= implementer_floor:
+    if _judge_capability(strongest) >= implementer_floor:
         return strongest
     return None
 
@@ -543,7 +625,13 @@ def _verdict_from_artifacts(artifacts: list[Artifact]) -> Optional[dict[str, Any
 
 
 def default_judge_review(
-    *, prompt: str, judge: "ModelSpec", cwd: Path, timeout: int, task: Task
+    *,
+    prompt: str,
+    judge: "ModelSpec",
+    cwd: Path,
+    timeout: int,
+    task: Task,
+    judge_identity: Optional[str] = None,
 ) -> ReviewVerdict:
     """Run the judge model read-only over the diff and read back its verdict.
 
@@ -551,12 +639,17 @@ def default_judge_review(
     call (a deliberate, flagged spend). Fail-closed: any error, timeout, or
     unparseable answer from a judge that *did* run rejects the diff — a review
     oracle that can't be read is treated as a failed review, never a pass."""
+    concrete_judge_identity = judge_identity or f"review-judge-{judge.id}"
     if not os.environ.get(_REVIEW_ENABLE_ENV):
         return ReviewVerdict(
             available=False,
             passed=True,
             reasons=[f"{_REVIEW_ENABLE_ENV} not set; live review disabled"],
-            detail={"enabled": False},
+            detail={
+                "enabled": False,
+                "availability_reason": f"{_REVIEW_ENABLE_ENV} not set; live review disabled",
+                "judge_identity": concrete_judge_identity,
+            },
         )
     try:
         from dataclasses import replace as _replace
@@ -580,7 +673,7 @@ def default_judge_review(
             },
         )
         artifacts = get_adapter(judge.adapter).run(
-            judge_task, prompt, f"review-judge-{judge.id}"
+            judge_task, prompt, concrete_judge_identity
         )
     except Exception as exc:  # judge crashed → fail-closed
         return ReviewVerdict(
@@ -588,7 +681,7 @@ def default_judge_review(
             passed=False,
             severity="critical",
             reasons=[f"judge invocation failed: {exc}"],
-            detail={"error": str(exc)},
+            detail={"error": str(exc), "judge_identity": concrete_judge_identity},
         )
 
     verdict = _verdict_from_artifacts(artifacts)
@@ -598,7 +691,10 @@ def default_judge_review(
             passed=False,
             severity="critical",
             reasons=["judge produced no parseable verdict"],
-            detail={"judge_artifacts": len(artifacts)},
+            detail={
+                "judge_artifacts": len(artifacts),
+                "judge_identity": concrete_judge_identity,
+            },
         )
     reasons = verdict.get("reasons")
     return ReviewVerdict(
@@ -606,7 +702,10 @@ def default_judge_review(
         passed=bool(verdict.get("pass")),
         severity=str(verdict.get("severity", "none")),
         reasons=[str(r) for r in reasons] if isinstance(reasons, list) else [],
-        detail={"raw_verdict": verdict},
+        detail={
+            "raw_verdict": verdict,
+            "judge_identity": concrete_judge_identity,
+        },
     )
 
 
@@ -665,7 +764,14 @@ def _resolve_review_rubric(
     """Choose rubric text for the review gate (selection is best-effort)."""
     explicit = spec.get("rubric")
     if explicit:
-        return str(explicit), {"rubric_source": "spec"}
+        rubric = str(explicit)
+        revision = spec.get("evaluator_revision")
+        if revision is None:
+            revision = "sha256:" + hashlib.sha256(rubric.encode("utf-8")).hexdigest()
+        return rubric, {
+            "rubric_source": "spec",
+            "evaluator_revision": revision,
+        }
     try:
         from puppetmaster.evaluators import evaluator_epoch_for_job, epoch_evaluator_for_role
 
@@ -680,10 +786,16 @@ def _resolve_review_rubric(
                     "rubric_source": "evaluator_epoch",
                     "evaluator_slot": entry.get("slot_id"),
                     "evaluator_version": entry.get("version"),
+                    "evaluator_revision": spec.get("evaluator_revision", entry.get("version")),
                 }
     except Exception:
         pass
-    return _DEFAULT_REVIEW_RUBRIC, {"rubric_source": "default"}
+    return _DEFAULT_REVIEW_RUBRIC, {
+        "rubric_source": "default",
+        "evaluator_revision": spec.get(
+            "evaluator_revision", _DEFAULT_REVIEW_EVALUATOR_REVISION
+        ),
+    }
 
 
 def _gate_review(
@@ -693,24 +805,73 @@ def _gate_review(
     artifacts: list[Artifact],
     store: "SwarmStore",
     cwd: Path,
+    worker_id: Optional[str] = None,
 ) -> GateResult:
+    required = bool(spec.get("required", False))
+    requested = bool(spec.get("requested", required))
+    review_state = {
+        "review_required": required,
+        "review_requested": requested,
+    }
     diff = _collect_diff(artifacts, cwd)
+    artifact_fingerprint = "sha256:" + hashlib.sha256(diff.encode("utf-8")).hexdigest()
     if not diff.strip():
-        # Nothing to review. ``require_diff`` owns the "implement did nothing"
-        # failure; an empty diff here is not the review gate's problem.
-        return GateResult(name, "review", True, "no diff to review")
+        passed = not required
+        reason = (
+            "requested review unavailable: no diff to review"
+            if required
+            else "optional review skipped: no diff to review"
+        )
+        return GateResult(
+            name,
+            "review",
+            passed,
+            reason,
+            {
+                **review_state,
+                "review_status": "unavailable" if required else "skipped",
+                "reviewed_artifact_fingerprint": artifact_fingerprint,
+            },
+        )
 
     sample = spec.get("sample")
     if isinstance(sample, (int, float)) and not _review_sampled(task.id, float(sample)):
+        passed = not required
         return GateResult(
-            name, "review", True, f"not sampled (sample={sample})", {"sampled": False}
+            name,
+            "review",
+            passed,
+            (
+                f"requested review unavailable: not sampled (sample={sample})"
+                if required
+                else f"optional review skipped: not sampled (sample={sample})"
+            ),
+            {
+                **review_state,
+                "review_status": "unavailable" if required else "skipped",
+                "sampled": False,
+                "reviewed_artifact_fingerprint": artifact_fingerprint,
+            },
         )
 
     judge = resolve_judge_model(task, spec)
     if judge is None:
+        passed = not required
         return GateResult(
-            name, "review", True, "review skipped: no adequate judge model available",
-            {"judge": None},
+            name,
+            "review",
+            passed,
+            (
+                "requested review unavailable: no adequate judge model available"
+                if required
+                else "optional review skipped: no adequate judge model available"
+            ),
+            {
+                **review_state,
+                "review_status": "unavailable" if required else "skipped",
+                "judge": None,
+                "reviewed_artifact_fingerprint": artifact_fingerprint,
+            },
         )
 
     max_chars = int(spec.get("max_diff_chars", _REVIEW_MAX_DIFF_CHARS))
@@ -722,21 +883,80 @@ def _gate_review(
     rubric, rubric_meta = _resolve_review_rubric(spec, task, store)
     prompt = build_review_prompt(task, diff_for_judge, rubric)
     timeout = int(spec.get("timeout_seconds", _REVIEW_TIMEOUT))
+    configured_identity = str(
+        spec.get("judge_identity") or f"review-judge-{judge.id}"
+    )
 
-    verdict = _REVIEW_JUDGE(prompt=prompt, judge=judge, cwd=cwd, timeout=timeout, task=task)
+    verdict = _REVIEW_JUDGE(
+        prompt=prompt,
+        judge=judge,
+        cwd=cwd,
+        timeout=timeout,
+        task=task,
+        judge_identity=configured_identity,
+    )
+    judge_identity = str(
+        verdict.detail.get("judge_identity") or configured_identity
+    )
     if not verdict.available:
+        availability_reason = str(
+            verdict.detail.get("availability_reason")
+            or "; ".join(verdict.reasons)
+            or "judge unavailable"
+        )
+        passed = not required
         return GateResult(
-            name, "review", True, "review skipped: judge unavailable",
-            {"judge": judge.id, **rubric_meta, **verdict.detail},
+            name,
+            "review",
+            passed,
+            (
+                f"requested review unavailable: {availability_reason}"
+                if required
+                else f"optional review skipped: {availability_reason}"
+            ),
+            {
+                **review_state,
+                "review_status": "unavailable" if required else "skipped",
+                "judge": judge.id,
+                "judge_identity": judge_identity,
+                "judge_model": judge.id,
+                "judge_adapter": getattr(judge, "adapter", None),
+                "reviewed_artifact_fingerprint": artifact_fingerprint,
+                **rubric_meta,
+                **verdict.detail,
+            },
         )
 
     detail = {
+        **review_state,
+        "review_status": "completed",
+        "judge": judge.id,
+        "judge_identity": judge_identity,
         "judge_model": judge.id,
+        "judge_adapter": getattr(judge, "adapter", None),
+        "judge_adapter_model": getattr(judge, "adapter_model_name", None),
         "severity": verdict.severity,
         "reasons": verdict.reasons,
         "diff_chars": len(diff),
+        "reviewed_artifact_fingerprint": artifact_fingerprint,
+        "review_input_fingerprint": "sha256:"
+        + hashlib.sha256(diff_for_judge.encode("utf-8")).hexdigest(),
+        "review_input_truncated": diff_for_judge != diff,
         **rubric_meta,
     }
+    if (
+        "different_worker" in _independence_constraints(spec)
+        and worker_id is not None
+        and judge_identity == worker_id
+    ):
+        detail["review_status"] = "independence_failed"
+        return GateResult(
+            name,
+            "review",
+            False,
+            "requested independent review used the implementer worker",
+            detail,
+        )
     if verdict.passed:
         return GateResult(name, "review", True, f"{judge.id} approved the diff", detail)
     draft_recorded = False

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -3064,11 +3064,20 @@ def route_task_schema() -> JsonObject:
             },
             "policy": {
                 "type": "string",
-                "enum": ["balanced", "cheap", "quality", "escalating"],
+                "enum": [
+                    "balanced",
+                    "cheap",
+                    "absolute-cheapest",
+                    "quality",
+                    "escalating",
+                ],
                 "default": "balanced",
                 "description": (
-                    "Routing policy. balanced=cheapest sufficient; cheap=lowest cost; "
-                    "quality=highest capability; escalating=ordered chain for retries."
+                    "Routing policy. balanced=cost-aware cheapest sufficient; "
+                    "cheap=cheapest sufficient by nominal usage cost; "
+                    "absolute-cheapest=explicitly allow the lowest-cost model "
+                    "even when insufficient; quality=highest capability; "
+                    "escalating=ordered chain for retries."
                 ),
             },
             "min_capability": {
@@ -4383,7 +4392,7 @@ def _auto_route_schema_properties(*, include_required_tags: bool = True) -> Json
         },
         "routing_policy": {
             "type": "string",
-            "enum": ["balanced", "cheap", "quality", "escalating"],
+            "enum": ["balanced", "cheap", "absolute-cheapest", "quality", "escalating"],
             "description": "Routing policy for auto-routed workers.",
         },
         "max_cost_usd": {
@@ -4512,7 +4521,7 @@ def swarm_schema() -> JsonObject:
             },
             "routing_policy": {
                 "type": "string",
-                "enum": ["balanced", "cheap", "quality", "escalating"],
+                "enum": ["balanced", "cheap", "absolute-cheapest", "quality", "escalating"],
                 "description": "Routing policy for auto-routed workers. Defaults to 'balanced'.",
             },
             "max_cost_usd": {
@@ -4936,7 +4945,7 @@ def edit_schema() -> JsonObject:
             },
             "routing_policy": {
                 "type": "string",
-                "enum": ["cheap", "balanced", "quality", "escalating"],
+                "enum": ["cheap", "absolute-cheapest", "balanced", "quality", "escalating"],
                 "default": "cheap",
                 "description": "Router policy when not pinning a model (default: cheap).",
             },
@@ -5014,7 +5023,7 @@ def browser_swarm_schema() -> JsonObject:
             },
             "routing_policy": {
                 "type": "string",
-                "enum": ["cheap", "balanced", "quality", "escalating"],
+                "enum": ["cheap", "absolute-cheapest", "balanced", "quality", "escalating"],
                 "default": "balanced",
                 "description": "Router policy above the capability floor (default: balanced).",
             },

--- a/puppetmaster/model_registry.py
+++ b/puppetmaster/model_registry.py
@@ -31,6 +31,7 @@ Each entry pairs:
 """
 from __future__ import annotations
 
+from collections.abc import Mapping
 import hashlib
 import json
 import os
@@ -42,6 +43,7 @@ from puppetmaster.fs_permissions import write_private_text
 from puppetmaster.interprocess_lock import InterProcessFileLock
 
 REGISTRY_ENV = "PUPPETMASTER_MODELS_PATH"
+REGISTRY_SCHEMA_VERSION = 1
 
 # Discovery names are user-facing source names, while registry entries use
 # adapter names. Keep this mapping in the shared registry layer so diagnostics,
@@ -58,6 +60,11 @@ DISCOVERY_SOURCE_TO_ADAPTER: dict[str, str] = {
     "antigravity": "antigravity",
     "agy": "antigravity",
 }
+
+# Registry rows are executable authority, so adapter aliases and arbitrary
+# future strings are not accepted here.  New model-backed adapters must first
+# become canonical discovery/runtime adapters and then be added to this set.
+REGISTRY_ADAPTERS = frozenset(DISCOVERY_SOURCE_TO_ADAPTER.values())
 
 
 @dataclass(frozen=True)
@@ -80,6 +87,14 @@ class ModelSpec:
     tags: list[str] = field(default_factory=list)
     notes: str = ""
     enabled: bool = True
+    disabled_reason: str = ""
+    disabled_authority: str = ""
+    # Retirement is a durable, user-authorized quarantine.  It is deliberately
+    # separate from ``enabled``: a temporary disable may later be toggled,
+    # while discovery must never infer that a retired identity is available.
+    retired: bool = False
+    retirement_reason: str = ""
+    retirement_authority: str = ""
     payload_defaults: dict[str, Any] = field(default_factory=dict)
     output_token_multiplier: float = 1.0
     # Billing source for routing cost-containment. ``plan`` = covered by a
@@ -101,6 +116,40 @@ class ModelSpec:
     _VALID_BILLING = ("plan", "api", "unknown")
 
     def __post_init__(self) -> None:
+        for field_name, value in (
+            ("id", self.id),
+            ("adapter", self.adapter),
+            ("adapter_model_name", self.adapter_model_name),
+        ):
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{field_name} must be a non-empty string")
+            if value != value.strip():
+                raise ValueError(f"{field_name} must not contain surrounding whitespace")
+        if not isinstance(self.enabled, bool):
+            raise ValueError(f"enabled for {self.id} must be a boolean")
+        if not isinstance(self.retired, bool):
+            raise ValueError(f"retired for {self.id} must be a boolean")
+        for field_name, value in (
+            ("disabled_reason", self.disabled_reason),
+            ("disabled_authority", self.disabled_authority),
+            ("retirement_reason", self.retirement_reason),
+            ("retirement_authority", self.retirement_authority),
+        ):
+            if not isinstance(value, str):
+                raise ValueError(f"{field_name} for {self.id} must be a string")
+        if bool(self.disabled_reason) != bool(self.disabled_authority):
+            missing = "authority" if self.disabled_reason else "reason"
+            raise ValueError(f"disabled {missing} for {self.id} must be non-empty")
+        if self.retired:
+            if not isinstance(self.retirement_reason, str) or not self.retirement_reason.strip():
+                raise ValueError(f"retirement reason for {self.id} must be non-empty")
+            if (
+                not isinstance(self.retirement_authority, str)
+                or not self.retirement_authority.strip()
+            ):
+                raise ValueError(f"retirement authority for {self.id} must be non-empty")
+            if self.enabled:
+                raise ValueError(f"retired model {self.id} must have enabled=false")
         if not 0 <= self.capability_score <= 100:
             raise ValueError(
                 f"capability_score for {self.id} must be 0..100, got {self.capability_score}"
@@ -130,6 +179,11 @@ class ModelSpec:
             raise ValueError(
                 f"billing for {self.id} must be one of {self._VALID_BILLING}, got {self.billing!r}"
             )
+
+    @property
+    def is_routable(self) -> bool:
+        """Whether routing and direct-pin resolution may use this model."""
+        return self.enabled and not self.retired
 
     @property
     def is_plan_billed(self) -> bool:
@@ -175,11 +229,12 @@ def default_registry_path() -> Path:
 
 
 def load_registry(path: Optional[Path] = None) -> list[ModelSpec]:
-    """Read the registry from disk. Returns [] if no file exists.
+    """Read and atomically validate the user-owned registry authority.
 
-    Missing fields fall back to dataclass defaults so users can author
-    minimal entries. Unknown fields are tolerated and dropped (forward
-    compat for future Puppetmaster releases).
+    Both documented shapes are accepted: a top-level list of model objects,
+    and an object containing a ``models`` list.  Unknown model fields remain
+    forward-compatible, but malformed envelopes, rows, identities, and
+    adapters fail closed instead of returning a partial or empty registry.
     """
     resolved = path or default_registry_path()
     if not resolved.is_file():
@@ -188,11 +243,56 @@ def load_registry(path: Optional[Path] = None) -> list[ModelSpec]:
         raw = json.loads(resolved.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"models registry at {resolved} is not valid JSON: {exc}") from exc
-    entries = raw.get("models", raw if isinstance(raw, list) else [])
+    if isinstance(raw, list):
+        entries = raw
+    elif isinstance(raw, dict):
+        if "models" not in raw:
+            raise RuntimeError(
+                f"models registry at {resolved} must contain a 'models' list"
+            )
+        entries = raw["models"]
+        version = raw.get("schema_version", REGISTRY_SCHEMA_VERSION)
+        if type(version) is not int or version != REGISTRY_SCHEMA_VERSION:
+            raise RuntimeError(
+                f"models registry at {resolved} has unsupported schema_version "
+                f"{version!r}; expected {REGISTRY_SCHEMA_VERSION}"
+            )
+    else:
+        raise RuntimeError(
+            f"models registry at {resolved} must be a list or an object containing 'models'"
+        )
+    if not isinstance(entries, list):
+        raise RuntimeError(f"models registry at {resolved} field 'models' must be a list")
+
     specs: list[ModelSpec] = []
-    for entry in entries:
-        kwargs = {k: v for k, v in entry.items() if k in ModelSpec.__dataclass_fields__}
-        specs.append(ModelSpec(**kwargs))
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, Mapping):
+            raise RuntimeError(
+                f"models registry at {resolved} entry {index} must be an object"
+            )
+        missing = [
+            name
+            for name in ("id", "adapter", "adapter_model_name")
+            if name not in entry
+        ]
+        if missing:
+            raise RuntimeError(
+                f"models registry at {resolved} entry {index} is missing required "
+                f"field(s): {', '.join(missing)}"
+            )
+        kwargs = {
+            k: v for k, v in entry.items() if k in ModelSpec.__dataclass_fields__
+        }
+        try:
+            specs.append(ModelSpec(**kwargs))
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"models registry at {resolved} entry {index} is invalid: {exc}"
+            ) from exc
+    try:
+        validate_registry(specs)
+    except ValueError as exc:
+        raise RuntimeError(f"models registry at {resolved} is invalid: {exc}") from exc
     return specs
 
 
@@ -201,8 +301,11 @@ def save_registry(
 ) -> Path:
     """Persist the registry. Creates parent dirs. Returns the written path."""
     resolved = path or default_registry_path()
+    materialized = list(specs)
+    validate_registry(materialized)
     payload: dict[str, Any] = {
-        "models": [_spec_to_jsonable(spec) for spec in specs],
+        "schema_version": REGISTRY_SCHEMA_VERSION,
+        "models": [_spec_to_jsonable(spec) for spec in materialized],
     }
     # A registry is user-global. Serialize writers even when callers provide
     # an explicit path, and publish the complete JSON document atomically.
@@ -218,6 +321,11 @@ def _spec_to_jsonable(spec: ModelSpec) -> dict[str, Any]:
     # Drop fields equal to their default to keep the file readable.
     for k, default_value in [
         ("enabled", True),
+        ("disabled_reason", ""),
+        ("disabled_authority", ""),
+        ("retired", False),
+        ("retirement_reason", ""),
+        ("retirement_authority", ""),
         ("notes", ""),
         ("tags", []),
         ("context_window", 0),
@@ -230,6 +338,74 @@ def _spec_to_jsonable(spec: ModelSpec) -> dict[str, Any]:
         if data.get(k) == default_value:
             data.pop(k)
     return data
+
+
+def _execution_identity(spec: ModelSpec) -> tuple[str, str, str]:
+    """Return the adapter-scoped identity that a direct pin can execute.
+
+    Payload defaults are part of the identity because effort/provider variants
+    intentionally share a wire model name.  Two otherwise identical normalized
+    identities are ambiguous authority and therefore rejected.
+    """
+    defaults = json.dumps(
+        spec.payload_defaults or {}, sort_keys=True, separators=(",", ":")
+    )
+    return (
+        spec.adapter,
+        _normalize_model_token(spec.adapter_model_name),
+        defaults,
+    )
+
+
+def validate_registry(specs: Iterable[ModelSpec]) -> None:
+    """Validate a complete registry without accepting a partial authority."""
+    ids: set[str] = set()
+    identities: dict[tuple[str, str, str], str] = {}
+    for index, spec in enumerate(specs):
+        if not isinstance(spec, ModelSpec):
+            raise ValueError(
+                f"entry {index} must be ModelSpec, got {type(spec).__name__}"
+            )
+        if spec.adapter not in REGISTRY_ADAPTERS:
+            known = ", ".join(sorted(REGISTRY_ADAPTERS))
+            raise ValueError(
+                f"adapter for {spec.id} must be canonical and supported; "
+                f"got {spec.adapter!r} (known: {known})"
+            )
+        if spec.id in ids:
+            raise ValueError(f"duplicate model id: {spec.id}")
+        ids.add(spec.id)
+
+        identity = _execution_identity(spec)
+        prior_id = identities.get(identity)
+        if prior_id is not None:
+            raise ValueError(
+                "duplicate or ambiguous model identity for adapter "
+                f"{spec.adapter!r}: {prior_id!r} and {spec.id!r} normalize to "
+                f"{identity[1]!r}"
+            )
+        identities[identity] = spec.id
+
+
+def registry_digest(specs: Iterable[ModelSpec]) -> str:
+    """Return a deterministic SHA-256 digest of routing authority.
+
+    JSON object order is normalized, while registry row order is deliberately
+    preserved because it remains routing precedence for otherwise equal
+    candidates.  Material model fields, including capability, lifecycle state,
+    retirement provenance, and payload defaults, remain digest inputs so
+    recovery/audit can detect drift.
+    """
+    materialized = list(specs)
+    validate_registry(materialized)
+    canonical = {
+        "schema_version": REGISTRY_SCHEMA_VERSION,
+        "models": [asdict(spec) for spec in materialized],
+    }
+    encoded = json.dumps(
+        canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def starter_registry() -> list[ModelSpec]:
@@ -1164,7 +1340,7 @@ def catalog_staleness_days(
 
 
 def enabled_specs(specs: Iterable[ModelSpec]) -> list[ModelSpec]:
-    return [s for s in specs if s.enabled]
+    return [s for s in specs if s.is_routable]
 
 
 def _normalize_model_token(value: str) -> str:

--- a/puppetmaster/orchestrator.py
+++ b/puppetmaster/orchestrator.py
@@ -227,11 +227,6 @@ def _auto_route_must_resolve_model(spec: WorkerSpec) -> bool:
         return False
     if spec.adapter not in _MODEL_BACKED_ADAPTERS:
         return False
-    if payload.get("pinned_model"):
-        return False
-    model = payload.get("model")
-    if model is not None and str(model).strip():
-        return False
     return True
 
 
@@ -788,8 +783,8 @@ class Orchestrator:
     def _reroute_recoverable_failures(self, job: Job) -> int:
         """Re-queue each FAILED task with a recoverable failure onto a funded
         adapter. Returns the count re-queued (0 when nothing is re-routable)."""
-        from puppetmaster.model_registry import default_registry_path, load_registry
         from puppetmaster.platform_billing import detect_adapter_billing_cached
+        from puppetmaster.routing_authority import load_bound_registry
         from puppetmaster.router import (
             NoEligibleModelError,
             route_task,
@@ -808,11 +803,6 @@ class Orchestrator:
         failure_by_task = self._recoverable_failure_by_task(job)
         failed = [t for t in failed if t.id in failure_by_task]
         if not failed:
-            return 0
-
-        registry_path = default_registry_path()
-        registry = [s for s in load_registry(registry_path) if s.enabled]
-        if not registry:
             return 0
 
         billing_cache: dict[str, object] = {}
@@ -838,6 +828,12 @@ class Orchestrator:
             # Never silently re-route an explicit hand pin. Router-placed work
             # (auto_route + router_model_id) may still fall back to another model.
             if _payload_has_explicit_model_pin(payload):
+                continue
+            registry_path, bound_registry, registry_epoch = load_bound_registry(
+                payload
+            )
+            registry = [spec for spec in bound_registry if spec.is_routable]
+            if not registry:
                 continue
             tried_models = set(payload.get("tried_models") or [])
             current_model_id = str(payload.get("router_model_id") or "")
@@ -945,6 +941,8 @@ class Orchestrator:
                 artifact_payload["fallback_from_model"] = current_model_id
             artifact_payload["fallback_reason"] = reason
             artifact_payload["fallback_attempt"] = attempts
+            artifact_payload["registry_path"] = str(registry_path)
+            artifact_payload["registry_digest"] = registry_epoch
             self.store.save_artifact(
                 Artifact(
                     job_id=job.id,
@@ -1012,20 +1010,16 @@ class Orchestrator:
         """Re-queue each COMPLETE task whose verification confidence is below its
         configured threshold onto the cheapest strictly-stronger funded model.
         Returns the count re-queued (0 when nothing qualifies)."""
-        from puppetmaster.model_registry import default_registry_path, load_registry
         from puppetmaster.platform_billing import detect_adapter_billing
         from puppetmaster.platform_lock import is_adapter_enabled
         from puppetmaster.preflight import adapter_cli_present
+        from puppetmaster.routing_authority import load_bound_registry
+        from puppetmaster.scorecards import effective_capability_score
         from puppetmaster.router import (
             NoEligibleModelError,
             route_task,
             signals_from_worker_spec,
         )
-
-        registry = [s for s in load_registry(default_registry_path()) if s.enabled]
-        if not registry:
-            return 0
-        by_model_id = {s.id: s for s in registry}
 
         billing_cache: dict[str, object] = {}
 
@@ -1054,6 +1048,11 @@ class Orchestrator:
             # router_model_id for cost/audit).
             if _payload_has_explicit_model_pin(payload):
                 continue
+            registry_path, bound_registry, registry_epoch = load_bound_registry(
+                payload
+            )
+            registry = [spec for spec in bound_registry if spec.is_routable]
+            by_model_id = {spec.id: spec for spec in registry}
             current_model_id = payload.get("router_model_id")
             current_spec = by_model_id.get(current_model_id) if current_model_id else None
             if current_spec is None:
@@ -1078,11 +1077,12 @@ class Orchestrator:
             if not candidates:
                 continue
 
-            # Demand strictly more capability than the current model by lifting
-            # the floor one point above its score, then route normally.
+            # Demand strictly more role-effective capability than the current
+            # model; global manual scores do not override qualified role cards.
+            current_capability = effective_capability_score(current_spec, task.role)
             signals = replace(
                 signals_from_worker_spec(task),
-                explicit_min_capability=current_spec.capability_score + 1,
+                explicit_min_capability=current_capability + 1,
             )
             policy = payload.get("router_policy") or "balanced"
             try:
@@ -1093,7 +1093,8 @@ class Orchestrator:
             # meets the floor — guard so we only act on a genuine upgrade.
             if (
                 decision.model.id == current_model_id
-                or decision.model.capability_score <= current_spec.capability_score
+                or effective_capability_score(decision.model, task.role)
+                <= current_capability
             ):
                 continue
 
@@ -1126,6 +1127,8 @@ class Orchestrator:
             artifact_payload["escalated_from_confidence"] = round(confidence, 3)
             artifact_payload["confidence_threshold"] = threshold
             artifact_payload["escalation_attempt"] = attempts
+            artifact_payload["registry_path"] = str(registry_path)
+            artifact_payload["registry_digest"] = registry_epoch
             self.store.save_artifact(
                 Artifact(
                     job_id=job.id,
@@ -1235,20 +1238,16 @@ class Orchestrator:
     def _reroute_failed_review(self, job: Job) -> int:
         """Re-queue each review-rejected task onto the cheapest strictly-stronger
         funded model. Returns the count re-queued (0 when nothing qualifies)."""
-        from puppetmaster.model_registry import default_registry_path, load_registry
         from puppetmaster.platform_billing import detect_adapter_billing
         from puppetmaster.platform_lock import is_adapter_enabled
         from puppetmaster.preflight import adapter_cli_present
+        from puppetmaster.routing_authority import load_bound_registry
+        from puppetmaster.scorecards import effective_capability_score
         from puppetmaster.router import (
             NoEligibleModelError,
             route_task,
             signals_from_worker_spec,
         )
-
-        registry = [s for s in load_registry(default_registry_path()) if s.enabled]
-        if not registry:
-            return 0
-        by_model_id = {s.id: s for s in registry}
 
         artifacts = self.store.list_artifacts(job.id)
         failed_review = self._failed_review_task_ids(artifacts)
@@ -1276,6 +1275,11 @@ class Orchestrator:
             # model (the user chose it deliberately).
             if _payload_has_explicit_model_pin(payload):
                 continue
+            registry_path, bound_registry, registry_epoch = load_bound_registry(
+                payload
+            )
+            registry = [spec for spec in bound_registry if spec.is_routable]
+            by_model_id = {spec.id: spec for spec in registry}
             current_model_id = payload.get("router_model_id")
             current_spec = by_model_id.get(current_model_id) if current_model_id else None
             if current_spec is None:
@@ -1297,9 +1301,10 @@ class Orchestrator:
             if not candidates:
                 continue
 
+            current_capability = effective_capability_score(current_spec, task.role)
             signals = replace(
                 signals_from_worker_spec(task),
-                explicit_min_capability=current_spec.capability_score + 1,
+                explicit_min_capability=current_capability + 1,
             )
             policy = payload.get("router_policy") or "balanced"
             try:
@@ -1308,7 +1313,8 @@ class Orchestrator:
                 continue
             if (
                 decision.model.id == current_model_id
-                or decision.model.capability_score <= current_spec.capability_score
+                or effective_capability_score(decision.model, task.role)
+                <= current_capability
             ):
                 continue  # no genuine upgrade available — leave it FAILED
 
@@ -1338,6 +1344,8 @@ class Orchestrator:
             artifact_payload["role"] = task.role
             artifact_payload["review_escalated_from_model"] = current_model_id
             artifact_payload["review_escalation_attempt"] = attempts
+            artifact_payload["registry_path"] = str(registry_path)
+            artifact_payload["registry_digest"] = registry_epoch
             self.store.save_artifact(
                 Artifact(
                     job_id=job.id,
@@ -1422,19 +1430,23 @@ class Orchestrator:
         Keeping the first artifact seen meant a stale failure reason could win
         after a retry produced a newer one; compare created_at so the most
         recent recoverable failure per task is the one reported."""
-        out: dict[str, str] = {}
-        latest_at: dict[str, str] = {}
+        latest: dict[str, tuple[str, int, object]] = {}
         if artifacts is None:
             artifacts = self.store.list_artifacts(job.id)
-        for artifact in artifacts:
+        for index, artifact in enumerate(artifacts):
             failure = (artifact.payload or {}).get("failure")
-            if failure not in RECOVERABLE_FAILURES:
+            if not failure:
                 continue
             task_id = artifact.task_id
-            if task_id not in latest_at or artifact.created_at > latest_at[task_id]:
-                latest_at[task_id] = artifact.created_at
-                out[task_id] = str(failure)
-        return out
+            candidate = (artifact.created_at, index, failure)
+            previous = latest.get(task_id)
+            if previous is None or candidate[:2] > previous[:2]:
+                latest[task_id] = candidate
+        return {
+            task_id: str(failure)
+            for task_id, (_created_at, _index, failure) in latest.items()
+            if failure in RECOVERABLE_FAILURES
+        }
 
     def _has_hard_failure(
         self,
@@ -1530,6 +1542,7 @@ class Orchestrator:
 
     def _create_tasks(self, job: Job, specs: list[WorkerSpec]) -> list[Task]:
         specs, routing_decisions = self._apply_auto_routing(job, specs)
+        specs = self._bind_explicit_model_pins(specs)
         self._enforce_platform_lock(job, specs)
         tasks_by_role: dict[str, Task] = {}
         for spec in specs:
@@ -1591,6 +1604,32 @@ class Orchestrator:
         self._emit_routing_artifacts(job, tasks_by_role, routing_decisions)
         self._emit_predicted_conflicts(job, tasks)
         return tasks
+
+    @staticmethod
+    def _bind_explicit_model_pins(specs: list[WorkerSpec]) -> list[WorkerSpec]:
+        """Resolve non-routed model pins before any task is persisted."""
+        from puppetmaster.routing_authority import resolve_and_bind_explicit_pin
+
+        bound: list[WorkerSpec] = []
+        for spec in specs:
+            payload = dict(spec.payload or {})
+            if (
+                payload.get("auto_route")
+                or not str(payload.get("model") or payload.get("pinned_model") or "").strip()
+                or spec.adapter not in _MODEL_BACKED_ADAPTERS
+            ):
+                bound.append(spec)
+                continue
+            bound.append(
+                replace(
+                    spec,
+                    payload=resolve_and_bind_explicit_pin(
+                        payload,
+                        adapter=spec.adapter,
+                    ),
+                )
+            )
+        return bound
 
     def _final_job_status(self, job: Job) -> JobStatus:
         """COMPLETE only when at least one task actually completed.
@@ -1774,21 +1813,35 @@ class Orchestrator:
         result: list[WorkerSpec] = []
         decisions: list[tuple[str, dict]] = []
         registry_cache: Optional[list] = None
+        registry_authority_cache: Optional[list] = None
         registry_path: Optional[Path] = None
         registry_reconciliation: Optional[RegistryReconciliation] = None
         empty_registry_announced = False
         for spec in specs:
-            payload = spec.payload or {}
+            payload = dict(spec.payload or {})
             if not payload.get("auto_route"):
                 result.append(spec)
                 continue
-            if registry_cache is None:
-                registry_path_override = payload.get("registry_path")
-                registry_path = (
-                    Path(str(registry_path_override)).expanduser()
-                    if registry_path_override
-                    else default_registry_path()
-                )
+            # auto_route is authoritative. Clear every stale explicit-pin and
+            # prior-route identity before classification so an old pin cannot
+            # suppress later fallback/escalation or override the fresh pick.
+            for stale_key in (
+                "model",
+                "router_model_id",
+                "pinned_model",
+                "pinned_adapter_model_name",
+            ):
+                payload.pop(stale_key, None)
+            spec = replace(spec, payload=payload)
+            registry_path_override = payload.get("registry_path")
+            requested_registry_path = (
+                Path(str(registry_path_override)).expanduser().resolve()
+                if registry_path_override
+                else default_registry_path().expanduser().resolve()
+            )
+            if registry_cache is None or registry_path != requested_registry_path:
+                registry_path = requested_registry_path
+                registry_reconciliation = None
                 registry_cache = load_registry(registry_path)
                 from puppetmaster.static_catalog import reconcile_agentic_catalog
 
@@ -1803,6 +1856,11 @@ class Orchestrator:
                         save_registry(registry_cache, registry_path)
                     except Exception:
                         pass
+                # Bind the same coherent registry epoch that supplied the
+                # route. Later billing/CLI eligibility views may filter or
+                # annotate candidates, but must not trigger a second authority
+                # read that can race with registry replacement.
+                registry_authority_cache = list(registry_cache)
                 self._emit_agentic_catalog_event(job, agentic_report)
                 if registry_cache:
                     registry_reconciliation = reconcile_registry(registry_cache)
@@ -1875,7 +1933,12 @@ class Orchestrator:
             policy = payload.get("routing_policy") or "balanced"
             signals = signals_from_worker_spec(spec)
             try:
-                decision = route_task(signals, registry_cache, policy=policy)
+                decision = route_task(
+                    signals,
+                    registry_cache,
+                    policy=policy,
+                    shadow_policy=payload.get("shadow_policy"),
+                )
             except NoEligibleModelError as exc:
                 self.store.emit(
                     job.id,
@@ -1898,7 +1961,29 @@ class Orchestrator:
                 result.append(spec)
                 continue
 
-            new_payload = merge_routing_payload(payload, decision)
+            from puppetmaster.routing_authority import bind_registry_authority
+
+            authority_registry = list(registry_authority_cache or [])
+            selected_authority = next(
+                (
+                    model
+                    for model in authority_registry
+                    if model.id == decision.model.id and model.is_routable
+                ),
+                None,
+            )
+            if selected_authority is None:
+                from puppetmaster.routing_authority import RegistryAuthorityError
+
+                raise RegistryAuthorityError(
+                    "initial route selected a model absent or unroutable in "
+                    f"the bound registry snapshot: {decision.model.id}"
+                )
+            new_payload = bind_registry_authority(
+                merge_routing_payload(payload, decision),
+                registry_path,
+                authority_registry,
+            )
             routed_spec = replace(
                 spec,
                 adapter=decision.model.adapter,
@@ -1915,6 +2000,7 @@ class Orchestrator:
                     )
             artifact_payload["role"] = spec.role
             artifact_payload["registry_path"] = str(registry_path) if registry_path else None
+            artifact_payload["registry_digest"] = new_payload["registry_digest"]
             decisions.append((spec.role, artifact_payload))
 
         return result, decisions

--- a/puppetmaster/quality.py
+++ b/puppetmaster/quality.py
@@ -90,9 +90,52 @@ def _is_max_turns_without_findings(
     return not _worker_has_substantive_output(artifacts, artifact.created_by)
 
 
+def _objective_evaluator_summary(artifacts: list[Artifact]) -> dict[str, Any]:
+    """Summarize explicit evaluator evidence without inferring semantics.
+
+    Structural artifact presence still drives the legacy ``quality`` field,
+    while this companion field makes the proof boundary machine-readable.
+    """
+    outcomes: list[bool] = []
+    revisions: set[str] = set()
+    for artifact in artifacts:
+        if artifact.type != ArtifactType.GATE:
+            continue
+        payload = _payload(artifact)
+        review_status = str(payload.get("review_status") or "").lower()
+        if review_status in {"unavailable", "skipped", "independence_failed"}:
+            continue
+        is_evaluator = bool(
+            payload.get("evaluator_revision")
+            or payload.get("evaluator_version")
+            or payload.get("reviewed_artifact_fingerprint")
+            or payload.get("objective_score") is not None
+        )
+        if not is_evaluator or "passed" not in payload:
+            continue
+        outcomes.append(bool(payload.get("passed")))
+        revision = payload.get("evaluator_revision") or payload.get("evaluator_version")
+        if revision not in (None, ""):
+            revisions.add(str(revision))
+    return {
+        "semantic_quality": (
+            "passed" if outcomes and all(outcomes)
+            else "failed" if outcomes
+            else "not_evaluated"
+        ),
+        "objective_evaluations": len(outcomes),
+        "evaluator_revisions": sorted(revisions),
+        "trust_basis": (
+            "objective_evaluator" if outcomes
+            else "structural_artifact_presence"
+        ),
+    }
+
+
 def assess_run_quality(artifacts: Iterable[Artifact]) -> dict[str, Any]:
     """Classify a finished run. See module docstring for verdict semantics."""
     artifacts = list(artifacts)
+    evaluator_summary = _objective_evaluator_summary(artifacts)
     reasons: list[str] = []
 
     blocked = [a for a in artifacts if _is_blocked(a)]
@@ -113,6 +156,7 @@ def assess_run_quality(artifacts: Iterable[Artifact]) -> dict[str, Any]:
             "reasons": reasons,
             "trustworthy": False,
             "blocking_failures": failures,
+            **evaluator_summary,
         }
 
     if not artifacts:
@@ -121,6 +165,7 @@ def assess_run_quality(artifacts: Iterable[Artifact]) -> dict[str, Any]:
             "reasons": ["no artifacts were produced"],
             "trustworthy": False,
             "blocking_failures": [],
+            **evaluator_summary,
         }
 
     substantive = [a for a in artifacts if a.type in _SUBSTANTIVE_TYPES and not _is_degraded_marker(a)]
@@ -137,6 +182,7 @@ def assess_run_quality(artifacts: Iterable[Artifact]) -> dict[str, Any]:
             "reasons": reasons,
             "trustworthy": False,
             "blocking_failures": [],
+            **evaluator_summary,
         }
 
     return {
@@ -144,4 +190,5 @@ def assess_run_quality(artifacts: Iterable[Artifact]) -> dict[str, Any]:
         "reasons": [],
         "trustworthy": True,
         "blocking_failures": [],
+        **evaluator_summary,
     }

--- a/puppetmaster/router.py
+++ b/puppetmaster/router.py
@@ -8,7 +8,8 @@ model to invoke. The router is built around three pillars:
    instruction length, and content signals. The score is recorded on
    the routing artifact so users can see *why* a task went where.
 2. **User-controlled policy.** ``balanced`` (default), ``cheap``,
-   ``quality``, and ``escalating`` are the built-in policies. Users
+   ``absolute-cheapest``, ``quality``, and ``escalating`` are the built-in
+   policies. Users
    pin per-task overrides via ``payload.min_capability``,
    ``payload.max_cost_usd``, and ``payload.required_tags``.
 3. **Auditable decisions.** Every routing decision lists the rejected
@@ -23,8 +24,12 @@ import json
 import logging
 import os
 import re
-from dataclasses import dataclass, field
-from typing import Iterable, Optional
+from copy import deepcopy
+from dataclasses import dataclass, field, replace
+from functools import lru_cache
+from math import isfinite
+from pathlib import Path
+from typing import Iterable, Mapping, Optional
 
 from puppetmaster.model_registry import ModelSpec, enabled_specs, model_id_allowed
 from puppetmaster.scorecards import (
@@ -37,6 +42,206 @@ logger = logging.getLogger(__name__)
 
 _ROUTING_OVERRIDES_CACHE: dict[str, tuple[float, dict]] = {}
 _ROUTING_OVERRIDES_PARSE_WARNED: set[str] = set()
+
+ROLE_TAXONOMY_PATH = Path(__file__).with_name("routing_roles.json")
+_ROLE_TAXONOMY_SCHEMA_VERSION = 1
+
+
+class RoleTaxonomyError(RuntimeError):
+    """Raised when the packaged routing-role authority cannot be trusted."""
+
+
+def _normalized_role_key(role: object) -> str:
+    """Return the stable comparison form used by taxonomy roles and aliases."""
+    text = str(role or "").strip().casefold()
+    return re.sub(r"[^a-z0-9]+", "-", text).strip("-")
+
+
+def _taxonomy_int(value: object, *, field_name: str, minimum: int, maximum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RoleTaxonomyError(f"{field_name} must be an integer")
+    if not minimum <= value <= maximum:
+        raise RoleTaxonomyError(
+            f"{field_name} must be between {minimum} and {maximum}"
+        )
+    return value
+
+
+@lru_cache(maxsize=8)
+def _read_role_taxonomy(path_text: str, mtime_ns: int, size: int) -> dict:
+    del mtime_ns, size  # cache-key freshness only
+    path = Path(path_text)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RoleTaxonomyError(
+            f"Routing role taxonomy is unavailable at {path}: {exc}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise RoleTaxonomyError(
+            f"Routing role taxonomy at {path} is not valid JSON: {exc}"
+        ) from exc
+
+    if not isinstance(raw, dict):
+        raise RoleTaxonomyError("Routing role taxonomy root must be an object")
+    schema_version = _taxonomy_int(
+        raw.get("schema_version"),
+        field_name="schema_version",
+        minimum=_ROLE_TAXONOMY_SCHEMA_VERSION,
+        maximum=_ROLE_TAXONOMY_SCHEMA_VERSION,
+    )
+    taxonomy_version = raw.get("taxonomy_version")
+    if not isinstance(taxonomy_version, str) or not taxonomy_version.strip():
+        raise RoleTaxonomyError("taxonomy_version must be a non-empty string")
+
+    unknown = raw.get("unknown_role")
+    if not isinstance(unknown, dict):
+        raise RoleTaxonomyError("unknown_role must be an object")
+    unknown_canonical = _normalized_role_key(unknown.get("canonical_role"))
+    if not unknown_canonical:
+        raise RoleTaxonomyError(
+            "unknown_role.canonical_role must be a non-empty role name"
+        )
+    unknown_capability = _taxonomy_int(
+        unknown.get("base_capability"),
+        field_name="unknown_role.base_capability",
+        minimum=0,
+        maximum=100,
+    )
+    if not isinstance(unknown.get("tool_loop"), bool):
+        raise RoleTaxonomyError("unknown_role.tool_loop must be a boolean")
+    unknown_output = unknown.get("output_tokens", 1500)
+    _taxonomy_int(
+        unknown_output,
+        field_name="unknown_role.output_tokens",
+        minimum=1,
+        maximum=1_000_000,
+    )
+
+    roles = raw.get("roles")
+    if not isinstance(roles, dict) or not roles:
+        raise RoleTaxonomyError("roles must be a non-empty object")
+
+    validated_roles: dict[str, dict] = {}
+    aliases: dict[str, str] = {}
+    for role_name, profile in roles.items():
+        canonical = _normalized_role_key(role_name)
+        if not canonical or canonical != role_name:
+            raise RoleTaxonomyError(
+                f"roles key {role_name!r} must already be a canonical role name"
+            )
+        if canonical == unknown_canonical:
+            raise RoleTaxonomyError(
+                f"unknown role {unknown_canonical!r} must not also appear in roles"
+            )
+        if not isinstance(profile, dict):
+            raise RoleTaxonomyError(f"roles.{canonical} must be an object")
+        capability = _taxonomy_int(
+            profile.get("base_capability"),
+            field_name=f"roles.{canonical}.base_capability",
+            minimum=0,
+            maximum=100,
+        )
+        tool_loop = profile.get("tool_loop")
+        if not isinstance(tool_loop, bool):
+            raise RoleTaxonomyError(f"roles.{canonical}.tool_loop must be a boolean")
+        output_tokens = profile.get("output_tokens", 1500)
+        _taxonomy_int(
+            output_tokens,
+            field_name=f"roles.{canonical}.output_tokens",
+            minimum=1,
+            maximum=1_000_000,
+        )
+        raw_aliases = profile.get("aliases", [])
+        if not isinstance(raw_aliases, list) or any(
+            not isinstance(alias, str) or not _normalized_role_key(alias)
+            for alias in raw_aliases
+        ):
+            raise RoleTaxonomyError(
+                f"roles.{canonical}.aliases must be a list of non-empty strings"
+            )
+        validated_roles[canonical] = {
+            "base_capability": capability,
+            "tool_loop": tool_loop,
+            "output_tokens": output_tokens,
+            "aliases": [_normalized_role_key(alias) for alias in raw_aliases],
+        }
+
+    for canonical, profile in validated_roles.items():
+        for alias in [canonical, *profile["aliases"]]:
+            if alias == unknown_canonical:
+                raise RoleTaxonomyError(
+                    f"role alias {alias!r} conflicts with the reserved "
+                    "unknown_role canonical identity"
+                )
+            existing = aliases.get(alias)
+            if existing is not None and existing != canonical:
+                raise RoleTaxonomyError(
+                    f"role alias {alias!r} is ambiguous between "
+                    f"{existing!r} and {canonical!r}"
+                )
+            aliases[alias] = canonical
+
+    return {
+        "schema_version": schema_version,
+        "taxonomy_version": taxonomy_version.strip(),
+        "unknown_role": {
+            "canonical_role": unknown_canonical,
+            "base_capability": unknown_capability,
+            "tool_loop": unknown["tool_loop"],
+            "output_tokens": unknown_output,
+        },
+        "roles": validated_roles,
+        "aliases": aliases,
+    }
+
+
+def load_role_taxonomy(path: Optional[Path] = None) -> dict:
+    """Load and validate the versioned routing-role authority.
+
+    Missing, unreadable, malformed, or unsupported authority fails closed with
+    :class:`RoleTaxonomyError`; routing never silently falls back to a hidden
+    Python table.
+    """
+    authority_path = Path(path) if path is not None else ROLE_TAXONOMY_PATH
+    try:
+        stat = authority_path.stat()
+    except OSError as exc:
+        raise RoleTaxonomyError(
+            f"Routing role taxonomy is unavailable at {authority_path}: {exc}"
+        ) from exc
+    resolved = str(authority_path.resolve())
+    try:
+        taxonomy = _read_role_taxonomy(resolved, stat.st_mtime_ns, stat.st_size)
+    except RoleTaxonomyError as exc:
+        if resolved.casefold() in str(exc).casefold():
+            raise
+        raise RoleTaxonomyError(
+            f"Routing role taxonomy at {resolved} is invalid: {exc}"
+        ) from exc
+    # The cached validated authority is private. Public callers receive a
+    # detached object so accidental mutation cannot alter later routing.
+    return deepcopy(taxonomy)
+
+
+def normalize_routing_role(role: object) -> str:
+    """Map a display/custom role alias to its canonical routing role."""
+    taxonomy = load_role_taxonomy()
+    role_key = _normalized_role_key(role)
+    if not role_key:
+        role_key = "explore"
+    return taxonomy["aliases"].get(
+        role_key, taxonomy["unknown_role"]["canonical_role"]
+    )
+
+
+def _role_profile(role: object) -> tuple[str, dict, dict]:
+    taxonomy = load_role_taxonomy()
+    role_key = _normalized_role_key(role) or "explore"
+    canonical = taxonomy["aliases"].get(role_key)
+    if canonical is None:
+        return taxonomy["unknown_role"]["canonical_role"], taxonomy["unknown_role"], taxonomy
+    return canonical, taxonomy["roles"][canonical], taxonomy
 
 
 def _load_routing_overrides() -> dict:
@@ -99,6 +304,14 @@ class TaskSignals:
     required_tags: list[str] = field(default_factory=list)
     estimated_tokens_in: Optional[int] = None
     estimated_tokens_out: Optional[int] = None
+    # Adapter-owned prompt material (system instructions, tool declarations,
+    # repository summaries, etc.) that is known before dispatch.  Keep this
+    # separate from payload character counting so callers can declare exact
+    # token overhead without manufacturing a string placeholder.
+    adapter_enrichment_tokens: int = 0
+    # When true, capability sufficiency becomes a hard routing constraint.
+    # The default preserves the historical strongest-available fallback.
+    strict_capability: bool = False
     # Cost-containment knobs (the "stay inside the plan you already pay for"
     # default). ``prefer_plan_billed`` makes a subscription-covered model win
     # over an out-of-pocket API model at equal-or-sufficient capability.
@@ -122,61 +335,9 @@ class TaskSignals:
 # ----- Classifier ----------------------------------------------------------
 
 
-# Analyze roles stay deliberately cheap. The agentic adapter now carries its
-# structured output on the provider-native tool-calling channel (submit_findings
-# / submit_report), which every registered agentic model supports -- so even a
-# cheap-tier model returns reliably-structured artifacts and no longer degrades
-# to "empty findings" on a parse miss. That makes a capability floor unnecessary
-# for reliability; when a task genuinely needs deeper reasoning, escalate with
-# payload.min_capability or routing_policy=quality rather than paying for a
-# blanket bump here.
-_ROLE_BASE_SCORE = {
-    # Cheap, deterministic checks. A 50-capability model is overkill.
-    "verify-runtime": 25,
-    "shell": 20,
-    "demo": 25,
-    # Read-only exploration. Mid-tier is fine.
-    "explore": 50,
-    "review": 55,
-    "plan": 60,
-    # Anything that writes code or proposes patches. Need real ability.
-    "implement": 75,
-    "refactor": 75,
-    "patch": 75,
-    "fix": 70,
-    "test-coverage-reviewer": 60,
-    # Hard reasoning. Reserve frontier models.
-    "architect": 85,
-    "audit": 85,
-    "security-review": 90,
-    "decision-explainer": 70,
-    "conflict-auditor": 75,
-    "pipeline-mapper": 65,
-}
-
-# Roles that run an agentic-style tool loop (search / edit / submit_*). When at
-# least one registry candidate carries the ``tools`` tag, prefer those models
-# and treat untagged (often reasoning-only) tiers as ineligible. Fail-open when
-# nothing is tagged so untagged user registries behave exactly as before.
-_TOOL_LOOP_ROLES = frozenset(
-    {
-        "explore",
-        "review",
-        "plan",
-        "implement",
-        "refactor",
-        "patch",
-        "fix",
-        "build",
-        "architect",
-        "audit",
-        "security-review",
-        "decision-explainer",
-        "conflict-auditor",
-        "pipeline-mapper",
-        "test-coverage-reviewer",
-    }
-)
+# Capability bases, aliases, and tool-loop classification are intentionally
+# absent here. ``routing_roles.json`` is the versioned packaged authority; its
+# loader validates the complete table before any routing decision.
 TOOLS_TAG = "tools"
 
 _HARD_SIGNAL_PATTERNS = [
@@ -240,16 +401,17 @@ def classify_capability_needed(task: TaskSignals) -> int:
     ``task.explicit_min_capability`` (which we honor without modification)
     or cap the classifier output with ``task.explicit_max_capability``.
     """
+    canonical_role, profile, _taxonomy = _role_profile(task.role)
     if task.explicit_min_capability is not None:
         forced = max(0, min(100, task.explicit_min_capability))
         if task.explicit_max_capability is not None:
             forced = min(forced, max(0, min(100, task.explicit_max_capability)))
         return forced
 
-    role_base_score = _ROLE_BASE_SCORE.get(task.role, 50)
+    role_base_score = profile["base_capability"]
     overrides = _load_routing_overrides().get("overrides", {})
-    if isinstance(overrides, dict) and task.role in overrides:
-        candidate = overrides[task.role]
+    if isinstance(overrides, dict) and canonical_role in overrides:
+        candidate = overrides[canonical_role]
         # Only honor a real numeric override (bools are ints in Python but are
         # never a meaningful capability score, so reject them too). A bad value
         # — e.g. {"overrides": {"audit": "high"}} — is ignored so the later
@@ -319,40 +481,136 @@ def has_detailed_vision_signal(instruction: str) -> bool:
 
 def task_needs_tool_calling(task: TaskSignals) -> bool:
     """True for roles that run an agentic-style tool loop (search/edit/submit)."""
-    role = (task.role or "explore").strip().lower()
-    return role in _TOOL_LOOP_ROLES
+    _canonical_role, profile, _taxonomy = _role_profile(task.role)
+    return profile["tool_loop"]
 
 
 # ----- Token estimation ----------------------------------------------------
 
 
-def estimate_tokens_in(task: TaskSignals) -> int:
+def _validated_explicit_token_estimate(value: object, *, field_name: str) -> int:
+    """Return an authoritative token override or fail before routing math."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field_name} must be a non-negative integer")
+    return value
+
+
+@dataclass(frozen=True)
+class TokenEstimateCalibration:
+    """Explicit, immutable estimate correction derived from measured usage."""
+
+    adapter: str
+    model_id: str
+    canonical_role: str
+    source: str
+    sample_count: int
+    multiplier: float
+
+    def to_artifact_payload(self) -> dict:
+        return {
+            "adapter": self.adapter,
+            "model_id": self.model_id,
+            "canonical_role": self.canonical_role,
+            "source": self.source,
+            "sample_count": self.sample_count,
+            "multiplier": self.multiplier,
+        }
+
+
+def calibration_from_measurements(
+    measurements: Iterable[Mapping[str, object]],
+    *,
+    adapter: str,
+    model_id: str,
+    role: str,
+    source: str,
+) -> TokenEstimateCalibration:
+    """Build a read-only calibration value from attributable measurements.
+
+    The multiplier is the aggregate measured-input / aggregate estimated-input
+    ratio.  Aggregate weighting avoids a tiny request influencing the result as
+    much as a large request.  Approximate records explicitly marked
+    ``actual_tokens_measured=False`` are excluded; invalid rows are ignored and
+    an all-invalid input fails instead of inventing a neutral multiplier.
+
+    This function only returns data.  It never writes routing overrides or
+    mutates model scores/policy, so applying measured history remains an
+    explicit choice at the call site.
+    """
+    adapter_text = str(adapter or "").strip()
+    model_text = str(model_id or "").strip()
+    source_text = str(source or "").strip()
+    if not adapter_text or not model_text or not source_text:
+        raise ValueError("calibration adapter, model_id, and source are required")
+
+    estimated_total = 0
+    actual_total = 0
+    sample_count = 0
+    for row in measurements:
+        if not isinstance(row, Mapping):
+            continue
+        if row.get("actual_tokens_measured") is False:
+            continue
+        estimated = row.get("estimated_tokens_in")
+        actual = row.get("actual_tokens_in")
+        if (
+            isinstance(estimated, bool)
+            or not isinstance(estimated, (int, float))
+            or isinstance(actual, bool)
+            or not isinstance(actual, (int, float))
+            or not isfinite(float(estimated))
+            or not isfinite(float(actual))
+            or estimated <= 0
+            or actual <= 0
+        ):
+            continue
+        estimated_total += int(estimated)
+        actual_total += int(actual)
+        sample_count += 1
+    if sample_count == 0 or estimated_total <= 0:
+        raise ValueError("calibration requires at least one measured token sample")
+
+    return TokenEstimateCalibration(
+        adapter=adapter_text,
+        model_id=model_text,
+        canonical_role=normalize_routing_role(role),
+        source=source_text,
+        sample_count=sample_count,
+        multiplier=actual_total / estimated_total,
+    )
+
+
+def estimate_tokens_in(
+    task: TaskSignals,
+    *,
+    calibration: Optional[TokenEstimateCalibration] = None,
+) -> int:
     if task.estimated_tokens_in is not None:
-        return task.estimated_tokens_in
-    # ~4 chars/token is the standard rough heuristic.
-    text_chars = len(task.instruction) + task.payload_size_chars
-    return max(500, text_chars // 4 + 500)  # +500 for system + tools overhead
+        base = _validated_explicit_token_estimate(
+            task.estimated_tokens_in,
+            field_name="estimated_tokens_in",
+        )
+    else:
+        # ~4 chars/token is the standard rough heuristic.
+        text_chars = len(task.instruction) + task.payload_size_chars
+        base = max(500, text_chars // 4 + 500)  # system + tools baseline
+    enrichment = task.adapter_enrichment_tokens
+    if isinstance(enrichment, bool) or not isinstance(enrichment, int):
+        enrichment = 0
+    estimate = max(0, int(base)) + max(0, enrichment)
+    if calibration is not None:
+        estimate = int(round(estimate * calibration.multiplier))
+    return max(0, estimate)
 
 
 def estimate_tokens_out(task: TaskSignals) -> int:
     if task.estimated_tokens_out is not None:
-        return task.estimated_tokens_out
-    # Output budgets by role. Pure heuristic, override per task if needed.
-    by_role = {
-        "verify-runtime": 300,
-        "shell": 200,
-        "demo": 500,
-        "explore": 1500,
-        "review": 1500,
-        "plan": 2000,
-        "implement": 3000,
-        "refactor": 3000,
-        "patch": 3000,
-        "architect": 5000,
-        "audit": 5000,
-        "security-review": 5000,
-    }
-    return by_role.get(task.role, 1500)
+        return _validated_explicit_token_estimate(
+            task.estimated_tokens_out,
+            field_name="estimated_tokens_out",
+        )
+    _canonical_role, profile, _taxonomy = _role_profile(task.role)
+    return profile["output_tokens"]
 
 
 # ----- Routing -------------------------------------------------------------
@@ -386,12 +644,18 @@ class RoutingDecision:
     baseline_model_id: str = ""
     allowed_model_ids: Optional[list[str]] = None
     role: str = ""
+    canonical_role: str = ""
+    taxonomy_version: str = ""
     effective_capability_score: Optional[int] = None
     score_source: str = ""
     score_provenance: dict = field(default_factory=dict)
     sample_count: Optional[int] = None
     predicted_quality: Optional[float] = None
     predicted_latency_p50_ms: Optional[float] = None
+    token_estimate_calibration: Optional[TokenEstimateCalibration] = None
+    # Optional counterfactual evidence. This is deliberately metadata on the
+    # already-computed production decision; it never supplies dispatch fields.
+    shadow_routing: Optional[dict] = None
 
     def to_artifact_payload(self) -> dict:
         payload = {
@@ -420,6 +684,10 @@ class RoutingDecision:
             payload["payload_defaults"] = self.model.payload_defaults
         if self.role:
             payload["role"] = self.role
+        if self.canonical_role:
+            payload["canonical_role"] = self.canonical_role
+        if self.taxonomy_version:
+            payload["taxonomy_version"] = self.taxonomy_version
         if self.effective_capability_score is not None:
             payload["effective_capability_score"] = self.effective_capability_score
         if self.score_source:
@@ -432,6 +700,12 @@ class RoutingDecision:
             payload["predicted_quality"] = self.predicted_quality
         if self.predicted_latency_p50_ms is not None:
             payload["predicted_latency_p50_ms"] = self.predicted_latency_p50_ms
+        if self.token_estimate_calibration is not None:
+            payload["token_estimate_calibration"] = (
+                self.token_estimate_calibration.to_artifact_payload()
+            )
+        if self.shadow_routing is not None:
+            payload["shadow_routing"] = dict(self.shadow_routing)
         return payload
 
 
@@ -439,14 +713,21 @@ class NoEligibleModelError(RuntimeError):
     """Raised when the policy + constraints exclude every registered model."""
 
 
-VALID_POLICIES = {"balanced", "cheap", "quality", "escalating"}
+VALID_POLICIES = {
+    "balanced",
+    "cheap",
+    "absolute-cheapest",
+    "quality",
+    "escalating",
+}
 
 
-def route_task(
+def _route_task_once(
     task: TaskSignals,
     registry: Iterable[ModelSpec],
     *,
     policy: Optional[str] = None,
+    calibration: Optional[TokenEstimateCalibration] = None,
 ) -> RoutingDecision:
     """Pick a model for ``task`` from ``registry`` using ``policy``.
 
@@ -454,13 +735,13 @@ def route_task(
     empty/all-disabled registry, a platform lock that excludes every model, or
     a ``max_cost_usd`` cap nothing can satisfy.
 
-    Capability is treated as a *soft* preference, not a hard gate: when no model
-    meets the needed capability score, ``balanced`` deliberately falls back to
-    the highest-capability model available (with a reason that makes the gap
-    explicit) rather than raising — so a task still runs on the best option on
-    hand instead of failing closed. Use ``payload.min_capability`` /
-    ``payload.required_tags`` if you need a hard floor.
+    Capability is a soft preference by default: when no model meets the needed
+    score, cost-aware policies deliberately fall back to the strongest model
+    available with an explicit reason. Set ``strict_capability=True`` to make
+    the score a hard gate. Required tags remain independently hard constraints.
     """
+    canonical_role = normalize_routing_role(task.role)
+
     # An explicitly-passed policy always wins. Only when the caller leaves it
     # unspecified (``policy is None``) do we consult the saved routing.json
     # preference, falling back to ``balanced`` when none is configured.
@@ -478,9 +759,26 @@ def route_task(
             "to write a starter ~/.puppetmaster/models.json, then edit it."
         )
 
-    tokens_in = estimate_tokens_in(task)
+    base_tokens_in = estimate_tokens_in(task)
     tokens_out = estimate_tokens_out(task)
     need = classify_capability_needed(task)
+
+    def _candidate_calibration(
+        spec: ModelSpec,
+    ) -> Optional[TokenEstimateCalibration]:
+        if calibration is None:
+            return None
+        if calibration.canonical_role != canonical_role:
+            return None
+        if calibration.adapter != spec.adapter or calibration.model_id != spec.id:
+            return None
+        return calibration
+
+    def _tokens_in_for(spec: ModelSpec) -> int:
+        scoped = _candidate_calibration(spec)
+        if scoped is None:
+            return base_tokens_in
+        return estimate_tokens_in(task, calibration=scoped)
 
     # Auto-add vision tags when the instruction needs vision. The user
     # can still pin explicit tags via TaskSignals.required_tags; we
@@ -604,12 +902,41 @@ def route_task(
             f"No model in registry has all required tags {sorted(effective_required_tags)}"
         )
 
+    # Context capacity is a hard execution constraint, not a ranking hint.
+    # A zero/unknown registry value stays compatible with existing catalogs;
+    # any known positive window must hold both enriched input and the reserved
+    # output budget.  Apply this before cost/capability policy ranking so an
+    # attractive but impossible model can never win.
+    after_context: list[ModelSpec] = []
+    for spec in after_tags:
+        candidate_tokens_in = _tokens_in_for(spec)
+        required_context = candidate_tokens_in + tokens_out
+        window = spec.context_window
+        if window > 0 and required_context > window:
+            rejected.append(
+                (
+                    spec,
+                    "context overflow: estimated input "
+                    f"{candidate_tokens_in} + reserved output {tokens_out} = "
+                    f"{required_context} tokens exceeds context window {window}",
+                )
+            )
+            continue
+        after_context.append(spec)
+
+    if not after_context:
+        raise NoEligibleModelError(
+            "No model in registry can fit its estimated request context "
+            f"(base input {base_tokens_in}, reserved output {tokens_out}; "
+            "see per-model context rejection reasons)."
+        )
+
     # Cost budget filter. This is a hard marginal-spend cap; plan-billed
     # models remain $0 here even though their nominal usage rate is used for
     # ranking below.
     after_cost: list[ModelSpec] = []
-    for spec in after_tags:
-        est = spec.marginal_cost_usd(tokens_in, tokens_out)
+    for spec in after_context:
+        est = spec.marginal_cost_usd(_tokens_in_for(spec), tokens_out)
         if (
             task.explicit_max_cost_usd is not None
             and est > task.explicit_max_cost_usd
@@ -682,11 +1009,16 @@ def route_task(
     # the ledger compares like-for-like later instead of recomputing against a
     # possibly-changed registry.
     def _cap(spec: ModelSpec) -> int:
-        return effective_capability_score(spec, task.role)
+        return effective_capability_score(spec, canonical_role)
 
     _baseline_model = max(after_cost, key=_cap)
-    _baseline_cost = _baseline_model.marginal_cost_usd(tokens_in, tokens_out)
-    _baseline_nominal = _baseline_model.estimate_cost_usd(tokens_in, tokens_out)
+    _baseline_tokens_in = _tokens_in_for(_baseline_model)
+    _baseline_cost = _baseline_model.marginal_cost_usd(
+        _baseline_tokens_in, tokens_out
+    )
+    _baseline_nominal = _baseline_model.estimate_cost_usd(
+        _baseline_tokens_in, tokens_out
+    )
     _baseline_id = _baseline_model.id
 
     # Tie-break helper: when ``prefer_plan_billed`` is on, a subscription-covered
@@ -697,33 +1029,97 @@ def route_task(
             return 0
         return 0 if spec.is_plan_billed else 1
 
+    def _routing_cost(spec: ModelSpec) -> float:
+        return spec.routing_cost_usd(_tokens_in_for(spec), tokens_out)
+
+    sufficient = [s for s in after_cost if _cap(s) >= need]
+    if task.strict_capability and not sufficient:
+        strongest = max(after_cost, key=_cap)
+        raise NoEligibleModelError(
+            "Strict capability requirement failed: no eligible model meets "
+            f"capability {need}; strongest available is {strongest.id} "
+            f"at {_cap(strongest)}."
+        )
+
     if policy == "cheap":
-        # Rank by nominal usage cost, not marginal bill. Cursor plan models
-        # are all $0 marginally but consume a finite shared pool at different
-        # rates, so treating them as equal would route almost everything to
-        # the strongest model and exhaust the pool faster.
+        # ``cheap`` means cheapest *sufficient*.  The old unconditional-lowest
+        # behavior remains available only through the conspicuous
+        # ``absolute-cheapest`` opt-in below.
+        if sufficient:
+            pick = min(
+                sufficient,
+                key=lambda s: (
+                    _routing_cost(s),
+                    _plan_rank(s),
+                    _cap(s),
+                ),
+            )
+            reason = (
+                "policy=cheap: cheapest sufficient model whose "
+                f"capability_score ({_cap(pick)}) >= needed ({need})"
+                + role_card_override_note(pick, canonical_role)
+            )
+            for spec in after_cost:
+                if spec.id == pick.id:
+                    continue
+                if _cap(spec) < need:
+                    rejected.append(
+                        (spec, f"capability_score {_cap(spec)} < needed {need}")
+                    )
+                else:
+                    rejected.append(
+                        (spec, f"cheapest sufficient alternative {pick.id} chosen")
+                    )
+        else:
+            # Preserve the established compatible fallback when strict mode is
+            # not requested, but make the capability gap unmistakable.
+            pick = max(after_cost, key=_cap)
+            reason = (
+                f"policy=cheap: NO model meets capability need ({need}); "
+                "falling back to highest-capability available "
+                f"({pick.id} @ {_cap(pick)})"
+                + role_card_override_note(pick, canonical_role)
+            )
+            for spec in after_cost:
+                if spec.id != pick.id:
+                    rejected.append((spec, f"lower capability_score {_cap(spec)}"))
+        return _decision(
+            pick, policy, need, _tokens_in_for(pick), tokens_out, reason, rejected,
+            _baseline_cost, _baseline_id, _baseline_nominal,
+            allowed_model_ids=_allowed_for_artifact,
+            role=task.role,
+            calibration=_candidate_calibration(pick),
+        )
+
+    if policy == "absolute-cheapest":
+        absolute_pool = sufficient if task.strict_capability else after_cost
         pick = min(
-            after_cost,
+            absolute_pool,
             key=lambda s: (
-                s.routing_cost_usd(tokens_in, tokens_out),
+                _routing_cost(s),
                 _plan_rank(s),
                 _cap(s),
             ),
         )
         reason = (
-            "policy=cheap: lowest nominal per-call usage cost"
-            + role_card_override_note(pick, task.role)
+            "policy=absolute-cheapest: explicit opt-in to absolute lowest "
+            "nominal per-call usage cost"
+            + (
+                "; strict capability floor also enforced"
+                if task.strict_capability
+                else ""
+            )
+            + role_card_override_note(pick, canonical_role)
         )
         for spec in after_cost:
             if spec.id != pick.id:
-                rejected.append(
-                    (spec, f"cheaper alternative {pick.id} chosen"),
-                )
+                rejected.append((spec, f"absolute-cheapest alternative {pick.id} chosen"))
         return _decision(
-            pick, policy, need, tokens_in, tokens_out, reason, rejected,
+            pick, policy, need, _tokens_in_for(pick), tokens_out, reason, rejected,
             _baseline_cost, _baseline_id, _baseline_nominal,
             allowed_model_ids=_allowed_for_artifact,
             role=task.role,
+            calibration=_candidate_calibration(pick),
         )
 
     if policy == "quality":
@@ -735,16 +1131,17 @@ def route_task(
         )
         reason = (
             "policy=quality: highest capability_score"
-            + role_card_override_note(pick, task.role)
+            + role_card_override_note(pick, canonical_role)
         )
         for spec in after_cost:
             if spec.id != pick.id:
                 rejected.append((spec, f"higher-capability {pick.id} chosen"))
         return _decision(
-            pick, policy, need, tokens_in, tokens_out, reason, rejected,
+            pick, policy, need, _tokens_in_for(pick), tokens_out, reason, rejected,
             _baseline_cost, _baseline_id, _baseline_nominal,
             allowed_model_ids=_allowed_for_artifact,
             role=task.role,
+            calibration=_candidate_calibration(pick),
         )
 
     if policy == "escalating":
@@ -758,7 +1155,7 @@ def route_task(
         def _escalation_key(spec: ModelSpec):
             return (
                 _plan_rank(spec),
-                spec.routing_cost_usd(tokens_in, tokens_out),
+                _routing_cost(spec),
                 _cap(spec),
             )
 
@@ -774,7 +1171,7 @@ def route_task(
         reason = (
             "policy=escalating: start with cheapest sufficient; "
             "rejected list is the ordered escalation chain"
-            + role_card_override_note(pick, task.role)
+            + role_card_override_note(pick, canonical_role)
         )
         # Order the escalation chain cheapest-first so the orchestrator retries
         # up the ladder, with any insufficient models trailing the sufficient
@@ -787,14 +1184,14 @@ def route_task(
             if spec.id != pick.id:
                 rejected.append((spec, "escalation candidate"))
         return _decision(
-            pick, policy, need, tokens_in, tokens_out, reason, rejected,
+            pick, policy, need, _tokens_in_for(pick), tokens_out, reason, rejected,
             _baseline_cost, _baseline_id, _baseline_nominal,
             allowed_model_ids=_allowed_for_artifact,
             role=task.role,
+            calibration=_candidate_calibration(pick),
         )
 
     # balanced (default)
-    sufficient = [s for s in after_cost if _cap(s) >= need]
     if sufficient:
         # Pick the cheapest sufficient model using nominal usage rates. This
         # keeps the router cost-aware even when Cursor reports every
@@ -803,7 +1200,7 @@ def route_task(
             sufficient,
             key=lambda s: (
                 _plan_rank(s),
-                s.routing_cost_usd(tokens_in, tokens_out),
+                _routing_cost(s),
                 _cap(s),
             ),
         )
@@ -813,9 +1210,9 @@ def route_task(
         reason = (
             f"policy=balanced: cheapest sufficient model whose capability_score "
             f"({_cap(pick)}) >= needed ({need}){plan_note}"
-            f"{role_card_override_note(pick, task.role)}"
+            f"{role_card_override_note(pick, canonical_role)}"
         )
-        pick_cost = pick.routing_cost_usd(tokens_in, tokens_out)
+        pick_cost = _routing_cost(pick)
         for spec in after_cost:
             if spec.id != pick.id:
                 if _cap(spec) < need:
@@ -826,7 +1223,7 @@ def route_task(
                         )
                     )
                 else:
-                    spec_cost = spec.routing_cost_usd(tokens_in, tokens_out)
+                    spec_cost = _routing_cost(spec)
                     if spec_cost > pick_cost:
                         rejected.append(
                             (
@@ -857,7 +1254,7 @@ def route_task(
             f"falling back to highest-capability available "
             f"({pick.id} @ {_cap(pick)}). Consider adding a stronger "
             f"model to your registry or lowering payload.min_capability."
-            f"{role_card_override_note(pick, task.role)}"
+            f"{role_card_override_note(pick, canonical_role)}"
         )
         for spec in after_cost:
             if spec.id != pick.id:
@@ -865,10 +1262,56 @@ def route_task(
                     (spec, f"lower capability_score {_cap(spec)}")
                 )
     return _decision(
-        pick, policy, need, tokens_in, tokens_out, reason, rejected,
+        pick, policy, need, _tokens_in_for(pick), tokens_out, reason, rejected,
         _baseline_cost, _baseline_id, _baseline_nominal,
         allowed_model_ids=_allowed_for_artifact,
         role=task.role,
+        calibration=_candidate_calibration(pick),
+    )
+
+
+def route_task(
+    task: TaskSignals,
+    registry: Iterable[ModelSpec],
+    *,
+    policy: Optional[str] = None,
+    calibration: Optional[TokenEstimateCalibration] = None,
+    shadow_policy: Optional[str] = None,
+) -> RoutingDecision:
+    """Pick the production model and optionally attach counterfactual evidence.
+
+    Shadow routing is opt-in and non-interfering: the production decision is
+    computed first and returned unchanged except for an evidence-only payload.
+    The counterfactual route cannot replace its model, adapter, or policy.
+    """
+    models = tuple(registry)
+    production = _route_task_once(
+        task,
+        models,
+        policy=policy,
+        calibration=calibration,
+    )
+    if shadow_policy is None:
+        return production
+    if shadow_policy not in VALID_POLICIES:
+        raise ValueError(
+            f"unknown shadow_policy {shadow_policy!r}; expected one of {VALID_POLICIES}"
+        )
+    counterfactual = _route_task_once(
+        task,
+        models,
+        policy=shadow_policy,
+        calibration=calibration,
+    )
+    from puppetmaster.shadow_routing import shadow_evidence
+
+    return replace(
+        production,
+        shadow_routing=shadow_evidence(
+            production_model_id=production.model.id,
+            counterfactual_model_id=counterfactual.model.id,
+            policy=shadow_policy,
+        ),
     )
 
 
@@ -924,7 +1367,6 @@ def _decision_score_fields(pick: ModelSpec, role: str) -> dict:
     elif latency is not None:
         latency = float(latency)
     return {
-        "role": role or "",
         "effective_capability_score": effective,
         "score_source": "role_card" if used_card else "manual",
         "score_provenance": provenance,
@@ -947,8 +1389,10 @@ def _decision(
     baseline_nominal_cost_usd: float = 0.0,
     allowed_model_ids: Optional[list[str]] = None,
     role: str = "",
+    calibration: Optional[TokenEstimateCalibration] = None,
 ) -> RoutingDecision:
-    score_fields = _decision_score_fields(pick, role)
+    canonical_role, _profile, taxonomy = _role_profile(role)
+    score_fields = _decision_score_fields(pick, canonical_role)
     return RoutingDecision(
         model=pick,
         policy=policy,
@@ -963,6 +1407,10 @@ def _decision(
         baseline_nominal_cost_usd=baseline_nominal_cost_usd,
         baseline_model_id=baseline_model_id,
         allowed_model_ids=allowed_model_ids,
+        role=role,
+        canonical_role=canonical_role,
+        taxonomy_version=taxonomy["taxonomy_version"],
+        token_estimate_calibration=calibration,
         **score_fields,
     )
 
@@ -1009,6 +1457,43 @@ def _coerce_str_list(value: object) -> list[str]:
     return []
 
 
+def _coerce_nonnegative_int(value: object, default: int = 0) -> int:
+    """Read an integer token/count declaration without bool coercion traps."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return default
+    return max(0, value)
+
+
+def _nested_payload_string_chars(
+    value: object, _seen: Optional[set[int]] = None
+) -> int:
+    """Count strings recursively in JSON-like payload context.
+
+    Worker payloads are normally acyclic JSON values, but direct Python callers
+    can supply self-referential containers.  Track container identities so
+    estimation remains total and never recurses forever.
+    """
+    if isinstance(value, str):
+        return len(value)
+    if _seen is None:
+        _seen = set()
+    if isinstance(value, Mapping):
+        identity = id(value)
+        if identity in _seen:
+            return 0
+        _seen.add(identity)
+        return sum(
+            _nested_payload_string_chars(item, _seen) for item in value.values()
+        )
+    if isinstance(value, (list, tuple, set, frozenset)):
+        identity = id(value)
+        if identity in _seen:
+            return 0
+        _seen.add(identity)
+        return sum(_nested_payload_string_chars(item, _seen) for item in value)
+    return 0
+
+
 def signals_from_worker_spec(spec, *, instruction_override: Optional[str] = None) -> TaskSignals:
     """Build a :class:`TaskSignals` from a ``workers.WorkerSpec``.
 
@@ -1021,13 +1506,12 @@ def signals_from_worker_spec(spec, *, instruction_override: Optional[str] = None
     * ``allowed_model_ids`` / ``allowed_models`` — list[str], explicit model
       allowlist (registry ids or adapter model names)
     * ``estimated_tokens_in`` / ``estimated_tokens_out`` — override heuristic
+    * ``adapter_enrichment_tokens`` — exact additive adapter prompt overhead
+    * ``strict_capability`` — fail closed when no eligible model clears need
     """
     payload = getattr(spec, "payload", {}) or {}
     instruction = instruction_override or getattr(spec, "instruction", "") or ""
-    payload_str = ""
-    for value in payload.values():
-        if isinstance(value, str):
-            payload_str += value
+    payload_size_chars = _nested_payload_string_chars(payload)
 
     # A per-task override wins; otherwise inherit the user's platform lock.
     # A bare ``allowed_adapters: "openai"`` must mean the single adapter, not
@@ -1056,13 +1540,17 @@ def signals_from_worker_spec(spec, *, instruction_override: Optional[str] = None
     return TaskSignals(
         instruction=instruction,
         role=getattr(spec, "role", "explore") or "explore",
-        payload_size_chars=len(payload_str),
+        payload_size_chars=payload_size_chars,
         explicit_min_capability=payload.get("min_capability"),
         explicit_max_capability=payload.get("max_capability"),
         explicit_max_cost_usd=payload.get("max_cost_usd"),
         required_tags=_coerce_str_list(payload.get("required_tags")),
         estimated_tokens_in=payload.get("estimated_tokens_in"),
         estimated_tokens_out=payload.get("estimated_tokens_out"),
+        adapter_enrichment_tokens=_coerce_nonnegative_int(
+            payload.get("adapter_enrichment_tokens")
+        ),
+        strict_capability=_coerce_bool(payload.get("strict_capability"), False),
         prefer_plan_billed=_coerce_bool(payload.get("prefer_plan_billed"), True),
         allow_api_billing=_coerce_bool(payload.get("allow_api_billing"), True),
         allowed_adapters=allowed_adapters,

--- a/puppetmaster/routing_authority.py
+++ b/puppetmaster/routing_authority.py
@@ -1,0 +1,147 @@
+"""Durable model-registry authority for routed and explicitly pinned tasks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Optional
+
+from puppetmaster.model_registry import (
+    ModelSpec,
+    default_registry_path,
+    load_registry,
+    registry_digest,
+    resolve_model_pin,
+    stamp_resolved_model_pin,
+)
+
+
+class RegistryAuthorityError(RuntimeError):
+    """Raised when persisted model authority is missing, stale, or unusable."""
+
+
+def registry_path_from_payload(
+    payload: dict,
+    *,
+    allow_default: bool,
+) -> Path:
+    raw = (payload or {}).get("registry_path")
+    if raw is None or not str(raw).strip():
+        if not allow_default:
+            raise RegistryAuthorityError(
+                "task is missing durable registry_path authority"
+            )
+        return default_registry_path().expanduser().resolve()
+    return Path(str(raw)).expanduser().resolve()
+
+
+def bind_registry_authority(
+    payload: dict,
+    registry_path: Path,
+    registry: Iterable[ModelSpec],
+) -> dict:
+    """Return a payload bound to an exact registry path and content epoch."""
+    materialized = list(registry)
+    return {
+        **(payload or {}),
+        "registry_path": str(Path(registry_path).expanduser().resolve()),
+        "registry_digest": registry_digest(materialized),
+    }
+
+
+def load_bound_registry(payload: dict) -> tuple[Path, list[ModelSpec], str]:
+    """Load task authority and fail closed when its digest has drifted."""
+    path = registry_path_from_payload(payload, allow_default=False)
+    expected = str((payload or {}).get("registry_digest") or "").strip()
+    if not expected:
+        raise RegistryAuthorityError(
+            f"task registry authority at {path} is missing registry_digest"
+        )
+    registry = load_registry(path)
+    actual = registry_digest(registry)
+    if actual != expected:
+        raise RegistryAuthorityError(
+            "registry authority drift: digest mismatch for "
+            f"{path} (expected {expected}, found {actual})"
+        )
+    return path, registry, actual
+
+
+def resolve_and_bind_explicit_pin(
+    payload: dict,
+    *,
+    adapter: str,
+    registry_path: Optional[Path] = None,
+) -> dict:
+    """Resolve one live explicit pin and bind the registry authority used."""
+    source = str(
+        (payload or {}).get("pinned_model")
+        or (payload or {}).get("model")
+        or ""
+    ).strip()
+    if not source:
+        return dict(payload or {})
+    path = registry_path or registry_path_from_payload(payload, allow_default=True)
+    registry = load_registry(path)
+    pin = resolve_model_pin(source, registry, adapter=adapter)
+    if pin is None:
+        raise RegistryAuthorityError(
+            f"model pin {source!r} for adapter {adapter!r} is not enabled and "
+            f"routable in registry {path}; it may be disabled, retired, or absent"
+        )
+    stamped = stamp_resolved_model_pin(dict(payload or {}), pin)
+    return bind_registry_authority(stamped, path, registry)
+
+
+def validate_pinned_dispatch(payload: dict, *, adapter: str) -> dict:
+    """Canonicalize/revalidate explicit pin authority before worker dispatch.
+
+    Current tasks carry ``pinned_model``. Legacy persisted tasks may carry only
+    ``model`` with ``auto_route=false``; those are still explicit pins and are
+    upgraded to the durable stamped representation before invocation.
+    """
+    pinned = str((payload or {}).get("pinned_model") or "").strip()
+    if not pinned:
+        legacy_model = str((payload or {}).get("model") or "").strip()
+        if not legacy_model or bool((payload or {}).get("auto_route")):
+            return dict(payload or {})
+        if (payload or {}).get("registry_path") and (payload or {}).get(
+            "registry_digest"
+        ):
+            path, registry, _digest = load_bound_registry(payload)
+            pin = resolve_model_pin(legacy_model, registry, adapter=adapter)
+            if pin is None:
+                raise RegistryAuthorityError(
+                    f"legacy model pin {legacy_model!r} is disabled, retired, "
+                    f"or absent in registry {path}"
+                )
+            return bind_registry_authority(
+                stamp_resolved_model_pin(dict(payload or {}), pin),
+                path,
+                registry,
+            )
+        return resolve_and_bind_explicit_pin(payload, adapter=adapter)
+
+    path, registry, _digest = load_bound_registry(payload)
+    pin = resolve_model_pin(pinned, registry, adapter=adapter)
+    if pin is None:
+        raise RegistryAuthorityError(
+            f"model pin {pinned!r} is disabled, retired, or absent in registry {path}"
+        )
+    expected_wire = str((payload or {}).get("pinned_adapter_model_name") or "")
+    executable_wire = str((payload or {}).get("model") or "")
+    routed_id = str((payload or {}).get("router_model_id") or "")
+    if (
+        not expected_wire
+        or executable_wire != expected_wire
+        or pin.adapter_model_name != expected_wire
+    ):
+        raise RegistryAuthorityError(
+            f"registry authority invalid for model pin {pinned!r}: executable "
+            "model and pinned wire identity diverge"
+        )
+    if routed_id != pinned or pin.registry_id != pinned:
+        raise RegistryAuthorityError(
+            f"registry authority invalid for model pin {pinned!r}: "
+            "router_model_id and pinned registry identity diverge"
+        )
+    return dict(payload or {})

--- a/puppetmaster/routing_evaluation.py
+++ b/puppetmaster/routing_evaluation.py
@@ -1,0 +1,641 @@
+"""Provider-neutral paired evaluation for model-routing quality.
+
+The harness in this module deliberately stops at an injected ``execute``
+callable.  Codex, Claude Code, Hermes, Antigravity, or a deterministic fixture
+can all supply that callable without this module importing a provider SDK or
+reading credentials.
+"""
+from __future__ import annotations
+
+import json
+import random
+import re
+from dataclasses import dataclass
+from hashlib import sha256
+from math import isfinite, log, sqrt
+from pathlib import Path
+from statistics import fmean, stdev
+from typing import Any, Callable, Iterable, Mapping, Optional
+
+from puppetmaster.model_registry import ModelSpec
+from puppetmaster.router import TaskSignals, route_task
+
+
+REQUIRED_CORPUS_ROLES = frozenset({"implement", "explore", "audit", "plan"})
+ARM_NAMES = ("routed_balanced", "strongest_eligible")
+SUPPORTED_EVALUATORS = frozenset({"contains", "not_contains", "exact", "regex"})
+_DEFAULT_CORPUS = (
+    Path(__file__).resolve().parent / "baselines" / "routing-quality-corpus-v1.json"
+)
+
+
+@dataclass(frozen=True)
+class EvaluationCriterion:
+    criterion_id: str
+    description: str
+    evaluator_kind: str
+    expected: str
+
+
+@dataclass(frozen=True)
+class SeededFailure:
+    failure_id: str
+    description: str
+    output_text: str
+    changed_files: tuple[str, ...]
+    catastrophic: bool
+
+
+@dataclass(frozen=True)
+class EvaluationCase:
+    case_id: str
+    role: str
+    instruction: str
+    snapshot_id: str
+    snapshot_digest: str
+    snapshot_files: Mapping[str, str]
+    min_capability: int
+    estimated_tokens_in: int
+    estimated_tokens_out: int
+    allowed_changed_files: tuple[str, ...]
+    criteria: tuple[EvaluationCriterion, ...]
+    seeded_failures: tuple[SeededFailure, ...]
+
+
+@dataclass(frozen=True)
+class EvaluationCorpus:
+    schema_version: int
+    corpus_id: str
+    corpus_version: str
+    cases: tuple[EvaluationCase, ...]
+
+
+@dataclass(frozen=True)
+class CriterionResult:
+    criterion_id: str
+    passed: bool
+
+
+@dataclass(frozen=True)
+class CaseGrade:
+    acceptance_passed: bool
+    criterion_score: float
+    criterion_results: tuple[CriterionResult, ...]
+    unintended_files: tuple[str, ...]
+    catastrophic: bool
+
+
+@dataclass(frozen=True)
+class EvaluationRequest:
+    case: EvaluationCase
+    arm: str
+    repetition: int
+    arm_order: tuple[str, str]
+    snapshot_digest: str
+    model_id: str
+    adapter: str
+    adapter_model_name: str
+    routing_policy: str
+
+
+@dataclass(frozen=True)
+class ArmObservation:
+    request: EvaluationRequest
+    grade: CaseGrade
+    correction_cycles: float
+    elapsed_seconds: float
+    retries: float
+    tokens_in: float
+    tokens_out: float
+    nominal_cost_usd: float
+    marginal_cost_usd: float
+
+
+@dataclass(frozen=True)
+class PairObservation:
+    case_id: str
+    repetition: int
+    snapshot_digest: str
+    arm_order: tuple[str, str]
+    observations: tuple[ArmObservation, ArmObservation]
+
+
+@dataclass(frozen=True)
+class EvaluationReport:
+    corpus_id: str
+    corpus_version: str
+    repetitions: int
+    seed: int
+    noninferiority_margin: float
+    pairs: tuple[PairObservation, ...]
+    arms: Mapping[str, Mapping[str, float]]
+    paired_deltas: Mapping[str, Mapping[str, Any]]
+    claim: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "corpus_id": self.corpus_id,
+            "corpus_version": self.corpus_version,
+            "repetitions": self.repetitions,
+            "seed": self.seed,
+            "noninferiority_margin": self.noninferiority_margin,
+            "pairs": [
+                {
+                    "case_id": pair.case_id,
+                    "repetition": pair.repetition,
+                    "snapshot_digest": pair.snapshot_digest,
+                    "arm_order": list(pair.arm_order),
+                    "observations": {
+                        item.request.arm: _observation_dict(item)
+                        for item in pair.observations
+                    },
+                }
+                for pair in self.pairs
+            ],
+            "arms": {name: dict(metrics) for name, metrics in self.arms.items()},
+            "paired_deltas": {
+                name: dict(interval) for name, interval in self.paired_deltas.items()
+            },
+            "claim": dict(self.claim),
+        }
+
+
+Executor = Callable[[EvaluationRequest], Mapping[str, Any]]
+
+
+def _required_text(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value.strip()
+
+
+def _nonnegative_int(value: Any, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field_name} must be a non-negative integer")
+    return value
+
+
+def _parse_criterion(raw: Any, *, case_id: str) -> EvaluationCriterion:
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"criteria for {case_id} must be objects")
+    evaluator = raw.get("evaluator")
+    if not isinstance(evaluator, Mapping):
+        raise ValueError(f"criterion evaluator for {case_id} must be an object")
+    kind = _required_text(evaluator.get("kind"), "evaluator.kind")
+    if kind not in SUPPORTED_EVALUATORS:
+        raise ValueError(
+            f"unsupported deterministic evaluator {kind!r}; "
+            f"expected one of {sorted(SUPPORTED_EVALUATORS)}"
+        )
+    expected = _required_text(evaluator.get("expected"), "evaluator.expected")
+    if kind == "regex":
+        try:
+            re.compile(expected)
+        except re.error as exc:
+            raise ValueError(f"invalid regex evaluator for {case_id}: {exc}") from exc
+    return EvaluationCriterion(
+        criterion_id=_required_text(raw.get("criterion_id"), "criterion_id"),
+        description=_required_text(raw.get("description"), "criterion.description"),
+        evaluator_kind=kind,
+        expected=expected,
+    )
+
+
+def snapshot_digest_for_files(snapshot_files: Mapping[str, str]) -> str:
+    """Return the canonical digest of a snapshot's packaged text files."""
+    if not isinstance(snapshot_files, Mapping) or not snapshot_files:
+        raise ValueError("snapshot_files must be a non-empty mapping")
+    normalized: dict[str, str] = {}
+    for path, content in snapshot_files.items():
+        if not isinstance(path, str) or not path.strip():
+            raise ValueError("snapshot file paths must be non-empty strings")
+        if not isinstance(content, str):
+            raise ValueError(f"snapshot file {path!r} content must be text")
+        normalized[path] = content
+    canonical = json.dumps(
+        normalized,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return "sha256:" + sha256(canonical).hexdigest()
+
+
+def _parse_case(raw: Any) -> EvaluationCase:
+    if not isinstance(raw, Mapping):
+        raise ValueError("corpus cases must be objects")
+    case_id = _required_text(raw.get("case_id"), "case_id")
+    criteria_raw = raw.get("criteria")
+    if not isinstance(criteria_raw, list) or not criteria_raw:
+        raise ValueError(f"case {case_id} requires at least one criterion")
+    criteria = tuple(_parse_criterion(item, case_id=case_id) for item in criteria_raw)
+    criterion_ids = [item.criterion_id for item in criteria]
+    if len(set(criterion_ids)) != len(criterion_ids):
+        raise ValueError(f"case {case_id} has duplicate criterion IDs")
+
+    failures_raw = raw.get("seeded_failures", [])
+    if not isinstance(failures_raw, list):
+        raise ValueError(f"seeded_failures for {case_id} must be a list")
+    failures: list[SeededFailure] = []
+    for item in failures_raw:
+        if not isinstance(item, Mapping):
+            continue
+        failure_files = item.get("changed_files", [])
+        if not isinstance(failure_files, list) or any(
+            not isinstance(path, str) for path in failure_files
+        ):
+            raise ValueError(f"seeded failure changed_files for {case_id} must be a string list")
+        failure_catastrophic = item.get("catastrophic", False)
+        if not isinstance(failure_catastrophic, bool):
+            raise ValueError(f"seeded failure catastrophic for {case_id} must be boolean")
+        failures.append(
+            SeededFailure(
+                failure_id=_required_text(item.get("failure_id"), "failure_id"),
+                description=_required_text(item.get("description"), "failure.description"),
+                output_text=str(item.get("output_text", "")),
+                changed_files=tuple(failure_files),
+                catastrophic=failure_catastrophic,
+            )
+        )
+    failures_tuple = tuple(failures)
+    if len(failures_tuple) != len(failures_raw):
+        raise ValueError(f"seeded_failures for {case_id} must be objects")
+
+    allowed = raw.get("allowed_changed_files", [])
+    if not isinstance(allowed, list) or any(not isinstance(item, str) for item in allowed):
+        raise ValueError(f"allowed_changed_files for {case_id} must be a string list")
+    digest = _required_text(raw.get("snapshot_digest"), "snapshot_digest")
+    if not digest.startswith("sha256:"):
+        raise ValueError(f"snapshot_digest for {case_id} must start with sha256:")
+    snapshot_files = raw.get("snapshot_files")
+    computed_digest = snapshot_digest_for_files(snapshot_files)
+    if digest != computed_digest:
+        raise ValueError(
+            f"snapshot_digest for {case_id} does not match packaged snapshot_files"
+        )
+    min_capability = _nonnegative_int(raw.get("min_capability"), "min_capability")
+    if min_capability > 100:
+        raise ValueError(f"min_capability for {case_id} must be at most 100")
+    return EvaluationCase(
+        case_id=case_id,
+        role=_required_text(raw.get("role"), "role"),
+        instruction=_required_text(raw.get("instruction"), "instruction"),
+        snapshot_id=_required_text(raw.get("snapshot_id"), "snapshot_id"),
+        snapshot_digest=digest,
+        snapshot_files=dict(snapshot_files),
+        min_capability=min_capability,
+        estimated_tokens_in=_nonnegative_int(
+            raw.get("estimated_tokens_in"), "estimated_tokens_in"
+        ),
+        estimated_tokens_out=_nonnegative_int(
+            raw.get("estimated_tokens_out"), "estimated_tokens_out"
+        ),
+        allowed_changed_files=tuple(allowed),
+        criteria=criteria,
+        seeded_failures=failures_tuple,
+    )
+
+
+def load_evaluation_corpus(path: Optional[Path] = None) -> EvaluationCorpus:
+    """Load and validate a versioned deterministic routing-quality corpus."""
+    source = Path(path) if path is not None else _DEFAULT_CORPUS
+    raw = json.loads(source.read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise ValueError("evaluation corpus must be a JSON object")
+    schema_version = _nonnegative_int(raw.get("schema_version"), "schema_version")
+    if schema_version < 1:
+        raise ValueError("schema_version must be at least 1")
+    corpus = EvaluationCorpus(
+        schema_version=schema_version,
+        corpus_id=_required_text(raw.get("corpus_id"), "corpus_id"),
+        corpus_version=_required_text(raw.get("corpus_version"), "corpus_version"),
+        cases=tuple(_parse_case(item) for item in raw.get("cases", [])),
+    )
+    if not corpus.cases:
+        raise ValueError("evaluation corpus requires cases")
+    case_ids = [item.case_id for item in corpus.cases]
+    if len(set(case_ids)) != len(case_ids):
+        raise ValueError("evaluation corpus contains duplicate case IDs")
+    missing = REQUIRED_CORPUS_ROLES - {item.role for item in corpus.cases}
+    if missing:
+        raise ValueError(
+            "evaluation corpus is missing required roles: " + ", ".join(sorted(missing))
+        )
+    if not any(item.seeded_failures for item in corpus.cases):
+        raise ValueError("evaluation corpus requires at least one seeded failure")
+    for case in corpus.cases:
+        for failure in case.seeded_failures:
+            grade = grade_case(
+                case,
+                output_text=failure.output_text,
+                changed_files=failure.changed_files,
+                catastrophic=failure.catastrophic,
+            )
+            if grade.acceptance_passed:
+                raise ValueError(
+                    f"seeded failure {failure.failure_id!r} for {case.case_id} "
+                    "must fail deterministic acceptance"
+                )
+    return corpus
+
+
+def grade_case(
+    case: EvaluationCase,
+    *,
+    output_text: str,
+    changed_files: Iterable[str],
+    catastrophic: bool,
+) -> CaseGrade:
+    """Deterministically grade observable output and file changes."""
+    text = str(output_text)
+    results: list[CriterionResult] = []
+    for criterion in case.criteria:
+        if criterion.evaluator_kind == "contains":
+            passed = criterion.expected in text
+        elif criterion.evaluator_kind == "not_contains":
+            passed = criterion.expected not in text
+        elif criterion.evaluator_kind == "exact":
+            passed = criterion.expected == text
+        else:  # regex; validated at corpus load.
+            passed = re.search(criterion.expected, text) is not None
+        results.append(CriterionResult(criterion.criterion_id, passed))
+
+    allowed = set(case.allowed_changed_files)
+    unintended = tuple(sorted({str(path) for path in changed_files if str(path) not in allowed}))
+    criterion_score = fmean(float(item.passed) for item in results)
+    accepted = criterion_score == 1.0 and not unintended and not bool(catastrophic)
+    return CaseGrade(
+        acceptance_passed=accepted,
+        criterion_score=criterion_score,
+        criterion_results=tuple(results),
+        unintended_files=unintended,
+        catastrophic=bool(catastrophic),
+    )
+
+
+def _number(receipt: Mapping[str, Any], field_name: str) -> float:
+    value = receipt.get(field_name)
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not isfinite(float(value))
+        or value < 0
+    ):
+        raise ValueError(f"executor receipt {field_name} must be non-negative numeric")
+    return float(value)
+
+
+def _observe(request: EvaluationRequest, execute: Executor) -> ArmObservation:
+    receipt = execute(request)
+    if not isinstance(receipt, Mapping):
+        raise ValueError("executor must return a mapping receipt")
+    observed_snapshot = receipt.get("snapshot_digest")
+    if observed_snapshot != request.snapshot_digest:
+        raise ValueError(
+            "executor receipt snapshot_digest must match the requested immutable snapshot"
+        )
+    changed = receipt.get("changed_files", [])
+    if not isinstance(changed, (list, tuple)) or any(
+        not isinstance(path, str) for path in changed
+    ):
+        raise ValueError("executor receipt changed_files must be a string list")
+    catastrophic = receipt.get("catastrophic", False)
+    if not isinstance(catastrophic, bool):
+        raise ValueError("executor receipt catastrophic must be boolean")
+    grade = grade_case(
+        request.case,
+        output_text=str(receipt.get("output_text", "")),
+        changed_files=changed,
+        catastrophic=catastrophic,
+    )
+    return ArmObservation(
+        request=request,
+        grade=grade,
+        correction_cycles=_number(receipt, "correction_cycles"),
+        elapsed_seconds=_number(receipt, "elapsed_seconds"),
+        retries=_number(receipt, "retries"),
+        tokens_in=_number(receipt, "tokens_in"),
+        tokens_out=_number(receipt, "tokens_out"),
+        nominal_cost_usd=_number(receipt, "nominal_cost_usd"),
+        marginal_cost_usd=_number(receipt, "marginal_cost_usd"),
+    )
+
+
+def _observation_metrics(item: ArmObservation) -> dict[str, float]:
+    return {
+        "acceptance_pass_rate": float(item.grade.acceptance_passed),
+        "criterion_score_mean": item.grade.criterion_score,
+        "unintended_file_rate": float(bool(item.grade.unintended_files)),
+        "catastrophic_failure_rate": float(item.grade.catastrophic),
+        "correction_cycles_mean": item.correction_cycles,
+        "elapsed_seconds_mean": item.elapsed_seconds,
+        "retries_mean": item.retries,
+        "tokens_in_mean": item.tokens_in,
+        "tokens_out_mean": item.tokens_out,
+        "nominal_cost_usd_mean": item.nominal_cost_usd,
+        "marginal_cost_usd_mean": item.marginal_cost_usd,
+    }
+
+
+def _observation_dict(item: ArmObservation) -> dict[str, Any]:
+    return {
+        "model_id": item.request.model_id,
+        "adapter": item.request.adapter,
+        "routing_policy": item.request.routing_policy,
+        "acceptance_passed": item.grade.acceptance_passed,
+        "criterion_score": item.grade.criterion_score,
+        "unintended_files": list(item.grade.unintended_files),
+        "catastrophic": item.grade.catastrophic,
+        **_observation_metrics(item),
+    }
+
+
+def _paired_interval(
+    values: list[float], *, bounded: Optional[tuple[float, float]] = None
+) -> dict[str, Any]:
+    estimate = fmean(values)
+    if bounded is not None:
+        lower_bound, upper_bound = bounded
+        width = upper_bound - lower_bound
+        half_width = width * sqrt(log(40.0) / (2.0 * len(values)))
+        lower = max(lower_bound, estimate - half_width)
+        upper = min(upper_bound, estimate + half_width)
+        method = "paired_hoeffding_95pct"
+    elif len(values) < 2:
+        half_width = 0.0
+        method = "paired_point_only"
+        lower = estimate
+        upper = estimate
+    else:
+        half_width = 1.96 * stdev(values) / sqrt(len(values))
+        method = "paired_normal_95pct"
+        lower = estimate - half_width
+        upper = estimate + half_width
+    return {
+        "estimate": estimate,
+        "lower": lower,
+        "upper": upper,
+        "method": method,
+        "pairs": len(values),
+    }
+
+
+def run_paired_evaluation(
+    corpus: EvaluationCorpus,
+    registry: Iterable[ModelSpec],
+    *,
+    execute: Executor,
+    repetitions: int = 3,
+    seed: int = 0,
+    noninferiority_margin: float = 0.05,
+) -> EvaluationReport:
+    """Run balanced and strongest-eligible arms from identical snapshots."""
+    if repetitions < 3:
+        raise ValueError("paired evaluation requires at least 3 repetitions")
+    if (
+        isinstance(noninferiority_margin, bool)
+        or not isinstance(noninferiority_margin, (int, float))
+        or not isfinite(float(noninferiority_margin))
+        or not 0.0 <= float(noninferiority_margin) <= 1.0
+    ):
+        raise ValueError(
+            "noninferiority_margin must be a finite non-boolean number in [0, 1]"
+        )
+    noninferiority_margin = float(noninferiority_margin)
+    models = tuple(registry)
+    rng = random.Random(seed)
+    pairs: list[PairObservation] = []
+    by_arm: dict[str, list[ArmObservation]] = {name: [] for name in ARM_NAMES}
+
+    for case in corpus.cases:
+        signals = TaskSignals(
+            instruction=case.instruction,
+            role=case.role,
+            explicit_min_capability=case.min_capability,
+            estimated_tokens_in=case.estimated_tokens_in,
+            estimated_tokens_out=case.estimated_tokens_out,
+        )
+        routed = route_task(signals, models, policy="balanced")
+        strongest = route_task(signals, models, policy="quality")
+        decisions = {
+            "routed_balanced": routed,
+            "strongest_eligible": strongest,
+        }
+        for repetition in range(repetitions):
+            order = list(ARM_NAMES)
+            rng.shuffle(order)
+            arm_order = (order[0], order[1])
+            observations: list[ArmObservation] = []
+            for arm in arm_order:
+                decision = decisions[arm]
+                request = EvaluationRequest(
+                    case=case,
+                    arm=arm,
+                    repetition=repetition,
+                    arm_order=arm_order,
+                    snapshot_digest=case.snapshot_digest,
+                    model_id=decision.model.id,
+                    adapter=decision.model.adapter,
+                    adapter_model_name=decision.model.adapter_model_name,
+                    routing_policy=decision.policy,
+                )
+                observation = _observe(request, execute)
+                observations.append(observation)
+                by_arm[arm].append(observation)
+            pairs.append(
+                PairObservation(
+                    case_id=case.case_id,
+                    repetition=repetition,
+                    snapshot_digest=case.snapshot_digest,
+                    arm_order=arm_order,
+                    observations=(observations[0], observations[1]),
+                )
+            )
+
+    arm_metrics: dict[str, dict[str, float]] = {}
+    for arm, observations in by_arm.items():
+        rows = [_observation_metrics(item) for item in observations]
+        arm_metrics[arm] = {
+            metric: fmean(row[metric] for row in rows) for metric in rows[0]
+        }
+
+    paired_values: dict[str, list[float]] = {
+        metric: [] for metric in next(iter(arm_metrics.values()))
+    }
+    for pair in pairs:
+        by_name = {item.request.arm: item for item in pair.observations}
+        routed_metrics = _observation_metrics(by_name["routed_balanced"])
+        baseline_metrics = _observation_metrics(by_name["strongest_eligible"])
+        for metric in paired_values:
+            paired_values[metric].append(routed_metrics[metric] - baseline_metrics[metric])
+    intervals = {
+        metric: _paired_interval(
+            values,
+            bounded=(-1.0, 1.0) if metric == "acceptance_pass_rate" else None,
+        )
+        for metric, values in paired_values.items()
+    }
+
+    quality = intervals["acceptance_pass_rate"]
+    if quality["lower"] >= -noninferiority_margin:
+        status = "noninferior"
+    elif quality["upper"] < -noninferiority_margin:
+        status = "inferior"
+    else:
+        status = "inconclusive"
+    claim = {
+        "status": status,
+        "basis": "paired_noninferiority",
+        "metric": "acceptance_pass_rate",
+        "margin": noninferiority_margin,
+        "lower_bound": quality["lower"],
+        "upper_bound": quality["upper"],
+    }
+    return EvaluationReport(
+        corpus_id=corpus.corpus_id,
+        corpus_version=corpus.corpus_version,
+        repetitions=repetitions,
+        seed=seed,
+        noninferiority_margin=noninferiority_margin,
+        pairs=tuple(pairs),
+        arms=arm_metrics,
+        paired_deltas=intervals,
+        claim=claim,
+    )
+
+
+def render_evaluation_report(report: EvaluationReport) -> str:
+    """Render a deterministic, claim-bounded Markdown report."""
+    payload = report.to_dict()
+    lines = [
+        "# Routing quality paired evaluation",
+        "",
+        f"Corpus: `{report.corpus_id}` version `{report.corpus_version}`",
+        f"Repetitions per case: {report.repetitions}; seed: {report.seed}",
+        "",
+        "## Paired non-inferiority result",
+        "",
+        f"Status: **{payload['claim']['status']}** at margin "
+        f"{report.noninferiority_margin:.3f}.",
+        "",
+        "This bounded run grades only the deterministic corpus criteria. "
+        "Structural artifact presence is health evidence; it does not establish "
+        "semantic quality outside those criteria.",
+        "",
+        "## Arm metrics",
+        "",
+    ]
+    for arm in ARM_NAMES:
+        lines.append(f"### {arm}")
+        lines.append("")
+        for metric, value in report.arms[arm].items():
+            lines.append(f"- `{metric}`: {value:.6f}")
+        lines.append("")
+    lines.extend(["## Paired deltas (routed minus strongest eligible)", ""])
+    for metric, interval in report.paired_deltas.items():
+        lines.append(
+            f"- `{metric}`: {interval['estimate']:.6f} "
+            f"[{interval['lower']:.6f}, {interval['upper']:.6f}] "
+            f"({interval['method']})"
+        )
+    return "\n".join(lines).rstrip() + "\n"

--- a/puppetmaster/routing_roles.json
+++ b/puppetmaster/routing_roles.json
@@ -1,0 +1,120 @@
+{
+  "schema_version": 1,
+  "taxonomy_version": "2026-08-22.1",
+  "unknown_role": {
+    "canonical_role": "unknown",
+    "base_capability": 60,
+    "tool_loop": true,
+    "output_tokens": 1500
+  },
+  "roles": {
+    "verify-runtime": {
+      "base_capability": 25,
+      "tool_loop": false,
+      "output_tokens": 300,
+      "aliases": ["verify", "runtime-check"]
+    },
+    "shell": {
+      "base_capability": 20,
+      "tool_loop": false,
+      "output_tokens": 200,
+      "aliases": ["command", "command-runner"]
+    },
+    "demo": {
+      "base_capability": 25,
+      "tool_loop": false,
+      "output_tokens": 500,
+      "aliases": ["demonstration"]
+    },
+    "explore": {
+      "base_capability": 50,
+      "tool_loop": true,
+      "output_tokens": 1500,
+      "aliases": ["analysis", "analyze", "investigate", "research"]
+    },
+    "review": {
+      "base_capability": 55,
+      "tool_loop": true,
+      "output_tokens": 1500,
+      "aliases": ["code-review", "codex-review", "test"]
+    },
+    "plan": {
+      "base_capability": 60,
+      "tool_loop": true,
+      "output_tokens": 2000,
+      "aliases": ["planning", "planner"]
+    },
+    "implement": {
+      "base_capability": 75,
+      "tool_loop": true,
+      "output_tokens": 3000,
+      "aliases": ["implementation", "hermes-implement"]
+    },
+    "refactor": {
+      "base_capability": 75,
+      "tool_loop": true,
+      "output_tokens": 3000,
+      "aliases": ["refactoring"]
+    },
+    "patch": {
+      "base_capability": 75,
+      "tool_loop": true,
+      "output_tokens": 3000,
+      "aliases": ["edit", "code-edit"]
+    },
+    "fix": {
+      "base_capability": 70,
+      "tool_loop": true,
+      "output_tokens": 1500,
+      "aliases": ["bugfix", "bug-fix"]
+    },
+    "build": {
+      "base_capability": 75,
+      "tool_loop": true,
+      "output_tokens": 1500,
+      "aliases": ["builder"]
+    },
+    "architect": {
+      "base_capability": 85,
+      "tool_loop": true,
+      "output_tokens": 5000,
+      "aliases": ["architecture", "evaluation-design"]
+    },
+    "audit": {
+      "base_capability": 85,
+      "tool_loop": true,
+      "output_tokens": 5000,
+      "aliases": ["redteam", "red-team", "routing-quality", "recovery-governance"]
+    },
+    "security-review": {
+      "base_capability": 90,
+      "tool_loop": true,
+      "output_tokens": 5000,
+      "aliases": ["security-audit", "security"]
+    },
+    "decision-explainer": {
+      "base_capability": 70,
+      "tool_loop": true,
+      "output_tokens": 1500,
+      "aliases": ["explain-decision"]
+    },
+    "conflict-auditor": {
+      "base_capability": 75,
+      "tool_loop": true,
+      "output_tokens": 1500,
+      "aliases": ["conflict-audit"]
+    },
+    "pipeline-mapper": {
+      "base_capability": 65,
+      "tool_loop": true,
+      "output_tokens": 1500,
+      "aliases": ["pipeline-map"]
+    },
+    "test-coverage-reviewer": {
+      "base_capability": 60,
+      "tool_loop": true,
+      "output_tokens": 1500,
+      "aliases": ["coverage-reviewer"]
+    }
+  }
+}

--- a/puppetmaster/scorecards.py
+++ b/puppetmaster/scorecards.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import replace
+from datetime import date
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
@@ -16,6 +17,9 @@ from typing import Any, Iterable, Optional
 _PACKAGED_BASELINE = Path("baselines") / "role-scorecards-v1.json"
 _DOCS_BASELINE = Path("docs") / "baselines" / "role-scorecards-v1.json"
 _PROVENANCE_SOURCE_COMMUNITY = "community_baseline"
+ROLE_CARD_SCALE = "puppetmaster-capability-0-100"
+MIN_QUALIFIED_SAMPLE_COUNT = 5
+MAX_CALIBRATION_AGE_DAYS = 180
 
 
 def default_community_baseline_path() -> Path:
@@ -32,13 +36,56 @@ def default_community_baseline_path() -> Path:
     return candidates[0]
 
 
+def _qualified_card(card: Any, *, today: Optional[date] = None) -> bool:
+    """Whether a role card is current, reproducible routing authority.
+
+    Incomplete cards remain useful evidence in the registry and audit output,
+    but they cannot override the user's manual ``capability_score``.  The
+    qualification fields are deliberately card-local: a model-wide provenance
+    blob cannot make one role's stale or undersampled measurement authoritative.
+    """
+    if not isinstance(card, dict):
+        return False
+    sample_count = card.get("sample_count")
+    if (
+        isinstance(sample_count, bool)
+        or not isinstance(sample_count, int)
+        or sample_count < MIN_QUALIFIED_SAMPLE_COUNT
+    ):
+        return False
+    if card.get("scale") != ROLE_CARD_SCALE:
+        return False
+    scale_version = card.get("scale_version")
+    if not isinstance(scale_version, str) or not scale_version.strip():
+        return False
+    provenance = card.get("provenance")
+    if not isinstance(provenance, dict) or not provenance:
+        return False
+    source = provenance.get("source")
+    version = provenance.get("version")
+    if not isinstance(source, str) or not source.strip():
+        return False
+    if not isinstance(version, str) or not version.strip():
+        return False
+    calibrated = card.get("last_calibrated")
+    if not isinstance(calibrated, str):
+        return False
+    try:
+        calibrated_on = date.fromisoformat(calibrated)
+    except ValueError:
+        return False
+    reference = today or date.today()
+    age_days = (reference - calibrated_on).days
+    return 0 <= age_days <= MAX_CALIBRATION_AGE_DAYS
+
+
 def card_capability(spec: Any, role: str) -> Optional[int]:
-    """Return the role card capability when it is an int in 0-100, else None."""
+    """Return a qualified role-card capability, otherwise ``None``."""
     cards = getattr(spec, "role_scorecards", None) or {}
     if not isinstance(cards, dict):
         return None
     card = cards.get(role or "")
-    if not isinstance(card, dict):
+    if not _qualified_card(card):
         return None
     cap = card.get("capability")
     if isinstance(cap, bool) or not isinstance(cap, int):

--- a/puppetmaster/shadow_routing.py
+++ b/puppetmaster/shadow_routing.py
@@ -1,0 +1,20 @@
+"""Pure construction of opt-in, non-interfering shadow-routing evidence."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def shadow_evidence(
+    *,
+    production_model_id: str,
+    counterfactual_model_id: str,
+    policy: str,
+) -> dict[str, Any]:
+    """Describe a counterfactual without authorizing it for dispatch."""
+    return {
+        "enabled": True,
+        "policy": policy,
+        "production_model_id": production_model_id,
+        "counterfactual_model_id": counterfactual_model_id,
+        "production_selection_changed": False,
+    }

--- a/puppetmaster/static_catalog.py
+++ b/puppetmaster/static_catalog.py
@@ -31,6 +31,7 @@ from puppetmaster.model_registry import (
     DISCOVERY_SOURCE_TO_ADAPTER,
     ModelSpec,
     catalog_content_hash,
+    normalize_model_token,
 )
 
 # Hand-maintained catalog of what each non-enumerable platform offers. The
@@ -760,6 +761,11 @@ def curated_to_specs(
     filtering entirely (the default — preserves every existing caller).
     """
     by_name = {s.adapter_model_name: s for s in existing if s.adapter == adapter}
+    by_normalized_name = {
+        normalize_model_token(s.adapter_model_name): s
+        for s in existing
+        if s.adapter == adapter and normalize_model_token(s.adapter_model_name)
+    }
     specs: list[ModelSpec] = []
     for item in curated_catalog(adapter):
         if allowed_providers is not None:
@@ -771,7 +777,9 @@ def curated_to_specs(
         entry_billing = str(item.get("billing") or billing).strip().lower() or billing
         plan = entry_billing == "plan"
         model = str(item["model"])
-        prior = by_name.get(model)
+        prior = by_name.get(model) or by_normalized_name.get(
+            normalize_model_token(model)
+        )
         capability = prior.capability_score if prior else int(item["capability"])
         context = (
             prior.context_window
@@ -859,20 +867,31 @@ def merge_curated_into_registry(
     discovered = curated_to_specs(
         adapter, billing, existing, allowed_providers=allowed_providers
     )
-    by_name = {s.adapter_model_name: s for s in discovered}
-    existing_names = {s.adapter_model_name for s in existing if s.adapter == adapter}
-    added = sorted(by_name.keys() - existing_names)
+    by_identity = {
+        normalize_model_token(s.adapter_model_name): s for s in discovered
+    }
+    existing_identities = {
+        normalize_model_token(s.adapter_model_name)
+        for s in existing
+        if s.adapter == adapter
+    }
+    added = sorted(
+        spec.adapter_model_name
+        for identity, spec in by_identity.items()
+        if identity not in existing_identities
+    )
 
     merged: list[ModelSpec] = []
     seen: set[str] = set()
     for spec in existing:
-        if spec.adapter == adapter and spec.adapter_model_name in by_name:
-            merged.append(by_name[spec.adapter_model_name])
-            seen.add(spec.adapter_model_name)
+        identity = normalize_model_token(spec.adapter_model_name)
+        if spec.adapter == adapter and identity in by_identity:
+            merged.append(by_identity[identity])
+            seen.add(identity)
         else:
             merged.append(spec)
-    for name, spec in by_name.items():
-        if name not in seen:
+    for identity, spec in by_identity.items():
+        if identity not in seen:
             merged.append(spec)
 
     skipped: list[dict] = []
@@ -887,7 +906,7 @@ def merge_curated_into_registry(
         "source": ADAPTER_TO_SOURCE.get(adapter, adapter),
         "discovered_count": len(discovered),
         "added": added,
-        "refreshed": sorted(seen),
+        "refreshed": sorted(by_identity[identity].adapter_model_name for identity in seen),
         "skipped": skipped,
         "billing": billing,
     }

--- a/puppetmaster/swebench_baseline.py
+++ b/puppetmaster/swebench_baseline.py
@@ -258,6 +258,7 @@ def build_swebench_bash_only_bundle(
         # local evidence for one role with community evidence for another.
         provenance = {
             "source": "community_benchmark",
+            "version": f"{_BENCHMARK_ID}:{revision}:{harness_version}",
             "benchmark": _BENCHMARK_ID,
             "leaderboard": "bash-only",
             "agent": _AGENT,
@@ -275,6 +276,8 @@ def build_swebench_bash_only_bundle(
             "quality": _quality_from_resolved(resolved, resolved_scale),
             "sample_count": sample_count,
             "last_calibrated": str(row.get("date") or published_at),
+            "scale": "puppetmaster-capability-0-100",
+            "scale_version": "1",
             "provenance": provenance,
         }
         if isinstance(row.get("instance_cost"), (int, float)):

--- a/puppetmaster/worker_runtime.py
+++ b/puppetmaster/worker_runtime.py
@@ -68,6 +68,48 @@ class WorkerRuntime:
             )
             raise SystemExit(77)
 
+        # Explicit model pins are executable authority, so revalidate their
+        # bound registry epoch after claim and immediately before constructing
+        # LocalWorker. A retirement/disable/drift between creation and dispatch
+        # must never reach an adapter.
+        from puppetmaster.routing_authority import (
+            RegistryAuthorityError,
+            validate_pinned_dispatch,
+        )
+
+        try:
+            dispatch_payload = validate_pinned_dispatch(
+                task.payload or {}, adapter=task.adapter
+            )
+            if dispatch_payload != (task.payload or {}):
+                task = replace(task, payload=dispatch_payload, updated_at=now_iso())
+                self.store.save_task(task)
+        except RegistryAuthorityError as exc:
+            failed_run = AgentRun(
+                job_id=self.job_id,
+                task_id=task.id,
+                role=task.role,
+                worker_id=self.worker_id,
+                status=TaskStatus.FAILED,
+                completed_at=now_iso(),
+            )
+            self.store.save_run(failed_run)
+            self.store.update_task_status(
+                task, TaskStatus.FAILED, worker_id=self.worker_id
+            )
+            self.store.emit(
+                self.job_id,
+                "worker.failed_task",
+                {
+                    "worker_id": self.worker_id,
+                    "task_id": task.id,
+                    "role": task.role,
+                    "failure": "registry_authority_invalid",
+                    "error": str(exc),
+                },
+            )
+            return True
+
         run = AgentRun(
             job_id=self.job_id,
             task_id=task.id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ exclude = ["node_modules*", "docs*", "examples*", "tests*"]
 # copy it into ~/.hermes/plugins (a fresh pip install otherwise has no plugin).
 puppetmaster = [
   "*.mjs",
+  "routing_roles.json",
   "skills/**/*.md",
   "skills/**/*",
   "hermes_plugin/**/*.py",

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -26,6 +26,18 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 
+
+def _persist_test_registry(root, models):
+    """Write a real registry authority and return its durable payload fields."""
+    from puppetmaster.model_registry import registry_digest, save_registry
+
+    path = Path(root) / "models.json"
+    save_registry(models, path)
+    return {
+        "registry_path": str(path),
+        "registry_digest": registry_digest(models),
+    }
+
 # Hermetic tests: the orchestrator's first-run plan-catalog auto-discovery
 # shells out to the Cursor SDK (node) when CURSOR_API_KEY is set. The suite
 # must never make that network/subprocess call implicitly — tests that
@@ -9119,7 +9131,7 @@ class ModelRouterTests(unittest.TestCase):
         decision = route_task(signal, self._three_tier_registry(), policy="balanced")
         self.assertEqual(decision.model.id, "frontier-model")
 
-    def test_cheap_policy_always_picks_lowest_cost(self) -> None:
+    def test_cheap_policy_picks_cheapest_sufficient_model(self) -> None:
         from puppetmaster.router import TaskSignals, route_task
 
         signal = TaskSignals(
@@ -9127,8 +9139,11 @@ class ModelRouterTests(unittest.TestCase):
             role="audit",
         )
         decision = route_task(signal, self._three_tier_registry(), policy="cheap")
-        # Even though the task needs high capability, cheap policy ignores fit.
-        self.assertEqual(decision.model.id, "cheap-model")
+        self.assertEqual(decision.model.id, "frontier-model")
+        absolute = route_task(
+            signal, self._three_tier_registry(), policy="absolute-cheapest"
+        )
+        self.assertEqual(absolute.model.id, "cheap-model")
 
     def test_quality_policy_always_picks_highest_capability(self) -> None:
         from puppetmaster.router import TaskSignals, route_task
@@ -16418,43 +16433,29 @@ class PreflightTests(unittest.TestCase):
             self.assertIn("live_probe:registry_pin_fallback", result.evidence)
             self.assertIn("live_probe:billing_or_quota", result.evidence)
 
-    def test_ambiguous_model_pin_fails_closed_in_preflight(self) -> None:
+    def test_ambiguous_model_identity_fails_closed_at_registry_write(self) -> None:
         from puppetmaster.model_registry import ModelSpec, save_registry
-        from puppetmaster.preflight import preflight_check
 
         with TemporaryDirectory() as tmp:
             registry_path = Path(tmp) / "models.json"
-            save_registry(
-                [
-                    ModelSpec(
-                        id="cursor/grok-a",
-                        adapter="cursor",
-                        adapter_model_name="grok-a",
-                        enabled=True,
-                    ),
-                    ModelSpec(
-                        id="cursor/grok-a-alt",
-                        adapter="cursor",
-                        adapter_model_name="grok-a",
-                        enabled=True,
-                    ),
-                ],
-                registry_path,
-            )
-            with patch.dict(
-                os.environ,
-                {"PUPPETMASTER_MODELS_PATH": str(registry_path)},
-                clear=False,
-            ):
-                result = preflight_check(
-                    "cursor",
-                    "grok-a",
-                    env={"CURSOR_API_KEY": "k"},
-                    catalog_fetcher=lambda: [{"id": "grok-a"}],
+            with self.assertRaisesRegex(ValueError, "ambiguous model identity"):
+                save_registry(
+                    [
+                        ModelSpec(
+                            id="cursor/grok-a",
+                            adapter="cursor",
+                            adapter_model_name="grok-a",
+                            enabled=True,
+                        ),
+                        ModelSpec(
+                            id="cursor/grok-a-alt",
+                            adapter="cursor",
+                            adapter_model_name="grok-a",
+                            enabled=True,
+                        ),
+                    ],
+                    registry_path,
                 )
-            self.assertFalse(result.ok)
-            self.assertIn("ambiguous model pin", result.reason)
-            self.assertIn("preflight:ambiguous_model_pin", result.evidence)
 
     def test_probe_cursor_uses_devnull_utf8_and_hidden_console(self) -> None:
         import subprocess
@@ -18739,16 +18740,22 @@ class WorkerRuntimeFailureStatusTests(unittest.TestCase):
             self.assertEqual(orch._final_job_status(job), JobStatus.COMPLETE)
 
 class AutoFallbackTests(unittest.TestCase):
-    def _setup(self, tmp):
+    def _setup(self, tmp, registry=None):
         from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
         from puppetmaster.store import SwarmStore
 
         store = SwarmStore(Path(tmp) / ".puppetmaster")
         job = store.create_job("fix the bug")
+        authority = _persist_test_registry(tmp, registry) if registry is not None else {}
         task = Task(
             job_id=job.id, role="implement", instruction="implement the fix",
             adapter="claude-code", status=TaskStatus.FAILED,
-            payload={"auto_route": True, "model": "claude-opus-4-8"},
+            payload={
+                "auto_route": True,
+                "model": "claude-opus-4-8",
+                "router_model_id": "claude-code/opus-4-8",
+                **authority,
+            },
         )
         store.save_task(task)
         store.save_artifact(Artifact(
@@ -18777,10 +18784,9 @@ class AutoFallbackTests(unittest.TestCase):
             return BillingStatus(adapter=adapter, billing="unknown", healthy=False, detail="no", evidence=[])
 
         with TemporaryDirectory() as tmp:
-            store, job, task = self._setup(tmp)
+            store, job, task = self._setup(tmp, registry)
             orch = Orchestrator(store)
-            with patch("puppetmaster.model_registry.load_registry", return_value=registry), \
-                 patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=_billing):
+            with patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=_billing):
                 rerouted = orch._reroute_recoverable_failures(job)
             self.assertEqual(rerouted, 1)
             updated = store.get_task_by_id(task.id)
@@ -18978,7 +18984,12 @@ class AutoFallbackTests(unittest.TestCase):
                 instruction="implement the fix",
                 adapter="cursor",
                 status=TaskStatus.FAILED,
-                payload={"auto_route": True, "model": "x", "router_model_id": "cursor/x"},
+                payload={
+                    "auto_route": True,
+                    "model": "x",
+                    "router_model_id": "cursor/x",
+                    **_persist_test_registry(tmp, registry),
+                },
             )
             store.save_task(task)
             store.save_artifact(
@@ -18998,8 +19009,7 @@ class AutoFallbackTests(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             store, job, task = _make(tmp)
             orch = Orchestrator(store)
-            with patch("puppetmaster.model_registry.load_registry", return_value=registry), \
-                 patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=_healthy), \
+            with patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=_healthy), \
                  patch("puppetmaster.platform_lock.is_adapter_enabled", return_value=True), \
                  patch("puppetmaster.preflight.adapter_cli_present", return_value=False):
                 rerouted = orch._reroute_recoverable_failures(job)
@@ -19010,8 +19020,7 @@ class AutoFallbackTests(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             store, job, task = _make(tmp)
             orch = Orchestrator(store)
-            with patch("puppetmaster.model_registry.load_registry", return_value=registry), \
-                 patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=_healthy), \
+            with patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=_healthy), \
                  patch("puppetmaster.platform_lock.is_adapter_enabled", return_value=True), \
                  patch("puppetmaster.preflight.adapter_cli_present", return_value=True):
                 rerouted = orch._reroute_recoverable_failures(job)
@@ -19074,6 +19083,7 @@ class AutoFallbackTests(unittest.TestCase):
                     "auto_route": True,
                     "model": "claude-fable-5",
                     "router_model_id": "claude-code/fable-5",
+                    **_persist_test_registry(tmp, registry),
                 },
             )
             store.save_task(task)
@@ -19094,8 +19104,7 @@ class AutoFallbackTests(unittest.TestCase):
                 )
             )
             orch = Orchestrator(store)
-            with patch("puppetmaster.model_registry.load_registry", return_value=registry), \
-                 patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=_billing):
+            with patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=_billing):
                 rerouted = orch._reroute_recoverable_failures(job)
             self.assertEqual(rerouted, 1)
             updated = store.get_task_by_id(task.id)
@@ -19160,6 +19169,7 @@ class AutoFallbackTests(unittest.TestCase):
                     "auto_route": True,
                     "model": "claude-fable-5",
                     "router_model_id": "claude-code/fable-5",
+                    **_persist_test_registry(tmp, registry),
                 },
             )
             store.save_task(task)
@@ -19180,8 +19190,7 @@ class AutoFallbackTests(unittest.TestCase):
                 )
             )
             orch = Orchestrator(store)
-            with patch("puppetmaster.model_registry.load_registry", return_value=registry), \
-                 patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=_billing), \
+            with patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=_billing), \
                  patch("puppetmaster.platform_billing.detect_adapter_billing_cached", side_effect=_billing), \
                  patch("puppetmaster.preflight.adapter_cli_present", return_value=True), \
                  patch("puppetmaster.platform_lock.is_adapter_enabled", return_value=True):
@@ -19209,10 +19218,9 @@ class AutoFallbackTests(unittest.TestCase):
             return BillingStatus(adapter=adapter, billing="unknown", healthy=False, detail="no", evidence=[])
 
         with TemporaryDirectory() as tmp:
-            store, job, task = self._setup(tmp)
+            store, job, task = self._setup(tmp, registry)
             orch = Orchestrator(store)
-            with patch("puppetmaster.model_registry.load_registry", return_value=registry), \
-                 patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=_billing):
+            with patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=_billing):
                 rerouted = orch._reroute_recoverable_failures(job)
             self.assertEqual(rerouted, 0)
 
@@ -20359,7 +20367,12 @@ class AutoEscalationTests(unittest.TestCase):
 
         store = SwarmStore(Path(tmp) / ".puppetmaster")
         job = store.create_job("do the work")
-        payload = {"auto_route": True, "router_model_id": model_id, "model": "x"}
+        payload = {
+            "auto_route": True,
+            "router_model_id": model_id,
+            "model": "x",
+            **_persist_test_registry(tmp, self._registry()),
+        }
         payload.update(payload_extra or {})
         task = Task(
             job_id=job.id, role="implement", instruction="implement the thing",
@@ -20392,8 +20405,7 @@ class AutoEscalationTests(unittest.TestCase):
         from puppetmaster.orchestrator import Orchestrator
 
         orch = Orchestrator(store)
-        with patch("puppetmaster.model_registry.load_registry", return_value=self._registry()), \
-             patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=self._plan_billing), \
+        with patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=self._plan_billing), \
              patch("puppetmaster.platform_lock.is_adapter_enabled", return_value=True):
             return orch._reroute_low_confidence(job)
 
@@ -20514,7 +20526,7 @@ class RoutingAuditTests(unittest.TestCase):
             escalated_from=escalated_from, fell_back=fell_back,
         )
 
-    def test_under_delivering_model_gets_lower_score_suggested(self) -> None:
+    def test_self_signal_is_diagnostic_only_not_routing_authority(self) -> None:
         from puppetmaster.audit import build_audit_report
 
         # weak/55 is the initial pick on 6 tasks; 4 escalate away to strong/80.
@@ -20530,12 +20542,10 @@ class RoutingAuditTests(unittest.TestCase):
         weak = next(m for m in report.models if m.model_id == "weak/55")
         self.assertEqual(weak.selections, 6)  # 2 retained + 4 escalated away
         self.assertAlmostEqual(weak.escalated_away_rate, 4 / 6, places=2)
-        self.assertIn("under-provisioned", weak.flags)
-        self.assertIsNotNone(weak.suggested_score)
-        self.assertLess(weak.suggested_score, 55)
-        sug = report.suggestions
-        self.assertEqual(len(sug), 1)
-        self.assertEqual(sug[0]["model_id"], "weak/55")
+        self.assertEqual(weak.flags, ["weak-self-signal"])
+        self.assertIsNone(weak.suggested_score)
+        self.assertEqual(report.suggestions, [])
+        self.assertEqual(report.role_scorecard_suggestions, [])
 
     def test_well_calibrated_model_gets_no_suggestion(self) -> None:
         from puppetmaster.audit import build_audit_report
@@ -20759,7 +20769,7 @@ class RoutingAuditTests(unittest.TestCase):
             weak = next(m for m in report.models if m.model_id == "weak/55")
             self.assertEqual(weak.escalated_away, 1)
 
-    def test_cli_apply_writes_lowered_score(self) -> None:
+    def test_cli_apply_ignores_nonobjective_self_signal(self) -> None:
         import argparse
 
         from puppetmaster.cli import _run_audit_command
@@ -20825,9 +20835,10 @@ class RoutingAuditTests(unittest.TestCase):
             )
             rc = _run_audit_command(args, store)
             self.assertEqual(rc, 0)
-            after = {s.id: s.capability_score for s in load_registry(registry_path)}
-            self.assertLess(after["weak/55"], 55)  # lowered
-            self.assertEqual(after["strong/80"], 80)  # untouched
+            after = {s.id: s for s in load_registry(registry_path)}
+            self.assertEqual(after["weak/55"].capability_score, 55)
+            self.assertEqual(after["strong/80"].capability_score, 80)
+            self.assertEqual(after["weak/55"].role_scorecards, {})
 
 class CodegraphUsageTests(unittest.TestCase):
     """The local, numbers-only codegraph usage log + its aggregation."""
@@ -23521,6 +23532,10 @@ class ReviewGateTests(unittest.TestCase):
             ModelSpec(id="cursor/gpt-5-5", adapter="cursor", adapter_model_name="gpt-5.5", capability_score=90, billing="plan", tags=["cursor"]),
         ]
 
+    def _task_with_registry(self, tmp, registry=None, **payload):
+        models = self._registry() if registry is None else registry
+        return self._task(**payload, **_persist_test_registry(tmp, models))
+
     # ----- pure helpers -----
 
     def test_build_review_prompt_contains_intent_diff_and_contract(self) -> None:
@@ -23553,21 +23568,23 @@ class ReviewGateTests(unittest.TestCase):
     def test_resolve_judge_picks_cheapest_strictly_stronger(self) -> None:
         from puppetmaster.gates import resolve_judge_model
 
-        with patch("puppetmaster.model_registry.load_registry", return_value=self._registry()), \
-             patch("puppetmaster.platform_lock.is_adapter_enabled", return_value=True):
-            judge = resolve_judge_model(
-                self._task(router_model_id="cursor/composer-2-5"), {}
-            )
+        with TemporaryDirectory() as tmp, patch(
+            "puppetmaster.platform_lock.is_adapter_enabled", return_value=True
+        ):
+            judge = resolve_judge_model(self._task_with_registry(
+                tmp, router_model_id="cursor/composer-2-5"
+            ), {})
         self.assertEqual(judge.id, "cursor/gpt-5-5")
 
     def test_resolve_judge_peer_when_implementer_top_tier(self) -> None:
         from puppetmaster.gates import resolve_judge_model
 
-        with patch("puppetmaster.model_registry.load_registry", return_value=self._registry()), \
-             patch("puppetmaster.platform_lock.is_adapter_enabled", return_value=True):
-            judge = resolve_judge_model(
-                self._task(router_model_id="cursor/gpt-5-5"), {}
-            )
+        with TemporaryDirectory() as tmp, patch(
+            "puppetmaster.platform_lock.is_adapter_enabled", return_value=True
+        ):
+            judge = resolve_judge_model(self._task_with_registry(
+                tmp, router_model_id="cursor/gpt-5-5"
+            ), {})
         # No strictly-stronger model exists; the strongest available (the peer
         # top tier) is used rather than skipping review entirely.
         self.assertEqual(judge.id, "cursor/gpt-5-5")
@@ -23575,8 +23592,9 @@ class ReviewGateTests(unittest.TestCase):
     def test_resolve_judge_none_without_registry(self) -> None:
         from puppetmaster.gates import resolve_judge_model
 
-        with patch("puppetmaster.model_registry.load_registry", return_value=[]):
-            self.assertIsNone(resolve_judge_model(self._task(), {}))
+        with TemporaryDirectory() as tmp:
+            task = self._task_with_registry(tmp, [], router_model_id="cursor/missing")
+            self.assertIsNone(resolve_judge_model(task, {}))
 
     def test_default_judge_disabled_without_env(self) -> None:
         from unittest.mock import Mock
@@ -23695,26 +23713,52 @@ class ReviewGateTests(unittest.TestCase):
             self.assertEqual(verdict["quality"], "blocked")
             self.assertFalse(verdict["trustworthy"])
 
-    def test_gate_skips_when_no_diff(self) -> None:
+    def test_requested_review_blocks_when_no_diff(self) -> None:
         from puppetmaster.gates import ReviewVerdict
 
         with TemporaryDirectory() as tmp:
-            # Judge would reject, but there's no diff so the gate never consults it.
+            # No judge can review an absent diff, so an explicitly requested
+            # review remains unsatisfied rather than becoming a false pass.
             evald = self._eval_review(
                 tmp, with_change=False,
                 judge_verdict=ReviewVerdict(available=True, passed=False),
             )
-            self.assertTrue(evald.passed)
+            self.assertFalse(evald.passed)
+            self.assertIn("requested review unavailable: no diff", evald.failed_reason)
+            review = [
+                a for a in evald.artifacts if (a.payload or {}).get("kind") == "review"
+            ]
+            self.assertEqual(len(review), 1)
+            self.assertEqual(review[0].payload["review_status"], "unavailable")
+            self.assertTrue(review[0].payload["review_requested"])
+            self.assertTrue(review[0].payload["review_required"])
+            self.assertNotIn("judge_identity", review[0].payload)
 
-    def test_gate_skips_when_judge_unavailable(self) -> None:
+    def test_requested_review_blocks_when_judge_unavailable(self) -> None:
         from puppetmaster.gates import ReviewVerdict
 
         with TemporaryDirectory() as tmp:
             evald = self._eval_review(
                 tmp, with_change=True,
-                judge_verdict=ReviewVerdict(available=False, passed=True),
+                judge_verdict=ReviewVerdict(
+                    available=False,
+                    passed=True,
+                    reasons=["judge process unavailable"],
+                ),
             )
-            self.assertTrue(evald.passed)
+            self.assertFalse(evald.passed)
+            self.assertIn("requested review unavailable", evald.failed_reason)
+            review = [
+                a for a in evald.artifacts if (a.payload or {}).get("kind") == "review"
+            ]
+            self.assertEqual(len(review), 1)
+            payload = review[0].payload
+            self.assertEqual(payload["review_status"], "unavailable")
+            self.assertEqual(payload["judge"], "cursor/gpt-5-5")
+            self.assertEqual(payload["judge_model"], "cursor/gpt-5-5")
+            self.assertTrue(payload["review_requested"])
+            self.assertTrue(payload["review_required"])
+            self.assertFalse(payload["passed"])
 
     def test_deterministic_sampling(self) -> None:
         from puppetmaster.gates import _review_sampled
@@ -24045,7 +24089,13 @@ class ReviewEscalationTests(unittest.TestCase):
 
         store = SwarmStore(Path(tmp) / ".puppetmaster")
         job = store.create_job("do the work")
-        payload = {"auto_route": True, "router_model_id": model_id, "model": "x", "mode": "implement"}
+        payload = {
+            "auto_route": True,
+            "router_model_id": model_id,
+            "model": "x",
+            "mode": "implement",
+            **_persist_test_registry(tmp, self._registry()),
+        }
         payload.update(payload_extra or {})
         task = Task(
             job_id=job.id, role="implement", instruction="implement the thing",
@@ -24063,8 +24113,7 @@ class ReviewEscalationTests(unittest.TestCase):
         from puppetmaster.orchestrator import Orchestrator
 
         orch = Orchestrator(store)
-        with patch("puppetmaster.model_registry.load_registry", return_value=self._registry()), \
-             patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=self._plan_billing), \
+        with patch("puppetmaster.platform_billing.detect_adapter_billing", side_effect=self._plan_billing), \
              patch("puppetmaster.platform_lock.is_adapter_enabled", return_value=True):
             return orch._reroute_failed_review(job)
 

--- a/tests/test_recovery_pin_governance.py
+++ b/tests/test_recovery_pin_governance.py
@@ -1,0 +1,890 @@
+"""Focused governance tests for routing recovery, pins, and escalation.
+
+The suite is intentionally black-box at the orchestration seams: it proves the
+authority and provenance a persisted task carries without depending on a live
+model, provider credential, or CLI installation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import date
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Optional
+from unittest import TestCase
+from unittest.mock import patch
+
+from puppetmaster.model_registry import ModelSpec, registry_digest, save_registry
+from puppetmaster.models import AgentRun, Artifact, ArtifactType, Task, TaskStatus
+from puppetmaster.orchestrator import Orchestrator, _payload_has_explicit_model_pin
+from puppetmaster.platform_billing import BillingStatus
+from puppetmaster.store import SwarmStore
+from puppetmaster.workers import WorkerSpec
+
+
+class RecoveryPinGovernanceTests(TestCase):
+    @staticmethod
+    def _store_job(root: str, goal: str = "govern routed work"):
+        store = SwarmStore(Path(root) / ".puppetmaster")
+        job = store.create_job(goal)
+        return store, job
+
+    @staticmethod
+    def _model(
+        model_id: str,
+        capability: int,
+        *,
+        adapter: Optional[str] = None,
+        enabled: bool = True,
+        retired: bool = False,
+        role_scores: Optional[dict[str, int]] = None,
+    ) -> ModelSpec:
+        resolved_adapter, wire_name = model_id.split("/", 1)
+        resolved_adapter = adapter or resolved_adapter
+        cards = {}
+        for role, score in (role_scores or {}).items():
+            cards[role] = {
+                "capability": score,
+                "sample_count": 8,
+                "scale": "puppetmaster-capability-0-100",
+                "scale_version": "v1",
+                "last_calibrated": date.today().isoformat(),
+                "provenance": {"source": "focused-test", "version": "v1"},
+            }
+        return ModelSpec(
+            id=model_id,
+            adapter=resolved_adapter,
+            adapter_model_name=wire_name,
+            capability_score=capability,
+            input_per_mtok_usd=1.0,
+            output_per_mtok_usd=1.0,
+            billing="plan",
+            enabled=enabled,
+            retired=retired,
+            retirement_reason="superseded" if retired else "",
+            retirement_authority="user:test" if retired else "",
+            role_scorecards=cards,
+        )
+
+    @staticmethod
+    def _healthy(adapter: str, **_kwargs) -> BillingStatus:
+        return BillingStatus(
+            adapter=adapter,
+            billing="plan",
+            healthy=True,
+            detail="focused test",
+            evidence=[],
+        )
+
+    @staticmethod
+    def _failure(job_id: str, task_id: str, failure: str, created_at: str) -> Artifact:
+        return Artifact(
+            job_id=job_id,
+            task_id=task_id,
+            type=ArtifactType.VERIFICATION,
+            created_by="worker",
+            payload={"check": "worker", "result": "blocked", "failure": failure},
+            confidence=0.2,
+            evidence=[failure],
+            created_at=created_at,
+        )
+
+    def test_newest_failure_controls_recoverability_even_when_older_failure_was_soft(self) -> None:
+        # Arrange
+        with TemporaryDirectory() as root:
+            store, job = self._store_job(root)
+            old_soft_new_hard = Task(
+                job_id=job.id,
+                role="implement",
+                instruction="first task",
+                status=TaskStatus.FAILED,
+            )
+            old_hard_new_soft = Task(
+                job_id=job.id,
+                role="implement",
+                instruction="second task",
+                status=TaskStatus.FAILED,
+            )
+            artifacts = [
+                self._failure(
+                    job.id,
+                    old_soft_new_hard.id,
+                    "billing_or_quota",
+                    "2026-08-22T00:00:00Z",
+                ),
+                self._failure(
+                    job.id,
+                    old_soft_new_hard.id,
+                    "adapter_exception",
+                    "2026-08-22T00:00:01Z",
+                ),
+                self._failure(
+                    job.id,
+                    old_hard_new_soft.id,
+                    "adapter_exception",
+                    "2026-08-22T00:00:00Z",
+                ),
+                self._failure(
+                    job.id,
+                    old_hard_new_soft.id,
+                    "model_unavailable",
+                    "2026-08-22T00:00:01Z",
+                ),
+            ]
+
+            # Act
+            recoverable = Orchestrator(store)._recoverable_failure_by_task(
+                job, artifacts=artifacts
+            )
+
+            # Assert
+            self.assertNotIn(old_soft_new_hard.id, recoverable)
+            self.assertEqual(recoverable[old_hard_new_soft.id], "model_unavailable")
+
+    def test_auto_route_wins_and_clears_stale_explicit_pin_provenance(self) -> None:
+        # Arrange
+        with TemporaryDirectory() as root:
+            registry_path = Path(root) / "models.json"
+            models = [
+                self._model("cursor/low", 40),
+                self._model("cursor/selected", 80),
+            ]
+            save_registry(models, registry_path)
+            store, job = self._store_job(root)
+            spec = WorkerSpec(
+                role="implement",
+                instruction="implement a cross-module migration",
+                adapter="cursor",
+                payload={
+                    "auto_route": True,
+                    "registry_path": str(registry_path),
+                    "model": "stale-wire-name",
+                    "router_model_id": "cursor/stale",
+                    "pinned_model": "cursor/stale",
+                    "pinned_adapter_model_name": "stale-wire-name",
+                    "min_capability": 70,
+                },
+            )
+
+            # Act
+            with patch(
+                "puppetmaster.preflight.adapter_cli_present", return_value=True
+            ), patch(
+                "puppetmaster.platform_lock.is_adapter_enabled", return_value=True
+            ):
+                task = Orchestrator(store)._create_tasks(job, [spec])[0]
+
+            # Assert
+            self.assertTrue(task.payload["auto_route"])
+            self.assertEqual(task.payload["router_model_id"], "cursor/selected")
+            self.assertEqual(task.payload["model"], "selected")
+            self.assertNotIn("pinned_model", task.payload)
+            self.assertNotIn("pinned_adapter_model_name", task.payload)
+            self.assertFalse(_payload_has_explicit_model_pin(task.payload))
+            self.assertEqual(Path(task.payload["registry_path"]), registry_path)
+            self.assertEqual(task.payload["registry_digest"], registry_digest(models))
+
+    def test_initial_route_and_bound_digest_describe_the_same_registry_snapshot(self) -> None:
+        # Arrange
+        from puppetmaster.routing_authority import load_bound_registry
+
+        with TemporaryDirectory() as root:
+            registry_path = Path(root) / "models.json"
+            routed_snapshot = [self._model("cursor/selected", 90)]
+            replacement_snapshot = [self._model("cursor/replacement", 30)]
+            save_registry(routed_snapshot, registry_path)
+            store, job = self._store_job(root)
+            spec = WorkerSpec(
+                role="implement",
+                instruction="implement a cross-module migration",
+                adapter="cursor",
+                payload={
+                    "auto_route": True,
+                    "registry_path": str(registry_path),
+                    "min_capability": 80,
+                },
+            )
+            loads = 0
+
+            def changing_registry(_path):
+                nonlocal loads
+                loads += 1
+                if loads == 1:
+                    return routed_snapshot
+                save_registry(replacement_snapshot, registry_path)
+                return replacement_snapshot
+
+            # Act
+            with patch(
+                "puppetmaster.model_registry.load_registry",
+                side_effect=changing_registry,
+            ), patch(
+                "puppetmaster.preflight.adapter_cli_present", return_value=True
+            ), patch(
+                "puppetmaster.platform_lock.is_adapter_enabled", return_value=True
+            ):
+                task = Orchestrator(store)._create_tasks(job, [spec])[0]
+
+            # Assert
+            _path, bound_registry, bound_digest = load_bound_registry(task.payload)
+            self.assertEqual(task.payload["registry_digest"], bound_digest)
+            self.assertIn(
+                task.payload["router_model_id"],
+                {model.id for model in bound_registry},
+                "selected model must exist in the exact registry epoch bound to the task",
+            )
+
+    def test_explicit_pin_is_resolved_and_bound_to_live_registry_at_creation(self) -> None:
+        # Arrange
+        with TemporaryDirectory() as root:
+            registry_path = Path(root) / "models.json"
+            models = [self._model("cursor/current", 80)]
+            save_registry(models, registry_path)
+            store, job = self._store_job(root)
+            spec = WorkerSpec(
+                role="implement",
+                instruction="use the requested model",
+                adapter="cursor",
+                payload={
+                    "model": "current",
+                    "registry_path": str(registry_path),
+                },
+            )
+
+            # Act
+            with patch(
+                "puppetmaster.platform_lock.is_adapter_enabled", return_value=True
+            ):
+                task = Orchestrator(store)._create_tasks(job, [spec])[0]
+
+            # Assert
+            self.assertEqual(task.payload["pinned_model"], "cursor/current")
+            self.assertEqual(task.payload["router_model_id"], "cursor/current")
+            self.assertEqual(task.payload["model"], "current")
+            self.assertEqual(Path(task.payload["registry_path"]), registry_path)
+            self.assertEqual(task.payload["registry_digest"], registry_digest(models))
+
+    def test_retired_explicit_pin_is_rejected_before_task_is_persisted(self) -> None:
+        # Arrange
+        with TemporaryDirectory() as root:
+            registry_path = Path(root) / "models.json"
+            retired = self._model(
+                "cursor/retired", 90, enabled=False, retired=True
+            )
+            save_registry([retired], registry_path)
+            store, job = self._store_job(root)
+            spec = WorkerSpec(
+                role="implement",
+                instruction="must not invoke retired authority",
+                adapter="cursor",
+                payload={
+                    "model": "retired",
+                    "registry_path": str(registry_path),
+                },
+            )
+
+            # Act / Assert
+            with self.assertRaisesRegex(RuntimeError, "(?i)model|pin|retir|disabled"):
+                Orchestrator(store)._create_tasks(job, [spec])
+            self.assertEqual(store.list_tasks(job.id), [])
+
+    def test_pin_retired_after_creation_is_blocked_before_adapter_invocation(self) -> None:
+        # Arrange
+        from puppetmaster.worker_runtime import WorkerRuntime
+
+        with TemporaryDirectory() as root:
+            registry_path = Path(root) / "models.json"
+            enabled = self._model("cursor/current", 80)
+            save_registry([enabled], registry_path)
+            store, job = self._store_job(root)
+            spec = WorkerSpec(
+                role="implement",
+                instruction="run only while authority remains live",
+                adapter="cursor",
+                payload={"model": "current", "registry_path": str(registry_path)},
+            )
+            with patch(
+                "puppetmaster.platform_lock.is_adapter_enabled", return_value=True
+            ):
+                task = Orchestrator(store)._create_tasks(job, [spec])[0]
+            save_registry(
+                [replace(
+                    enabled,
+                    enabled=False,
+                    retired=True,
+                    retirement_reason="superseded",
+                    retirement_authority="user:test",
+                )],
+                registry_path,
+            )
+            runtime = WorkerRuntime(
+                store=store,
+                job_id=job.id,
+                role=task.role,
+                worker_id="dispatch-guard",
+            )
+            completed_run = AgentRun(
+                job_id=job.id,
+                task_id=task.id,
+                role=task.role,
+                worker_id="dispatch-guard",
+                status=TaskStatus.COMPLETE,
+            )
+
+            # Act
+            with patch("puppetmaster.worker_runtime.LocalWorker") as worker:
+                worker.return_value.run.return_value = (completed_run, [])
+                self.assertTrue(runtime.run_once())
+
+            # Assert
+            worker.assert_not_called()
+            self.assertEqual(store.get_task_by_id(task.id).status, TaskStatus.FAILED)
+            failures = [
+                event
+                for event in store.read_events(job.id)
+                if event["event"] == "worker.failed_task"
+            ]
+            self.assertTrue(failures)
+            detail = str(failures[-1]["payload"]).lower()
+            self.assertTrue("retir" in detail or "registry" in detail)
+
+    def test_enabled_legacy_model_only_pin_is_canonicalized_before_dispatch(self) -> None:
+        # Arrange
+        from puppetmaster.worker_runtime import WorkerRuntime
+
+        with TemporaryDirectory() as root:
+            registry_path = Path(root) / "models.json"
+            models = [self._model("cursor/current", 80)]
+            save_registry(models, registry_path)
+            store, job = self._store_job(root)
+            task = Task(
+                job_id=job.id,
+                role="implement",
+                instruction="dispatch a legacy persisted pin",
+                adapter="cursor",
+                status=TaskStatus.QUEUED,
+                payload={"model": "current", "auto_route": False},
+            )
+            store.save_task(task)
+            runtime = WorkerRuntime(
+                store=store,
+                job_id=job.id,
+                role=task.role,
+                worker_id="legacy-dispatch-guard",
+            )
+            completed_run = AgentRun(
+                job_id=job.id,
+                task_id=task.id,
+                role=task.role,
+                worker_id="legacy-dispatch-guard",
+                status=TaskStatus.COMPLETE,
+            )
+
+            # Act
+            with patch.dict(
+                "os.environ", {"PUPPETMASTER_MODELS_PATH": str(registry_path)}
+            ), patch("puppetmaster.worker_runtime.LocalWorker") as worker:
+                worker.return_value.run.return_value = (completed_run, [])
+                self.assertTrue(runtime.run_once())
+
+            # Assert
+            worker.assert_called_once()
+            dispatched = worker.return_value.run.call_args.args[0]
+            self.assertEqual(dispatched.payload["pinned_model"], "cursor/current")
+            self.assertEqual(dispatched.payload["router_model_id"], "cursor/current")
+            self.assertEqual(Path(dispatched.payload["registry_path"]), registry_path)
+            self.assertEqual(
+                dispatched.payload["registry_digest"], registry_digest(models)
+            )
+            persisted = store.get_task_by_id(task.id)
+            self.assertEqual(persisted.status, TaskStatus.COMPLETE)
+            self.assertEqual(persisted.payload["pinned_model"], "cursor/current")
+            self.assertEqual(
+                persisted.payload["registry_digest"], registry_digest(models)
+            )
+
+    def test_retired_legacy_model_only_pin_is_blocked_before_dispatch(self) -> None:
+        # Arrange
+        from puppetmaster.worker_runtime import WorkerRuntime
+
+        with TemporaryDirectory() as root:
+            registry_path = Path(root) / "models.json"
+            retired = self._model(
+                "cursor/retired", 90, enabled=False, retired=True
+            )
+            save_registry([retired], registry_path)
+            store, job = self._store_job(root)
+            task = Task(
+                job_id=job.id,
+                role="implement",
+                instruction="never dispatch retired legacy authority",
+                adapter="cursor",
+                status=TaskStatus.QUEUED,
+                payload={"model": "retired", "auto_route": False},
+            )
+            store.save_task(task)
+            runtime = WorkerRuntime(
+                store=store,
+                job_id=job.id,
+                role=task.role,
+                worker_id="legacy-dispatch-guard",
+            )
+            completed_run = AgentRun(
+                job_id=job.id,
+                task_id=task.id,
+                role=task.role,
+                worker_id="legacy-dispatch-guard",
+                status=TaskStatus.COMPLETE,
+            )
+
+            # Act
+            with patch.dict(
+                "os.environ", {"PUPPETMASTER_MODELS_PATH": str(registry_path)}
+            ), patch("puppetmaster.worker_runtime.LocalWorker") as worker:
+                worker.return_value.run.return_value = (completed_run, [])
+                self.assertTrue(runtime.run_once())
+
+            # Assert
+            worker.assert_not_called()
+            self.assertEqual(store.get_task_by_id(task.id).status, TaskStatus.FAILED)
+            failures = [
+                event
+                for event in store.read_events(job.id)
+                if event["event"] == "worker.failed_task"
+            ]
+            self.assertTrue(failures)
+            detail = str(failures[-1]["payload"]).lower()
+            self.assertTrue("retir" in detail or "registry" in detail)
+
+    def test_divergent_stamped_and_executable_pin_identities_block_dispatch(self) -> None:
+        # Arrange
+        from puppetmaster.worker_runtime import WorkerRuntime
+
+        mismatches = (
+            {
+                "model": "different-wire",
+                "router_model_id": "cursor/current",
+                "pinned_model": "cursor/current",
+                "pinned_adapter_model_name": "current",
+            },
+            {
+                "model": "current",
+                "router_model_id": "cursor/different-id",
+                "pinned_model": "cursor/current",
+                "pinned_adapter_model_name": "current",
+            },
+        )
+        for mismatch in mismatches:
+            with self.subTest(mismatch=mismatch), TemporaryDirectory() as root:
+                registry_path = Path(root) / "models.json"
+                models = [self._model("cursor/current", 80)]
+                save_registry(models, registry_path)
+                store, job = self._store_job(root)
+                task = Task(
+                    job_id=job.id,
+                    role="implement",
+                    instruction="reject contradictory persisted pin identity",
+                    adapter="cursor",
+                    status=TaskStatus.QUEUED,
+                    payload={
+                        **mismatch,
+                        "auto_route": False,
+                        "registry_path": str(registry_path),
+                        "registry_digest": registry_digest(models),
+                    },
+                )
+                store.save_task(task)
+                runtime = WorkerRuntime(
+                    store=store,
+                    job_id=job.id,
+                    role=task.role,
+                    worker_id="identity-dispatch-guard",
+                )
+                completed_run = AgentRun(
+                    job_id=job.id,
+                    task_id=task.id,
+                    role=task.role,
+                    worker_id="identity-dispatch-guard",
+                    status=TaskStatus.COMPLETE,
+                )
+
+                # Act
+                with patch("puppetmaster.worker_runtime.LocalWorker") as worker:
+                    worker.return_value.run.return_value = (completed_run, [])
+                    self.assertTrue(runtime.run_once())
+
+                # Assert
+                worker.assert_not_called()
+                self.assertEqual(
+                    store.get_task_by_id(task.id).status, TaskStatus.FAILED
+                )
+                failures = [
+                    event
+                    for event in store.read_events(job.id)
+                    if event["event"] == "worker.failed_task"
+                ]
+                self.assertTrue(failures)
+                self.assertIn(
+                    "registry_authority_invalid", str(failures[-1]["payload"])
+                )
+
+    def test_fallback_uses_task_registry_authority_and_records_source_model(self) -> None:
+        # Arrange
+        with TemporaryDirectory() as root:
+            registry_path = Path(root) / "override-models.json"
+            models = [
+                self._model("cursor/failed", 70),
+                self._model("claude-code/recovery", 90),
+            ]
+            save_registry(models, registry_path)
+            store, job = self._store_job(root)
+            task = Task(
+                job_id=job.id,
+                role="implement",
+                instruction="recover the task",
+                adapter="cursor",
+                status=TaskStatus.FAILED,
+                payload={
+                    "auto_route": True,
+                    "model": "failed",
+                    "router_model_id": "cursor/failed",
+                    "registry_path": str(registry_path),
+                    "registry_digest": registry_digest(models),
+                },
+            )
+            store.save_task(task)
+            store.save_artifact(
+                self._failure(
+                    job.id,
+                    task.id,
+                    "billing_or_quota",
+                    "2026-08-22T00:00:00Z",
+                )
+            )
+
+            # Act
+            with patch(
+                "puppetmaster.model_registry.default_registry_path",
+                side_effect=AssertionError("fallback consulted ambient registry"),
+            ), patch(
+                "puppetmaster.platform_billing.detect_adapter_billing_cached",
+                side_effect=self._healthy,
+            ), patch(
+                "puppetmaster.platform_lock.is_adapter_enabled", return_value=True
+            ), patch(
+                "puppetmaster.preflight.adapter_cli_present", return_value=True
+            ):
+                rerouted = Orchestrator(store)._reroute_recoverable_failures(job)
+
+            # Assert
+            self.assertEqual(rerouted, 1)
+            updated = store.get_task_by_id(task.id)
+            self.assertEqual(updated.payload["router_model_id"], "claude-code/recovery")
+            self.assertEqual(updated.payload["fallback_from_model"], "cursor/failed")
+            self.assertEqual(Path(updated.payload["registry_path"]), registry_path)
+            self.assertEqual(updated.payload["registry_digest"], registry_digest(models))
+            artifacts = [
+                artifact
+                for artifact in store.list_artifacts(job.id)
+                if artifact.created_by == "router-fallback"
+            ]
+            self.assertEqual(artifacts[-1].payload["fallback_from_model"], "cursor/failed")
+
+    def test_confidence_escalation_uses_role_effective_scores_and_task_registry(self) -> None:
+        # Arrange
+        with TemporaryDirectory() as root:
+            registry_path = Path(root) / "override-models.json"
+            models = [
+                self._model("cursor/current", 90, role_scores={"implement": 50}),
+                self._model("cursor/role-stronger", 80, role_scores={"implement": 70}),
+            ]
+            save_registry(models, registry_path)
+            store, job = self._store_job(root)
+            task = Task(
+                job_id=job.id,
+                role="implement",
+                instruction="implement the change",
+                adapter="cursor",
+                status=TaskStatus.COMPLETE,
+                payload={
+                    "auto_route": True,
+                    "model": "current",
+                    "router_model_id": "cursor/current",
+                    "min_confidence": 0.8,
+                    "registry_path": str(registry_path),
+                    "registry_digest": registry_digest(models),
+                },
+            )
+            store.save_task(task)
+            store.save_artifact(
+                Artifact(
+                    job_id=job.id,
+                    task_id=task.id,
+                    type=ArtifactType.VERIFICATION,
+                    created_by="worker",
+                    payload={"check": "worker", "result": "done"},
+                    confidence=0.4,
+                    evidence=["low-confidence"],
+                )
+            )
+
+            # Act
+            with patch(
+                "puppetmaster.model_registry.default_registry_path",
+                side_effect=AssertionError("escalation consulted ambient registry"),
+            ), patch(
+                "puppetmaster.platform_billing.detect_adapter_billing",
+                side_effect=self._healthy,
+            ), patch(
+                "puppetmaster.platform_lock.is_adapter_enabled", return_value=True
+            ), patch(
+                "puppetmaster.preflight.adapter_cli_present", return_value=True
+            ):
+                rerouted = Orchestrator(store)._reroute_low_confidence(job)
+
+            # Assert
+            self.assertEqual(rerouted, 1)
+            updated = store.get_task_by_id(task.id)
+            self.assertEqual(updated.payload["router_model_id"], "cursor/role-stronger")
+            self.assertEqual(updated.payload["escalated_from_model"], "cursor/current")
+            self.assertEqual(Path(updated.payload["registry_path"]), registry_path)
+            self.assertEqual(updated.payload["registry_digest"], registry_digest(models))
+            artifact = next(
+                item
+                for item in store.list_artifacts(job.id)
+                if item.created_by == "router-escalation"
+            )
+            self.assertEqual(artifact.payload["escalated_from_model"], "cursor/current")
+            self.assertEqual(artifact.payload["effective_capability_score"], 70)
+
+    def test_review_escalation_uses_role_effective_scores_and_task_registry(self) -> None:
+        # Arrange
+        with TemporaryDirectory() as root:
+            registry_path = Path(root) / "override-models.json"
+            models = [
+                self._model("cursor/current", 90, role_scores={"implement": 50}),
+                self._model("cursor/role-stronger", 80, role_scores={"implement": 70}),
+            ]
+            save_registry(models, registry_path)
+            store, job = self._store_job(root)
+            task = Task(
+                job_id=job.id,
+                role="implement",
+                instruction="implement the change",
+                adapter="cursor",
+                status=TaskStatus.FAILED,
+                payload={
+                    "auto_route": True,
+                    "model": "current",
+                    "router_model_id": "cursor/current",
+                    "registry_path": str(registry_path),
+                    "registry_digest": registry_digest(models),
+                },
+            )
+            store.save_task(task)
+            store.save_artifact(
+                Artifact(
+                    job_id=job.id,
+                    task_id=task.id,
+                    type=ArtifactType.GATE,
+                    created_by="review-worker",
+                    payload={"gate": "review", "kind": "review", "passed": False},
+                    confidence=1.0,
+                    evidence=["review:rejected"],
+                )
+            )
+
+            # Act
+            with patch(
+                "puppetmaster.model_registry.default_registry_path",
+                side_effect=AssertionError("review escalation consulted ambient registry"),
+            ), patch(
+                "puppetmaster.platform_billing.detect_adapter_billing",
+                side_effect=self._healthy,
+            ), patch(
+                "puppetmaster.platform_lock.is_adapter_enabled", return_value=True
+            ), patch(
+                "puppetmaster.preflight.adapter_cli_present", return_value=True
+            ):
+                rerouted = Orchestrator(store)._reroute_failed_review(job)
+
+            # Assert
+            self.assertEqual(rerouted, 1)
+            updated = store.get_task_by_id(task.id)
+            self.assertEqual(updated.payload["router_model_id"], "cursor/role-stronger")
+            self.assertEqual(
+                updated.payload["review_escalated_from_model"], "cursor/current"
+            )
+            self.assertEqual(Path(updated.payload["registry_path"]), registry_path)
+            self.assertEqual(updated.payload["registry_digest"], registry_digest(models))
+            artifact = next(
+                item
+                for item in store.list_artifacts(job.id)
+                if item.created_by == "router-review-escalation"
+            )
+            self.assertEqual(
+                artifact.payload["review_escalated_from_model"], "cursor/current"
+            )
+            self.assertEqual(artifact.payload["effective_capability_score"], 70)
+
+    def test_judge_selection_uses_task_registry_and_role_effective_capability(self) -> None:
+        # Arrange
+        from puppetmaster.gates import resolve_judge_model
+
+        with TemporaryDirectory() as root:
+            registry_path = Path(root) / "override-models.json"
+            models = [
+                self._model("cursor/current", 90, role_scores={"implement": 50}),
+                self._model("claude-code/reviewer", 80, role_scores={"review": 70}),
+            ]
+            save_registry(models, registry_path)
+            task = Task(
+                job_id="job-review",
+                role="implement",
+                instruction="implement the change",
+                adapter="cursor",
+                payload={
+                    "router_model_id": "cursor/current",
+                    "registry_path": str(registry_path),
+                    "registry_digest": registry_digest(models),
+                },
+            )
+
+            # Act
+            with patch(
+                "puppetmaster.model_registry.default_registry_path",
+                side_effect=AssertionError("judge consulted ambient registry"),
+            ), patch(
+                "puppetmaster.platform_lock.is_adapter_enabled", return_value=True
+            ):
+                judge = resolve_judge_model(task, {})
+
+            # Assert
+            self.assertIsNotNone(judge)
+            self.assertEqual(judge.id, "claude-code/reviewer")
+
+    def test_judge_selection_rejects_registry_authority_drift(self) -> None:
+        # Arrange
+        from puppetmaster.gates import resolve_judge_model
+
+        with TemporaryDirectory() as root:
+            registry_path = Path(root) / "override-models.json"
+            models = [
+                self._model("cursor/current", 70),
+                self._model("claude-code/reviewer", 90),
+            ]
+            save_registry(models, registry_path)
+            task = Task(
+                job_id="job-review",
+                role="implement",
+                instruction="implement the change",
+                adapter="cursor",
+                payload={
+                    "router_model_id": "cursor/current",
+                    "registry_path": str(registry_path),
+                    "registry_digest": "0" * 64,
+                },
+            )
+
+            # Act / Assert
+            with patch(
+                "puppetmaster.platform_lock.is_adapter_enabled", return_value=True
+            ), self.assertRaisesRegex(RuntimeError, "(?i)registry.*drift|digest"):
+                resolve_judge_model(task, {})
+
+    def test_all_secondary_routes_fail_closed_on_registry_authority_drift(self) -> None:
+        # Arrange
+        from puppetmaster.routing_authority import RegistryAuthorityError
+
+        cases = (
+            ("fallback", TaskStatus.FAILED, "_reroute_recoverable_failures"),
+            ("confidence", TaskStatus.COMPLETE, "_reroute_low_confidence"),
+            ("review", TaskStatus.FAILED, "_reroute_failed_review"),
+        )
+        for kind, status, method_name in cases:
+            with self.subTest(kind=kind), TemporaryDirectory() as root:
+                registry_path = Path(root) / "override-models.json"
+                models = [
+                    self._model("cursor/current", 70),
+                    self._model("claude-code/recovery", 90),
+                ]
+                save_registry(models, registry_path)
+                store, job = self._store_job(root)
+                payload = {
+                    "auto_route": True,
+                    "model": "current",
+                    "router_model_id": "cursor/current",
+                    "registry_path": str(registry_path),
+                    "registry_digest": "0" * 64,
+                }
+                if kind == "confidence":
+                    payload["min_confidence"] = 0.8
+                task = Task(
+                    job_id=job.id,
+                    role="implement",
+                    instruction="continue only under bound authority",
+                    adapter="cursor",
+                    status=status,
+                    payload=payload,
+                )
+                store.save_task(task)
+                if kind == "fallback":
+                    store.save_artifact(
+                        self._failure(
+                            job.id,
+                            task.id,
+                            "billing_or_quota",
+                            "2026-08-22T00:00:00Z",
+                        )
+                    )
+                elif kind == "confidence":
+                    store.save_artifact(
+                        Artifact(
+                            job_id=job.id,
+                            task_id=task.id,
+                            type=ArtifactType.VERIFICATION,
+                            created_by="worker",
+                            payload={"check": "worker", "result": "done"},
+                            confidence=0.4,
+                            evidence=["low-confidence"],
+                        )
+                    )
+                else:
+                    store.save_artifact(
+                        Artifact(
+                            job_id=job.id,
+                            task_id=task.id,
+                            type=ArtifactType.GATE,
+                            created_by="review-worker",
+                            payload={
+                                "gate": "review",
+                                "kind": "review",
+                                "passed": False,
+                            },
+                            confidence=1.0,
+                            evidence=["review:rejected"],
+                        )
+                    )
+
+                # Act / Assert
+                with patch(
+                    "puppetmaster.platform_billing.detect_adapter_billing_cached",
+                    side_effect=self._healthy,
+                ), patch(
+                    "puppetmaster.platform_billing.detect_adapter_billing",
+                    side_effect=self._healthy,
+                ), patch(
+                    "puppetmaster.platform_lock.is_adapter_enabled", return_value=True
+                ), patch(
+                    "puppetmaster.preflight.adapter_cli_present", return_value=True
+                ), self.assertRaisesRegex(
+                    RegistryAuthorityError, "(?i)registry.*drift|digest"
+                ):
+                    getattr(Orchestrator(store), method_name)(job)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import unittest
+
+    unittest.main()

--- a/tests/test_registry_retirement.py
+++ b/tests/test_registry_retirement.py
@@ -1,0 +1,428 @@
+"""Adversarial registry-governance tests for TASK-004.
+
+These tests intentionally exercise public registry and discovery seams.  They
+define the authority boundary before the production implementation exists:
+malformed or ambiguous registries never partially load, and a local retirement
+cannot be undone by catalog reconciliation.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+
+def _entry(
+    model_id: str = "cursor/grok-4-5",
+    *,
+    adapter: str = "cursor",
+    adapter_model_name: str = "grok-4.5",
+) -> dict:
+    return {
+        "id": model_id,
+        "adapter": adapter,
+        "adapter_model_name": adapter_model_name,
+        "capability_score": 90,
+    }
+
+
+def _write_registry(tmp_path, payload):
+    path = tmp_path / "models.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [_entry()],
+        {"models": [_entry()]},
+    ],
+    ids=["documented-list-form", "documented-object-form"],
+)
+def test_load_registry_accepts_both_documented_forms(tmp_path, payload) -> None:
+    # Arrange
+    from puppetmaster.model_registry import load_registry
+
+    path = _write_registry(tmp_path, payload)
+
+    # Act
+    specs = load_registry(path)
+
+    # Assert
+    assert [spec.id for spec in specs] == ["cursor/grok-4-5"]
+
+
+@pytest.mark.parametrize(
+    "payload, expected",
+    [
+        ({"unexpected": []}, "models"),
+        ({"models": ["not-an-object"]}, "entry 0"),
+        ({"models": [_entry(adapter="invented-adapter")]}, "adapter"),
+        ({"models": [{"id": "missing-required-fields"}]}, "entry 0"),
+    ],
+    ids=[
+        "unsupported-object-envelope",
+        "non-mapping-entry",
+        "invalid-adapter",
+        "missing-required-fields",
+    ],
+)
+def test_load_registry_rejects_malformed_authority_as_runtime_error(
+    tmp_path, payload, expected
+) -> None:
+    # Arrange
+    from puppetmaster.model_registry import load_registry
+
+    path = _write_registry(tmp_path, payload)
+
+    # Act / Assert
+    with pytest.raises(RuntimeError, match=expected):
+        load_registry(path)
+
+
+def test_load_registry_rejects_duplicate_registry_ids(tmp_path) -> None:
+    # Arrange
+    from puppetmaster.model_registry import load_registry
+
+    path = _write_registry(
+        tmp_path,
+        {
+            "models": [
+                _entry(),
+                _entry(adapter_model_name="grok-4.6"),
+            ]
+        },
+    )
+
+    # Act / Assert
+    with pytest.raises(RuntimeError, match="duplicate.*id"):
+        load_registry(path)
+
+
+def test_load_registry_rejects_slug_equivalent_identity_twins(tmp_path) -> None:
+    # Arrange: both entries can satisfy the same direct pin after normalization.
+    from puppetmaster.model_registry import load_registry
+
+    path = _write_registry(
+        tmp_path,
+        {
+            "models": [
+                _entry("cursor/grok-dot", adapter_model_name="grok-4.5"),
+                _entry("cursor/grok-dash", adapter_model_name="grok-4-5"),
+            ]
+        },
+    )
+
+    # Act / Assert
+    with pytest.raises(RuntimeError, match="duplicate.*identity|ambiguous.*identity"):
+        load_registry(path)
+
+
+def _retired_spec(*, adapter_model_name: str = "grok-4.5"):
+    from puppetmaster.model_registry import ModelSpec
+
+    return ModelSpec(
+        id="cursor/retired-grok",
+        adapter="cursor",
+        adapter_model_name=adapter_model_name,
+        capability_score=99,
+        enabled=False,
+        retired=True,
+        retirement_reason="Superseded after local qualification",
+        retirement_authority="user:registry-owner",
+    )
+
+
+def test_retirement_requires_reason_and_authority_metadata() -> None:
+    # Arrange
+    from puppetmaster.model_registry import ModelSpec
+
+    common = {
+        "id": "cursor/retired-grok",
+        "adapter": "cursor",
+        "adapter_model_name": "grok-4.5",
+        "enabled": False,
+        "retired": True,
+    }
+
+    # Act / Assert
+    with pytest.raises(ValueError, match="reason"):
+        ModelSpec(**common, retirement_authority="user:registry-owner")
+    with pytest.raises(ValueError, match="authority"):
+        ModelSpec(**common, retirement_reason="Superseded")
+
+
+def test_retired_model_is_ineligible_for_routing_and_direct_pin() -> None:
+    # Arrange
+    from puppetmaster.model_registry import enabled_specs, resolve_model_pin
+
+    retired = _retired_spec()
+
+    # Act
+    routable = enabled_specs([retired])
+    pin = resolve_model_pin("cursor/retired-grok", [retired], adapter="cursor")
+
+    # Assert
+    assert routable == []
+    assert pin is None
+
+
+def test_retirement_metadata_round_trips_without_losing_quarantine(tmp_path) -> None:
+    # Arrange
+    from puppetmaster.model_registry import load_registry, save_registry
+
+    path = tmp_path / "models.json"
+    retired = _retired_spec()
+
+    # Act
+    save_registry([retired], path)
+    loaded = load_registry(path)
+
+    # Assert
+    assert len(loaded) == 1
+    assert loaded[0].retired is True
+    assert loaded[0].enabled is False
+    assert loaded[0].retirement_reason == retired.retirement_reason
+    assert loaded[0].retirement_authority == retired.retirement_authority
+
+
+def test_cursor_discovery_preserves_slug_equivalent_retirement() -> None:
+    # Arrange
+    from puppetmaster.cursor_discovery import merge_catalog_into_registry
+    from puppetmaster.model_registry import normalize_model_token
+
+    retired = _retired_spec(adapter_model_name="grok-4-5")
+
+    # Act
+    merged, _report = merge_catalog_into_registry(
+        [retired],
+        [{"id": "grok-4.5", "displayName": "Grok 4.5"}],
+    )
+
+    # Assert: discovery may refresh spelling, but cannot create an enabled twin.
+    matches = [
+        spec
+        for spec in merged
+        if spec.adapter == "cursor"
+        and normalize_model_token(spec.adapter_model_name)
+        == normalize_model_token("grok-4.5")
+    ]
+    assert len(matches) == 1
+    assert matches[0].retired is True
+    assert matches[0].enabled is False
+    assert matches[0].retirement_authority == "user:registry-owner"
+
+
+def test_curated_discovery_does_not_reenable_retired_identity() -> None:
+    # Arrange
+    from puppetmaster.model_registry import ModelSpec
+    from puppetmaster.static_catalog import curated_catalog, merge_curated_into_registry
+
+    catalog_model = str(curated_catalog("antigravity")[0]["model"])
+    retired = ModelSpec(
+        id="antigravity/locally-retired",
+        adapter="antigravity",
+        adapter_model_name=catalog_model,
+        enabled=False,
+        retired=True,
+        retirement_reason="Retired by local policy",
+        retirement_authority="user:registry-owner",
+    )
+
+    # Act
+    merged, _report = merge_curated_into_registry(
+        "antigravity", "plan", [retired]
+    )
+
+    # Assert
+    matches = [
+        spec
+        for spec in merged
+        if spec.adapter == "antigravity"
+        and spec.adapter_model_name == catalog_model
+    ]
+    assert len(matches) == 1
+    assert matches[0].retired is True
+    assert matches[0].enabled is False
+    assert matches[0].retirement_reason == "Retired by local policy"
+
+
+def test_curated_discovery_preserves_punctuation_equivalent_retirement() -> None:
+    # Arrange: curated catalogs may spell an identity with dots while a local
+    # quarantine uses its slug form. Those are the same executable identity.
+    from puppetmaster.model_registry import ModelSpec, normalize_model_token
+    from puppetmaster.static_catalog import curated_catalog, merge_curated_into_registry
+
+    catalog_model = next(
+        str(item["model"])
+        for item in curated_catalog("antigravity")
+        if str(item["model"]) != normalize_model_token(str(item["model"]))
+    )
+    retired = ModelSpec(
+        id="antigravity/punctuation-retired",
+        adapter="antigravity",
+        adapter_model_name=normalize_model_token(catalog_model),
+        enabled=False,
+        retired=True,
+        retirement_reason="Retired across catalog spellings",
+        retirement_authority="user:registry-owner",
+    )
+
+    # Act
+    merged, _report = merge_curated_into_registry(
+        "antigravity", "plan", [retired]
+    )
+
+    # Assert: refresh may adopt catalog punctuation but cannot create a twin.
+    matches = [
+        spec
+        for spec in merged
+        if spec.adapter == "antigravity"
+        and normalize_model_token(spec.adapter_model_name)
+        == normalize_model_token(catalog_model)
+    ]
+    assert len(matches) == 1
+    assert matches[0].retired is True
+    assert matches[0].enabled is False
+    assert matches[0].retirement_authority == "user:registry-owner"
+
+
+def test_api_discovery_does_not_reenable_retired_identity() -> None:
+    # Arrange
+    from puppetmaster.api_discovery import merge_api_catalog_into_registry
+    from puppetmaster.model_registry import ModelSpec
+
+    retired = ModelSpec(
+        id="openai/locally-retired",
+        adapter="openai",
+        adapter_model_name="gpt-retired",
+        enabled=False,
+        retired=True,
+        retirement_reason="Retired by local policy",
+        retirement_authority="user:registry-owner",
+    )
+
+    # Act
+    merged, _report = merge_api_catalog_into_registry(
+        "openai",
+        "api",
+        [retired],
+        [{"id": "gpt-retired"}],
+    )
+
+    # Assert
+    matches = [spec for spec in merged if spec.adapter_model_name == "gpt-retired"]
+    assert len(matches) == 1
+    assert matches[0].retired is True
+    assert matches[0].enabled is False
+
+
+def test_api_discovery_preserves_punctuation_equivalent_retirement() -> None:
+    # Arrange
+    from puppetmaster.api_discovery import merge_api_catalog_into_registry
+    from puppetmaster.model_registry import ModelSpec, normalize_model_token
+
+    retired = ModelSpec(
+        id="openai/punctuation-retired",
+        adapter="openai",
+        adapter_model_name="gpt.retired",
+        enabled=False,
+        retired=True,
+        retirement_reason="Retired across catalog spellings",
+        retirement_authority="user:registry-owner",
+    )
+
+    # Act
+    merged, _report = merge_api_catalog_into_registry(
+        "openai",
+        "api",
+        [retired],
+        [{"id": "gpt-retired"}],
+    )
+
+    # Assert
+    matches = [
+        spec
+        for spec in merged
+        if spec.adapter == "openai"
+        and normalize_model_token(spec.adapter_model_name)
+        == normalize_model_token("gpt-retired")
+    ]
+    assert len(matches) == 1
+    assert matches[0].retired is True
+    assert matches[0].enabled is False
+    assert matches[0].retirement_authority == "user:registry-owner"
+
+
+def test_registry_digest_and_schema_version_are_stable_across_round_trip(
+    tmp_path,
+) -> None:
+    # Arrange
+    import puppetmaster.model_registry as registry_module
+
+    retired = _retired_spec()
+    path = tmp_path / "models.json"
+
+    # Act
+    before = registry_module.registry_digest([retired])
+    registry_module.save_registry([retired], path)
+    after = registry_module.registry_digest(registry_module.load_registry(path))
+
+    # Assert
+    assert registry_module.REGISTRY_SCHEMA_VERSION >= 1
+    assert before == after
+    assert len(before) == 64
+    int(before, 16)
+
+
+def test_registry_digest_changes_for_routing_or_quarantine_authority() -> None:
+    # Arrange
+    import puppetmaster.model_registry as registry_module
+
+    retired = _retired_spec()
+
+    # Act
+    baseline = registry_module.registry_digest([retired])
+    capability_changed = registry_module.registry_digest(
+        [replace(retired, capability_score=retired.capability_score - 1)]
+    )
+    authority_changed = registry_module.registry_digest(
+        [replace(retired, retirement_authority="policy:security-team")]
+    )
+
+    # Assert
+    assert baseline != capability_changed
+    assert baseline != authority_changed
+
+
+def test_registry_digest_changes_when_routing_precedence_order_changes() -> None:
+    # Arrange: router min/max tie-breaking retains registry insertion order for
+    # otherwise equal candidates, so row order is material reproduction state.
+    import puppetmaster.model_registry as registry_module
+
+    first = registry_module.ModelSpec(
+        id="cursor/equal-first",
+        adapter="cursor",
+        adapter_model_name="equal-first",
+        capability_score=90,
+        input_per_mtok_usd=1.0,
+        output_per_mtok_usd=1.0,
+    )
+    second = registry_module.ModelSpec(
+        id="cursor/equal-second",
+        adapter="cursor",
+        adapter_model_name="equal-second",
+        capability_score=90,
+        input_per_mtok_usd=1.0,
+        output_per_mtok_usd=1.0,
+    )
+
+    # Act
+    first_precedence = registry_module.registry_digest([first, second])
+    second_precedence = registry_module.registry_digest([second, first])
+
+    # Assert
+    assert first_precedence != second_precedence

--- a/tests/test_review_gate_fail_closed.py
+++ b/tests/test_review_gate_fail_closed.py
@@ -1,0 +1,576 @@
+"""Focused RED tests for requested, attributable review gates.
+
+These tests intentionally exercise only the public gate evaluation seam and
+the judge resolver.  They never call a live model.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from puppetmaster.gates import ReviewVerdict, evaluate_task_gates
+from puppetmaster.model_registry import ModelSpec, registry_digest, save_registry
+from puppetmaster.models import Task
+from puppetmaster.sqlite_store import SQLiteSwarmStore
+
+
+class RequestedReviewFailClosedTests(TestCase):
+    def _store(self, root: str) -> SQLiteSwarmStore:
+        store = SQLiteSwarmStore(Path(root) / ".puppetmaster")
+        store.init()
+        return store
+
+    def _repo(self, root: str) -> Path:
+        repo = Path(root) / "repo"
+        repo.mkdir(parents=True)
+        for argv in (
+            ["git", "init", "-q"],
+            ["git", "config", "user.email", "review@test.invalid"],
+            ["git", "config", "user.name", "Review Test"],
+        ):
+            subprocess.run(argv, cwd=repo, check=True, capture_output=True)
+        (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "seed"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+        (repo / "feature.py").write_text("def feature():\n    return 1\n", encoding="utf-8")
+        return repo
+
+    def _task(self, repo: Path, *, review=True, router_model_id="cursor/gpt-5-5") -> Task:
+        return Task(
+            job_id="job-review",
+            id="task-review",
+            role="implement",
+            instruction="add the feature",
+            payload={
+                "cwd": str(repo),
+                "review": review,
+                "router_model_id": router_model_id,
+            },
+        )
+
+    def _raw_review_task(self, repo: Path, review_gate: dict) -> Task:
+        return Task(
+            job_id="job-review",
+            id="task-review",
+            role="implement",
+            instruction="add the feature",
+            payload={
+                "cwd": str(repo),
+                "router_model_id": "cursor/gpt-5-5",
+                "gates": [{"kind": "review", **review_gate}],
+            },
+        )
+
+    @staticmethod
+    def _review_payload(evaluation) -> dict:
+        matches = [
+            artifact.payload
+            for artifact in evaluation.artifacts
+            if (artifact.payload or {}).get("kind") == "review"
+        ]
+        assert len(matches) == 1
+        return matches[0]
+
+    def test_explicit_review_fails_when_live_review_flag_is_missing(self) -> None:
+        # Arrange
+        import puppetmaster.gates as gates
+
+        with TemporaryDirectory() as root:
+            repo = self._repo(root)
+            task = self._task(repo, review=True)
+            judge = Mock(
+                id="cursor/gpt-5-6",
+                adapter="cursor",
+                adapter_model_name="gpt-5.6",
+            )
+
+            # Act
+            with patch.object(gates, "resolve_judge_model", return_value=judge), patch.object(
+                gates, "_REVIEW_JUDGE", gates.default_judge_review
+            ), patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("PUPPETMASTER_REVIEW_GATE", None)
+                evaluation = evaluate_task_gates(
+                    task,
+                    [],
+                    self._store(root),
+                    worker_id="implementer-worker",
+                    cwd=repo,
+                )
+
+            # Assert
+            self.assertFalse(evaluation.passed)
+            payload = self._review_payload(evaluation)
+            self.assertFalse(payload["passed"])
+            self.assertIn("PUPPETMASTER_REVIEW_GATE", payload["reason"])
+            self.assertIn("disabled", payload["reason"].lower())
+
+    def test_explicit_review_fails_when_no_adequate_judge_resolves(self) -> None:
+        # Arrange
+        import puppetmaster.gates as gates
+
+        with TemporaryDirectory() as root:
+            repo = self._repo(root)
+            task = self._task(repo, review=True)
+
+            # Act
+            with patch.object(gates, "resolve_judge_model", return_value=None), patch.object(
+                gates, "_REVIEW_JUDGE"
+            ) as review_call:
+                evaluation = evaluate_task_gates(
+                    task,
+                    [],
+                    self._store(root),
+                    worker_id="implementer-worker",
+                    cwd=repo,
+                )
+
+            # Assert
+            self.assertFalse(evaluation.passed)
+            review_call.assert_not_called()
+            payload = self._review_payload(evaluation)
+            self.assertFalse(payload["passed"])
+            self.assertIsNone(payload["judge"])
+            self.assertIn("no adequate judge", payload["reason"].lower())
+
+    def test_raw_review_gate_cannot_make_its_implicit_request_optional(self) -> None:
+        # Arrange
+        import puppetmaster.gates as gates
+
+        with TemporaryDirectory() as root:
+            repo = self._repo(root)
+            task = self._raw_review_task(repo, {"required": False})
+
+            # Act
+            with patch.object(gates, "resolve_judge_model", return_value=None):
+                evaluation = evaluate_task_gates(
+                    task,
+                    [],
+                    self._store(root),
+                    worker_id="implementer-worker",
+                    cwd=repo,
+                )
+
+            # Assert
+            self.assertFalse(evaluation.passed)
+            payload = self._review_payload(evaluation)
+            self.assertTrue(payload["review_requested"])
+            self.assertTrue(payload["review_required"])
+            self.assertIn("no adequate judge", payload["reason"].lower())
+
+    def test_requested_raw_review_cannot_disable_required_when_judge_is_missing(self) -> None:
+        # Arrange
+        import puppetmaster.gates as gates
+
+        with TemporaryDirectory() as root:
+            repo = self._repo(root)
+            task = self._raw_review_task(
+                repo,
+                {"requested": True, "required": False},
+            )
+
+            # Act
+            with patch.object(gates, "resolve_judge_model", return_value=None):
+                evaluation = evaluate_task_gates(
+                    task,
+                    [],
+                    self._store(root),
+                    worker_id="implementer-worker",
+                    cwd=repo,
+                )
+
+            # Assert
+            self.assertFalse(evaluation.passed)
+            payload = self._review_payload(evaluation)
+            self.assertTrue(payload["review_requested"])
+            self.assertTrue(payload["review_required"])
+            self.assertIn("no adequate judge", payload["reason"].lower())
+
+    def test_requested_raw_review_cannot_disable_required_when_judge_is_unavailable(self) -> None:
+        # Arrange
+        import puppetmaster.gates as gates
+
+        with TemporaryDirectory() as root:
+            repo = self._repo(root)
+            task = self._raw_review_task(
+                repo,
+                {"requested": True, "required": False},
+            )
+            judge = Mock(id="cursor/gpt-5-6", adapter="cursor")
+            unavailable = ReviewVerdict(
+                available=False,
+                passed=True,
+                reasons=["provider offline"],
+                detail={"availability_reason": "provider offline"},
+            )
+
+            # Act
+            with patch.object(gates, "resolve_judge_model", return_value=judge), patch.object(
+                gates,
+                "_REVIEW_JUDGE",
+                return_value=unavailable,
+            ):
+                evaluation = evaluate_task_gates(
+                    task,
+                    [],
+                    self._store(root),
+                    worker_id="implementer-worker",
+                    cwd=repo,
+                )
+
+            # Assert
+            self.assertFalse(evaluation.passed)
+            payload = self._review_payload(evaluation)
+            self.assertTrue(payload["review_requested"])
+            self.assertTrue(payload["review_required"])
+            self.assertIn("provider offline", payload["reason"])
+
+    def test_requested_raw_review_cannot_disable_required_when_live_review_is_disabled(self) -> None:
+        # Arrange
+        import puppetmaster.gates as gates
+
+        with TemporaryDirectory() as root:
+            repo = self._repo(root)
+            task = self._raw_review_task(
+                repo,
+                {"requested": True, "required": False},
+            )
+            judge = Mock(
+                id="cursor/gpt-5-6",
+                adapter="cursor",
+                adapter_model_name="gpt-5.6",
+            )
+
+            # Act
+            with patch.object(gates, "resolve_judge_model", return_value=judge), patch.object(
+                gates,
+                "_REVIEW_JUDGE",
+                gates.default_judge_review,
+            ), patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("PUPPETMASTER_REVIEW_GATE", None)
+                evaluation = evaluate_task_gates(
+                    task,
+                    [],
+                    self._store(root),
+                    worker_id="implementer-worker",
+                    cwd=repo,
+                )
+
+            # Assert
+            self.assertFalse(evaluation.passed)
+            payload = self._review_payload(evaluation)
+            self.assertTrue(payload["review_requested"])
+            self.assertTrue(payload["review_required"])
+            self.assertIn("PUPPETMASTER_REVIEW_GATE", payload["reason"])
+
+    def test_raw_nonrequested_review_remains_explicitly_optional(self) -> None:
+        # Arrange
+        import puppetmaster.gates as gates
+
+        with TemporaryDirectory() as root:
+            repo = self._repo(root)
+            task = self._raw_review_task(
+                repo,
+                {"requested": False, "required": False},
+            )
+
+            # Act
+            with patch.object(gates, "resolve_judge_model", return_value=None):
+                evaluation = evaluate_task_gates(
+                    task,
+                    [],
+                    self._store(root),
+                    worker_id="implementer-worker",
+                    cwd=repo,
+                )
+
+            # Assert
+            self.assertTrue(evaluation.passed)
+            payload = self._review_payload(evaluation)
+            self.assertFalse(payload["review_requested"])
+            self.assertFalse(payload["review_required"])
+            self.assertEqual(payload["review_status"], "skipped")
+            self.assertIn("optional review skipped", payload["reason"].lower())
+
+    def test_explicit_review_flag_cannot_be_weakened_by_optional_gate_entry(self) -> None:
+        # Arrange
+        import puppetmaster.gates as gates
+
+        with TemporaryDirectory() as root:
+            repo = self._repo(root)
+            task = self._task(repo, review=True)
+            task = Task(
+                job_id=task.job_id,
+                id=task.id,
+                role=task.role,
+                instruction=task.instruction,
+                payload={
+                    **task.payload,
+                    "gates": [
+                        {
+                            "kind": "review",
+                            "required": False,
+                            "requested": False,
+                        }
+                    ],
+                },
+            )
+
+            # Act
+            with patch.object(gates, "resolve_judge_model", return_value=None):
+                evaluation = evaluate_task_gates(
+                    task,
+                    [],
+                    self._store(root),
+                    worker_id="implementer-worker",
+                    cwd=repo,
+                )
+
+            # Assert
+            self.assertFalse(evaluation.passed)
+            payload = self._review_payload(evaluation)
+            self.assertTrue(payload["review_required"])
+            self.assertTrue(payload["review_requested"])
+            self.assertIn("no adequate judge", payload["reason"].lower())
+
+    def test_explicit_review_fails_with_precise_unavailable_judge_reason(self) -> None:
+        # Arrange
+        import puppetmaster.gates as gates
+
+        with TemporaryDirectory() as root:
+            repo = self._repo(root)
+            task = self._task(repo, review=True)
+            judge = Mock(id="cursor/gpt-5-6")
+            unavailable = ReviewVerdict(
+                available=False,
+                passed=True,
+                reasons=["provider offline"],
+                detail={"availability_reason": "provider offline"},
+            )
+
+            # Act
+            with patch.object(gates, "resolve_judge_model", return_value=judge), patch.object(
+                gates, "_REVIEW_JUDGE", return_value=unavailable
+            ):
+                evaluation = evaluate_task_gates(
+                    task,
+                    [],
+                    self._store(root),
+                    worker_id="implementer-worker",
+                    cwd=repo,
+                )
+
+            # Assert
+            self.assertFalse(evaluation.passed)
+            payload = self._review_payload(evaluation)
+            self.assertFalse(payload["passed"])
+            self.assertEqual(payload["judge"], "cursor/gpt-5-6")
+            self.assertIn("provider offline", payload["reason"])
+            self.assertEqual(payload["availability_reason"], "provider offline")
+
+    def test_successful_review_is_bound_to_judge_evaluator_and_full_diff(self) -> None:
+        # Arrange
+        import puppetmaster.gates as gates
+
+        with TemporaryDirectory() as root:
+            repo = self._repo(root)
+            task = self._task(
+                repo,
+                review={
+                    "evaluator_revision": "review-gate-v1",
+                    "independence": "different_worker",
+                },
+            )
+            judge = Mock(id="cursor/gpt-5-6", adapter="cursor")
+            collected_diff = gates._collect_diff([], repo)
+            expected_fingerprint = "sha256:" + hashlib.sha256(
+                collected_diff.encode("utf-8")
+            ).hexdigest()
+            approved = ReviewVerdict(
+                available=True,
+                passed=True,
+                severity="none",
+                detail={"judge_identity": "review-worker-42"},
+            )
+
+            # Act
+            with patch.object(gates, "resolve_judge_model", return_value=judge), patch.object(
+                gates, "_REVIEW_JUDGE", return_value=approved
+            ):
+                evaluation = evaluate_task_gates(
+                    task,
+                    [],
+                    self._store(root),
+                    worker_id="implementer-worker",
+                    cwd=repo,
+                )
+
+            # Assert
+            self.assertTrue(evaluation.passed)
+            payload = self._review_payload(evaluation)
+            self.assertEqual(payload["judge_identity"], "review-worker-42")
+            self.assertNotEqual(payload["judge_identity"], "implementer-worker")
+            self.assertEqual(payload["judge_model"], "cursor/gpt-5-6")
+            self.assertEqual(payload["judge_adapter"], "cursor")
+            self.assertEqual(payload["evaluator_revision"], "review-gate-v1")
+            self.assertEqual(payload["reviewed_artifact_fingerprint"], expected_fingerprint)
+
+    def test_different_worker_constraint_blocks_same_worker_identity(self) -> None:
+        # Arrange
+        import puppetmaster.gates as gates
+
+        with TemporaryDirectory() as root:
+            repo = self._repo(root)
+            task = self._task(
+                repo,
+                review={"independence": "different_worker"},
+            )
+            judge = Mock(id="cursor/gpt-5-6", adapter="cursor")
+            approved_by_implementer = ReviewVerdict(
+                available=True,
+                passed=True,
+                detail={"judge_identity": "implementer-worker"},
+            )
+
+            # Act
+            with patch.object(gates, "resolve_judge_model", return_value=judge), patch.object(
+                gates, "_REVIEW_JUDGE", return_value=approved_by_implementer
+            ):
+                evaluation = evaluate_task_gates(
+                    task,
+                    [],
+                    self._store(root),
+                    worker_id="implementer-worker",
+                    cwd=repo,
+                )
+
+            # Assert
+            self.assertFalse(evaluation.passed)
+            payload = self._review_payload(evaluation)
+            self.assertEqual(payload["review_status"], "independence_failed")
+            self.assertIn("implementer worker", payload["reason"].lower())
+
+    def test_global_policy_review_remains_explicitly_optional(self) -> None:
+        # Arrange
+        import puppetmaster.gates as gates
+
+        with TemporaryDirectory() as root:
+            repo = self._repo(root)
+            task = Task(
+                job_id="job-review",
+                id="task-review",
+                role="implement",
+                instruction="add the feature",
+                payload={"cwd": str(repo), "mode": "implement"},
+            )
+
+            # Act
+            with patch.dict(os.environ, {"PUPPETMASTER_REVIEW_GATE": "1"}), patch.object(
+                gates, "resolve_judge_model", return_value=None
+            ):
+                evaluation = evaluate_task_gates(
+                    task,
+                    [],
+                    self._store(root),
+                    worker_id="implementer-worker",
+                    cwd=repo,
+                )
+
+            # Assert
+            self.assertTrue(evaluation.passed)
+            payload = self._review_payload(evaluation)
+            self.assertFalse(payload["review_required"])
+            self.assertFalse(payload["review_requested"])
+            self.assertEqual(payload["review_status"], "skipped")
+
+
+class IndependentJudgeSelectionTests(TestCase):
+    @staticmethod
+    def _model(model_id: str, capability: int, family: str) -> ModelSpec:
+        adapter, adapter_model_name = model_id.split("/", 1)
+        return ModelSpec(
+            id=model_id,
+            adapter=adapter,
+            adapter_model_name=adapter_model_name,
+            capability_score=capability,
+            tags=[f"family:{family}"],
+            billing="plan",
+        )
+
+    def test_different_model_family_constraint_selects_independent_judge(self) -> None:
+        # Arrange
+        from puppetmaster.gates import resolve_judge_model
+
+        with TemporaryDirectory() as root:
+            registry = [
+                self._model("cursor/gpt-5-5", 90, "openai"),
+                self._model("cursor/gpt-5-6", 95, "openai"),
+                self._model("claude-code/opus-4-1", 95, "anthropic"),
+            ]
+            registry_path = Path(root) / "models.json"
+            save_registry(registry, registry_path)
+            task = Task(
+                job_id="job-review",
+                role="implement",
+                instruction="high-risk edit",
+                payload={
+                    "router_model_id": "cursor/gpt-5-5",
+                    "registry_path": str(registry_path),
+                    "registry_digest": registry_digest(registry),
+                },
+            )
+
+            # Act
+            with patch(
+                "puppetmaster.platform_lock.is_adapter_enabled", return_value=True
+            ):
+                judge = resolve_judge_model(
+                    task, {"independence": "different_model_family"}
+                )
+
+            # Assert
+            self.assertIsNotNone(judge)
+            self.assertEqual(judge.id, "claude-code/opus-4-1")
+
+    def test_different_model_family_constraint_never_falls_back_to_same_family(self) -> None:
+        # Arrange
+        from puppetmaster.gates import resolve_judge_model
+
+        with TemporaryDirectory() as root:
+            registry = [
+                self._model("cursor/gpt-5-5", 90, "openai"),
+                self._model("cursor/gpt-5-6", 95, "openai"),
+            ]
+            registry_path = Path(root) / "models.json"
+            save_registry(registry, registry_path)
+            task = Task(
+                job_id="job-review",
+                role="implement",
+                instruction="high-risk edit",
+                payload={
+                    "router_model_id": "cursor/gpt-5-5",
+                    "registry_path": str(registry_path),
+                    "registry_digest": registry_digest(registry),
+                },
+            )
+
+            # Act
+            with patch(
+                "puppetmaster.platform_lock.is_adapter_enabled", return_value=True
+            ):
+                judge = resolve_judge_model(
+                    task, {"independence": "different_model_family"}
+                )
+
+            # Assert
+            self.assertIsNone(judge)

--- a/tests/test_role_scorecards.py
+++ b/tests/test_role_scorecards.py
@@ -5,6 +5,7 @@ import json
 import os
 import sys
 import unittest
+from datetime import date
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -25,6 +26,19 @@ def _spec(**kwargs):
     )
     defaults.update(kwargs)
     return ModelSpec(**defaults)
+
+
+def _qualified_card(capability, **extra):
+    card = {
+        "capability": capability,
+        "sample_count": 5,
+        "last_calibrated": date.today().isoformat(),
+        "scale": "puppetmaster-capability-0-100",
+        "scale_version": "1",
+        "provenance": {"source": "test_objective_evaluator", "version": "1"},
+    }
+    card.update(extra)
+    return card
 
 
 def _three_tier():
@@ -130,16 +144,34 @@ class EffectiveCapabilityTests(unittest.TestCase):
         self.assertEqual(effective_capability_score(spec, "implement"), 97)
         self.assertEqual(effective_capability_score(spec, "explore"), 97)
 
-    def test_role_card_overrides_only_that_role(self) -> None:
+    def test_only_qualified_role_card_overrides_matching_role(self) -> None:
         from puppetmaster.scorecards import effective_capability_score
 
-        spec = _spec(
+        unqualified = _spec(
             capability_score=97,
             role_scorecards={"implement": {"capability": 70}},
         )
-        self.assertEqual(effective_capability_score(spec, "implement"), 70)
-        self.assertEqual(effective_capability_score(spec, "explore"), 97)
-        self.assertEqual(effective_capability_score(spec, "review"), 97)
+        self.assertEqual(effective_capability_score(unqualified, "implement"), 97)
+
+        qualified = _spec(
+            capability_score=97,
+            role_scorecards={
+                "implement": {
+                    "capability": 70,
+                    "sample_count": 5,
+                    "last_calibrated": date.today().isoformat(),
+                    "scale": "puppetmaster-capability-0-100",
+                    "scale_version": "1",
+                    "provenance": {
+                        "source": "test_objective_evaluator",
+                        "version": "1",
+                    },
+                }
+            },
+        )
+        self.assertEqual(effective_capability_score(qualified, "implement"), 70)
+        self.assertEqual(effective_capability_score(qualified, "explore"), 97)
+        self.assertEqual(effective_capability_score(qualified, "review"), 97)
 
 
 class ImportBaselineTests(unittest.TestCase):
@@ -299,14 +331,16 @@ class ImportBaselineTests(unittest.TestCase):
 
 
 class RouteTaskScorecardTests(unittest.TestCase):
-    def test_empty_cards_same_pick_as_today(self) -> None:
+    def test_empty_cards_use_manual_scores_across_cost_policies(self) -> None:
         from puppetmaster.router import TaskSignals, route_task
 
         signal = TaskSignals(instruction="add a feature", role="implement")
         decision = route_task(signal, _three_tier(), policy="balanced")
         self.assertEqual(decision.model.id, "mid-model")
         cheap = route_task(signal, _three_tier(), policy="cheap")
-        self.assertEqual(cheap.model.id, "cheap-model")
+        self.assertEqual(cheap.model.id, "mid-model")
+        absolute = route_task(signal, _three_tier(), policy="absolute-cheapest")
+        self.assertEqual(absolute.model.id, "cheap-model")
 
     def test_implement_card_rejects_high_manual_score(self) -> None:
         from puppetmaster.model_registry import ModelSpec
@@ -320,7 +354,7 @@ class RouteTaskScorecardTests(unittest.TestCase):
             input_per_mtok_usd=0.5,
             output_per_mtok_usd=2.0,
             billing="api",
-            role_scorecards={"implement": {"capability": 72}},
+            role_scorecards={"implement": _qualified_card(72)},
         )
         gpt = ModelSpec(
             id="cursor/gpt-5-5",
@@ -330,7 +364,7 @@ class RouteTaskScorecardTests(unittest.TestCase):
             input_per_mtok_usd=5.0,
             output_per_mtok_usd=30.0,
             billing="api",
-            role_scorecards={"implement": {"capability": 70}},
+            role_scorecards={"implement": _qualified_card(70)},
             score_provenance={
                 "source": "community_baseline",
                 "bundle_id": "test-bundle",
@@ -363,12 +397,17 @@ class RouteTaskScorecardTests(unittest.TestCase):
             output_per_mtok_usd=6.0,
             billing="plan",
             role_scorecards={
-                "implement": {
-                    "capability": 88,
-                    "quality": 0.71,
-                    "latency_p50_ms": 1200,
-                    "sample_count": 40,
-                }
+                "implement": _qualified_card(
+                    88,
+                    quality=0.71,
+                    latency_p50_ms=1200,
+                    sample_count=40,
+                    provenance={
+                        "source": "community_baseline",
+                        "version": "1.0.0",
+                        "bundle_id": "puppetmaster-community-scorecards",
+                    },
+                )
             },
             score_provenance={
                 "source": "community_baseline",
@@ -554,7 +593,7 @@ class AuditScorecardTests(unittest.TestCase):
             self.assertEqual(record.attempts, 2)
             self.assertEqual(record.fallback_attempts, 1)
 
-    def test_apply_still_writes_capability_score_only(self) -> None:
+    def test_apply_ignores_self_signal_and_preserves_authority(self) -> None:
         import argparse
 
         from puppetmaster.cli import _run_audit_command
@@ -657,12 +696,129 @@ class AuditScorecardTests(unittest.TestCase):
             rc = _run_audit_command(args, store)
             self.assertEqual(rc, 0)
             after = {s.id: s for s in load_registry(registry_path)}
-            self.assertLess(after["weak/55"].capability_score, 55)
+            self.assertEqual(after["weak/55"].capability_score, 55)
             self.assertEqual(after["strong/80"].capability_score, 80)
             self.assertEqual(
                 after["weak/55"].role_scorecards["implement"]["capability"], 50
             )
             self.assertEqual(after["weak/55"].score_provenance["source"], "manual")
+
+    def test_apply_writes_only_qualified_objective_role_card(self) -> None:
+        import argparse
+
+        from puppetmaster.cli import _run_audit_command
+        from puppetmaster.model_registry import load_registry, save_registry
+        from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
+        from puppetmaster.store import SwarmStore
+
+        with TemporaryDirectory() as tmp:
+            registry_path = Path(tmp) / "models.json"
+            review_card = {"capability": 73, "notes": "preserve unrelated role"}
+            save_registry(
+                [
+                    _spec(
+                        id="weak/55",
+                        adapter="cursor",
+                        adapter_model_name="weak",
+                        capability_score=55,
+                        role_scorecards={"review": review_card},
+                        score_provenance={"source": "manual"},
+                    ),
+                    _spec(
+                        id="strong/80",
+                        adapter="cursor",
+                        adapter_model_name="strong",
+                        capability_score=80,
+                    ),
+                ],
+                registry_path,
+            )
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            store.init()
+            job = store.create_job("objective role-card authority")
+            epoch = {
+                "registry_digest": "registry-a",
+                "classifier_version": "classifier-a",
+                "taxonomy_version": "taxonomy-a",
+                "adapter_version": "cursor-a",
+            }
+            for index in range(6):
+                task = Task(
+                    job_id=job.id,
+                    role="implement",
+                    instruction=f"objective evaluation {index}",
+                    adapter="cursor",
+                    status=TaskStatus.COMPLETE,
+                    payload={
+                        "router_model_id": "weak/55",
+                        "router_capability_needed": 50,
+                        "router_estimated_cost_usd": 0.001,
+                    },
+                )
+                store.save_task(task)
+                store.save_artifact(
+                    Artifact(
+                        job_id=job.id,
+                        task_id=task.id,
+                        type=ArtifactType.ROUTING,
+                        created_by="router",
+                        payload={
+                            "model_id": "weak/55",
+                            "adapter": "cursor",
+                            "policy": "balanced",
+                            "capability_needed": 50,
+                            **epoch,
+                        },
+                        confidence=0.9,
+                        evidence=["routing"],
+                        created_at=f"2026-08-22T12:00:{index:02d}Z",
+                    )
+                )
+                store.save_artifact(
+                    Artifact(
+                        job_id=job.id,
+                        task_id=task.id,
+                        type=ArtifactType.GATE,
+                        created_by="objective-review",
+                        payload={
+                            "gate": "review",
+                            "passed": False,
+                            "review_status": "completed",
+                            "objective_score": 0.0,
+                            "evaluator_revision": "review-v2",
+                        },
+                        confidence=1.0,
+                        evidence=["objective evaluator"],
+                        created_at=f"2026-08-22T12:01:{index:02d}Z",
+                    )
+                )
+
+            args = argparse.Namespace(
+                registry_path=str(registry_path),
+                window=None,
+                apply=True,
+                json=False,
+            )
+            rc = _run_audit_command(args, store)
+
+            self.assertEqual(rc, 0)
+            after = {s.id: s for s in load_registry(registry_path)}
+            weak = after["weak/55"]
+            self.assertEqual(weak.capability_score, 55)
+            self.assertEqual(after["strong/80"].capability_score, 80)
+            self.assertEqual(weak.role_scorecards["review"], review_card)
+            implement = weak.role_scorecards["implement"]
+            self.assertEqual(implement["capability"], 50)
+            self.assertEqual(implement["sample_count"], 6)
+            self.assertEqual(implement["last_calibrated"], "2026-08-22")
+            self.assertEqual(implement["scale"], "puppetmaster-capability-0-100")
+            self.assertEqual(implement["scale_version"], "1")
+            self.assertEqual(implement["provenance"]["source"], "local_audit")
+            self.assertEqual(
+                implement["provenance"]["epoch"],
+                {**epoch, "evaluator_revision": "review-v2"},
+            )
+            self.assertEqual(weak.score_provenance["source"], "manual")
 
 
 if __name__ == "__main__":

--- a/tests/test_router_context_policy.py
+++ b/tests/test_router_context_policy.py
@@ -1,0 +1,415 @@
+"""Adversarial TASK-002 tests for context fit and routing policy semantics.
+
+These tests were authored against the TASK-001-completed baseline before the
+TASK-002 author implementation was inspected.  They intentionally exercise
+public behavior rather than private ranking helpers.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from puppetmaster import router
+from puppetmaster.model_registry import ModelSpec
+
+
+def _model(
+    model_id: str,
+    *,
+    capability: int,
+    input_cost: float,
+    context_window: int = 32_000,
+) -> ModelSpec:
+    """Arrange a deterministic plan-billed candidate without provider probes."""
+    return ModelSpec(
+        id=model_id,
+        adapter="cursor",
+        adapter_model_name=model_id.rsplit("/", 1)[-1],
+        capability_score=capability,
+        input_per_mtok_usd=input_cost,
+        output_per_mtok_usd=input_cost,
+        context_window=context_window,
+        billing="plan",
+    )
+
+
+def test_context_filter_reserves_output_before_selecting_cheapest_model() -> None:
+    # Arrange: input fits the bargain model, but input + output reserve does not.
+    bargain = _model(
+        "cursor/bargain", capability=60, input_cost=0.10, context_window=4_000
+    )
+    roomy = _model(
+        "cursor/roomy", capability=70, input_cost=1.00, context_window=16_000
+    )
+    task = router.TaskSignals(
+        instruction="verify the result",
+        role="verify-runtime",
+        explicit_min_capability=50,
+        estimated_tokens_in=3_000,
+        estimated_tokens_out=1_500,
+    )
+
+    # Act.
+    decision = router.route_task(task, [bargain, roomy], policy="cheap")
+
+    # Assert: the overflowing bargain model never reaches policy ranking.
+    assert decision.model.id == "cursor/roomy"
+    rejected_reason = dict((spec.id, why) for spec, why in decision.rejected)
+    assert "context" in rejected_reason["cursor/bargain"].lower()
+    assert "3000" in rejected_reason["cursor/bargain"]
+    assert "1500" in rejected_reason["cursor/bargain"]
+    assert "4000" in rejected_reason["cursor/bargain"]
+
+
+def test_context_filter_fails_when_every_known_window_overflows() -> None:
+    # Arrange.
+    task = router.TaskSignals(
+        instruction="verify the result",
+        role="verify-runtime",
+        explicit_min_capability=20,
+        estimated_tokens_in=3_500,
+        estimated_tokens_out=1_000,
+    )
+    models = [
+        _model("cursor/a", capability=50, input_cost=0.10, context_window=4_000),
+        _model("cursor/b", capability=90, input_cost=1.00, context_window=4_499),
+    ]
+
+    # Act / Assert.
+    with pytest.raises(router.NoEligibleModelError, match="(?i)context"):
+        router.route_task(task, models, policy="balanced")
+
+
+@pytest.mark.parametrize(
+    ("field_name", "invalid_value"),
+    [
+        pytest.param("estimated_tokens_in", -1, id="negative-input"),
+        pytest.param("estimated_tokens_in", True, id="boolean-input"),
+        pytest.param("estimated_tokens_in", 1.5, id="non-integer-input"),
+        pytest.param("estimated_tokens_in", "1000", id="malformed-input"),
+        pytest.param("estimated_tokens_out", -1, id="negative-output"),
+        pytest.param("estimated_tokens_out", False, id="boolean-output"),
+        pytest.param("estimated_tokens_out", 1.5, id="non-integer-output"),
+        pytest.param("estimated_tokens_out", "200", id="malformed-output"),
+    ],
+)
+def test_explicit_token_estimates_fail_closed_when_invalid(
+    field_name: str, invalid_value: object
+) -> None:
+    # Arrange: a deliberately small window would become falsely eligible if an
+    # invalid override were clamped, bool-coerced, truncated, or subtracted.
+    task_values = {
+        "instruction": "verify the result",
+        "role": "verify-runtime",
+        "explicit_min_capability": 20,
+        "estimated_tokens_in": 900,
+        "estimated_tokens_out": 200,
+    }
+    task_values[field_name] = invalid_value
+    task = router.TaskSignals(**task_values)
+    model = _model(
+        "cursor/small-window",
+        capability=60,
+        input_cost=0.10,
+        context_window=1_000,
+    )
+
+    # Act / Assert: malformed authority must fail before context or cost math.
+    with pytest.raises(ValueError, match=field_name):
+        router.route_task(task, [model], policy="balanced")
+
+
+def test_worker_signals_count_nested_payload_and_declared_enrichment() -> None:
+    # Arrange: almost all context is below the payload's top level.
+    nested_text = "nested repository context " * 400
+    spec = SimpleNamespace(
+        instruction="inspect",
+        role="explore",
+        payload={
+            "context": {
+                "documents": [
+                    {"body": nested_text},
+                    ("secondary context", {"notes": "more evidence"}),
+                ]
+            },
+            "adapter_enrichment_tokens": 1_200,
+        },
+    )
+
+    # Act.
+    signals = router.signals_from_worker_spec(spec)
+    estimate = router.estimate_tokens_in(signals)
+
+    # Assert: recursive payload context and explicit adapter overhead both count.
+    assert signals.payload_size_chars >= len(nested_text)
+    assert signals.adapter_enrichment_tokens == 1_200
+    un_enriched_floor = max(
+        500,
+        (len(spec.instruction) + signals.payload_size_chars) // 4 + 500,
+    )
+    assert estimate >= un_enriched_floor + 1_200
+
+
+def test_measured_calibration_is_explicit_attributable_and_policy_neutral() -> None:
+    # Arrange: three measurements establish a stable 2x estimate/actual drift.
+    measurements = [
+        {"estimated_tokens_in": 1_000, "actual_tokens_in": 2_000},
+        {"estimated_tokens_in": 2_000, "actual_tokens_in": 4_000},
+        {"estimated_tokens_in": 3_000, "actual_tokens_in": 6_000},
+    ]
+    calibration = router.calibration_from_measurements(
+        measurements,
+        adapter="cursor",
+        model_id="cursor/calibrated",
+        role="verify-runtime",
+        source="measured_usage",
+    )
+    task = router.TaskSignals(
+        instruction="verify",
+        role="verify-runtime",
+        estimated_tokens_in=1_000,
+        estimated_tokens_out=200,
+    )
+    model = _model(
+        "cursor/calibrated", capability=60, input_cost=0.10, context_window=8_000
+    )
+
+    # Act.
+    calibrated_estimate = router.estimate_tokens_in(task, calibration=calibration)
+    decision = router.route_task(
+        task,
+        [model],
+        policy="cheap",
+        calibration=calibration,
+    )
+    payload = decision.to_artifact_payload()
+
+    # Assert: measured data changes only the explicit estimate, not policy.
+    assert calibration.multiplier == pytest.approx(2.0)
+    assert calibration.sample_count == 3
+    assert calibrated_estimate == 2_000
+    assert decision.estimated_tokens_in == 2_000
+    assert decision.policy == "cheap"
+    assert payload["token_estimate_calibration"] == {
+        "adapter": "cursor",
+        "model_id": "cursor/calibrated",
+        "canonical_role": "verify-runtime",
+        "source": "measured_usage",
+        "sample_count": 3,
+        "multiplier": 2.0,
+    }
+
+
+def test_model_scoped_calibration_does_not_distort_other_candidates() -> None:
+    # Arrange: only cursor/calibrated has measured 2x drift. Its calibrated
+    # request overflows, while the uncalibrated alternative safely fits its
+    # own smaller window at the base estimate.
+    calibration = router.calibration_from_measurements(
+        [
+            {"estimated_tokens_in": 1_000, "actual_tokens_in": 2_000},
+            {"estimated_tokens_in": 2_000, "actual_tokens_in": 4_000},
+        ],
+        adapter="cursor",
+        model_id="cursor/calibrated",
+        role="verify-runtime",
+        source="measured_usage",
+    )
+    task = router.TaskSignals(
+        instruction="verify",
+        role="verify-runtime",
+        explicit_min_capability=40,
+        estimated_tokens_in=1_000,
+        estimated_tokens_out=200,
+    )
+    calibrated = _model(
+        "cursor/calibrated", capability=60, input_cost=0.01, context_window=1_900
+    )
+    uncalibrated = _model(
+        "cursor/uncalibrated", capability=60, input_cost=0.10, context_window=1_500
+    )
+
+    # Act.
+    decision = router.route_task(
+        task,
+        [calibrated, uncalibrated],
+        policy="cheap",
+        calibration=calibration,
+    )
+
+    # Assert: model-scoped evidence applies only to its named model. Applying
+    # 2x globally would incorrectly reject the safe uncalibrated alternative.
+    assert decision.model.id == "cursor/uncalibrated"
+    assert decision.estimated_tokens_in == 1_000
+    assert "token_estimate_calibration" not in decision.to_artifact_payload()
+
+
+def test_cheap_selects_cheapest_sufficient_model() -> None:
+    # Arrange.
+    task = router.TaskSignals(
+        instruction="perform the bounded task",
+        role="verify-runtime",
+        explicit_min_capability=70,
+        estimated_tokens_in=1_000,
+        estimated_tokens_out=200,
+    )
+    bargain_but_weak = _model(
+        "cursor/weak", capability=40, input_cost=0.01
+    )
+    cheapest_sufficient = _model(
+        "cursor/sufficient", capability=75, input_cost=0.10
+    )
+    costly_frontier = _model(
+        "cursor/frontier", capability=95, input_cost=1.00
+    )
+
+    # Act.
+    decision = router.route_task(
+        task,
+        [bargain_but_weak, cheapest_sufficient, costly_frontier],
+        policy="cheap",
+    )
+
+    # Assert.
+    assert decision.model.id == "cursor/sufficient"
+    assert "cheapest sufficient" in decision.reason.lower()
+    rejected_reason = dict((spec.id, why) for spec, why in decision.rejected)
+    assert "capability" in rejected_reason["cursor/weak"].lower()
+
+
+def test_absolute_cheapest_requires_explicit_policy_opt_in() -> None:
+    # Arrange.
+    task = router.TaskSignals(
+        instruction="perform the bounded task",
+        role="verify-runtime",
+        explicit_min_capability=70,
+        estimated_tokens_in=1_000,
+        estimated_tokens_out=200,
+    )
+    weak = _model("cursor/weak", capability=40, input_cost=0.01)
+    sufficient = _model("cursor/sufficient", capability=75, input_cost=0.10)
+
+    # Act.
+    decision = router.route_task(
+        task, [weak, sufficient], policy="absolute-cheapest"
+    )
+
+    # Assert.
+    assert decision.model.id == "cursor/weak"
+    assert decision.policy == "absolute-cheapest"
+    assert "absolute" in decision.reason.lower()
+
+
+def test_absolute_cheapest_is_reachable_through_every_cli_policy_flag() -> None:
+    # Arrange: inspect the parser's public policy choices recursively, including
+    # direct adapters, edit, swarm, browser, and the route dry-run command.
+    from puppetmaster.cli._parser import build_parser
+
+    parser = build_parser()
+    policy_actions = []
+    pending = [parser]
+    seen = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        for action in current._actions:
+            if action.dest in {"policy", "routing_policy"} and action.choices:
+                policy_actions.append(action)
+            choices = getattr(action, "choices", None)
+            if isinstance(choices, dict):
+                pending.extend(choices.values())
+
+    # Act / Assert: an internal router policy is not an available user opt-in
+    # while any public routing flag rejects it at argument parsing.
+    assert policy_actions
+    missing = [action.dest for action in policy_actions if "absolute-cheapest" not in action.choices]
+    assert missing == []
+
+
+def test_absolute_cheapest_is_reachable_through_every_mcp_policy_enum() -> None:
+    # Arrange: exercise every public MCP schema family with a routing policy.
+    from puppetmaster import mcp_server
+
+    schemas = {
+        "route_task": mcp_server.route_task_schema(),
+        "auto_route": {"properties": mcp_server._auto_route_schema_properties()},
+        "swarm": mcp_server.swarm_schema(),
+        "cursor_swarm": mcp_server.cursor_swarm_schema(),
+        "codex": mcp_server.codex_schema(),
+        "claude": mcp_server.claude_schema(),
+        "cursor_implement": mcp_server.cursor_implement_schema(),
+        "implement": mcp_server.implement_schema(),
+        "edit": mcp_server.edit_schema(),
+        "browser_swarm": mcp_server.browser_swarm_schema(),
+        "agentic": mcp_server.agentic_schema(),
+        "openai": mcp_server.openai_schema(),
+    }
+
+    # Act: collect each schema property whose public name denotes routing
+    # policy; recurse because some tool schemas compose nested definitions.
+    found = []
+
+    def visit(value, schema_name: str) -> None:
+        if isinstance(value, dict):
+            properties = value.get("properties")
+            if isinstance(properties, dict):
+                for property_name in ("policy", "routing_policy"):
+                    property_schema = properties.get(property_name)
+                    if isinstance(property_schema, dict) and "enum" in property_schema:
+                        found.append((schema_name, property_name, property_schema["enum"]))
+            for child in value.values():
+                visit(child, schema_name)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child, schema_name)
+
+    for name, schema in schemas.items():
+        visit(schema, name)
+
+    # Assert.
+    assert found
+    missing = [f"{name}.{property_name}" for name, property_name, enum in found if "absolute-cheapest" not in enum]
+    assert missing == []
+
+
+def test_strict_capability_fails_closed_when_catalog_is_insufficient() -> None:
+    # Arrange.
+    task = router.TaskSignals(
+        instruction="perform the critical task",
+        role="verify-runtime",
+        explicit_min_capability=95,
+        strict_capability=True,
+        estimated_tokens_in=1_000,
+        estimated_tokens_out=200,
+    )
+    models = [
+        _model("cursor/mid", capability=60, input_cost=0.10),
+        _model("cursor/best", capability=85, input_cost=1.00),
+    ]
+
+    # Act / Assert.
+    with pytest.raises(router.NoEligibleModelError, match="(?i)capability.*95"):
+        router.route_task(task, models, policy="balanced")
+
+
+def test_non_strict_balanced_fallback_remains_explicit_and_compatible() -> None:
+    # Arrange.
+    task = router.TaskSignals(
+        instruction="perform the task",
+        role="verify-runtime",
+        explicit_min_capability=95,
+        estimated_tokens_in=1_000,
+        estimated_tokens_out=200,
+    )
+    models = [
+        _model("cursor/mid", capability=60, input_cost=0.10),
+        _model("cursor/best", capability=85, input_cost=1.00),
+    ]
+
+    # Act.
+    decision = router.route_task(task, models, policy="balanced")
+
+    # Assert.
+    assert decision.model.id == "cursor/best"
+    assert "no model meets capability need (95)" in decision.reason.lower()
+    assert "falling back" in decision.reason.lower()

--- a/tests/test_routing_audit_quality.py
+++ b/tests/test_routing_audit_quality.py
@@ -1,0 +1,1062 @@
+"""Focused adversarial contract for objective, epoch-aware routing audit.
+
+These tests intentionally exercise only TASK-006.  They preserve the public
+legacy ``TaskAuditRecord`` construction shape while requiring newly collected
+evidence to remain attributable and qualified before it affects routing.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import date
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+
+def _legacy_record(model_id: str, *, role: str = "implement", **overrides):
+    from puppetmaster.audit import TaskAuditRecord
+
+    values = {
+        "model_id": model_id,
+        "adapter": "cursor",
+        "capability_needed": 60,
+        "est_cost_usd": 0.01,
+        "confidence": 0.9,
+        "escalated": False,
+        "escalated_from": None,
+        "fell_back": False,
+        "role": role,
+    }
+    values.update(overrides)
+    return TaskAuditRecord(**values)
+
+
+def _save_routed_task_with_reroute(*, reroute_created_by: str, reroute_payload: dict):
+    from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
+    from puppetmaster.store import SwarmStore
+
+    root = TemporaryDirectory()
+    store = SwarmStore(Path(root.name) / ".puppetmaster")
+    store.init()
+    job = store.create_job("attribute the rejected model")
+    task = Task(
+        job_id=job.id,
+        role="review",
+        instruction="review the patch",
+        adapter="cursor",
+        status=TaskStatus.COMPLETE,
+        payload={
+            "router_model_id": "cursor/strong",
+            "router_capability_needed": 70,
+            "router_estimated_cost_usd": 0.02,
+        },
+    )
+    store.save_task(task)
+    store.save_artifact(
+        Artifact(
+            job_id=job.id,
+            task_id=task.id,
+            type=ArtifactType.ROUTING,
+            created_by="router",
+            payload={
+                "model_id": "cursor/weak",
+                "adapter": "cursor",
+                "policy": "balanced",
+                "capability_needed": 60,
+            },
+            confidence=0.9,
+            evidence=["role:review"],
+            created_at="2026-08-22T12:00:00Z",
+        )
+    )
+    store.save_artifact(
+        Artifact(
+            job_id=job.id,
+            task_id=task.id,
+            type=ArtifactType.ROUTING,
+            created_by=reroute_created_by,
+            payload={
+                "model_id": "cursor/strong",
+                "adapter": "cursor",
+                "policy": "balanced",
+                **reroute_payload,
+            },
+            confidence=0.9,
+            evidence=["rerouted"],
+            created_at="2026-08-22T12:01:00Z",
+        )
+    )
+    store.save_artifact(
+        Artifact(
+            job_id=job.id,
+            task_id=task.id,
+            type=ArtifactType.VERIFICATION,
+            created_by="strong-worker",
+            payload={"check": "review", "result": "passed"},
+            confidence=0.95,
+            evidence=["test"],
+            created_at="2026-08-22T12:02:00Z",
+        )
+    )
+    return root, store
+
+
+def test_ordinary_fallback_is_attributed_to_the_rejected_model() -> None:
+    # Arrange
+    from puppetmaster.audit import build_audit_report, collect_records
+
+    root, store = _save_routed_task_with_reroute(
+        reroute_created_by="router-fallback",
+        reroute_payload={
+            "fallback_from_model": "cursor/weak",
+            "fallback_reason": "model_unavailable",
+        },
+    )
+
+    try:
+        # Act
+        records, _ = collect_records(store)
+        report = build_audit_report(
+            records, {"cursor/weak": 55, "cursor/strong": 85}
+        )
+
+        # Assert
+        assert records[0].fallback_from == "cursor/weak"
+        weak = next(model for model in report.models if model.model_id == "cursor/weak")
+        assert weak.fell_back_away == 1
+    finally:
+        root.cleanup()
+
+
+def test_review_escalation_is_attributed_to_the_review_rejected_model() -> None:
+    # Arrange
+    from puppetmaster.audit import build_audit_report, collect_records
+
+    root, store = _save_routed_task_with_reroute(
+        reroute_created_by="router-review-escalation",
+        reroute_payload={"review_escalated_from_model": "cursor/weak"},
+    )
+
+    try:
+        # Act
+        records, _ = collect_records(store)
+        report = build_audit_report(
+            records, {"cursor/weak": 55, "cursor/strong": 85}
+        )
+
+        # Assert
+        assert records[0].review_escalated_from == "cursor/weak"
+        weak = next(model for model in report.models if model.model_id == "cursor/weak")
+        assert weak.review_escalated_away == 1
+    finally:
+        root.cleanup()
+
+
+def test_two_step_fallback_attributes_every_rejected_model() -> None:
+    # Arrange: weak fails over to mid, then mid fails over to strong. A single
+    # latest fallback_from field must not erase the first rejected producer.
+    from puppetmaster.audit import build_audit_report, collect_records
+    from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
+    from puppetmaster.store import SwarmStore
+
+    with TemporaryDirectory() as tmp:
+        store = SwarmStore(Path(tmp) / ".puppetmaster")
+        store.init()
+        job = store.create_job("retain every fallback hop")
+        task = Task(
+            job_id=job.id,
+            role="implement",
+            instruction="implement with fallbacks",
+            adapter="cursor",
+            status=TaskStatus.COMPLETE,
+            payload={"router_model_id": "cursor/strong"},
+        )
+        store.save_task(task)
+        for created_by, created_at, payload in (
+            (
+                "router",
+                "2026-08-22T12:00:00Z",
+                {"model_id": "cursor/weak", "policy": "balanced"},
+            ),
+            (
+                "router-fallback",
+                "2026-08-22T12:01:00Z",
+                {
+                    "model_id": "cursor/mid",
+                    "policy": "balanced",
+                    "fallback_from_model": "cursor/weak",
+                },
+            ),
+            (
+                "router-fallback",
+                "2026-08-22T12:02:00Z",
+                {
+                    "model_id": "cursor/strong",
+                    "policy": "balanced",
+                    "fallback_from_model": "cursor/mid",
+                },
+            ),
+        ):
+            store.save_artifact(
+                Artifact(
+                    job_id=job.id,
+                    task_id=task.id,
+                    type=ArtifactType.ROUTING,
+                    created_by=created_by,
+                    payload={"adapter": "cursor", **payload},
+                    confidence=0.9,
+                    evidence=[created_by],
+                    created_at=created_at,
+                )
+            )
+
+        # Act
+        records, _ = collect_records(store)
+        report = build_audit_report(
+            records,
+            {"cursor/weak": 50, "cursor/mid": 65, "cursor/strong": 85},
+        )
+
+    # Assert
+    by_model = {model.model_id: model for model in report.models}
+    assert by_model["cursor/weak"].fell_back_away == 1
+    assert by_model["cursor/mid"].fell_back_away == 1
+    assert by_model["cursor/strong"].fell_back_away == 0
+
+
+def test_two_step_review_escalation_attributes_every_rejected_model() -> None:
+    # Arrange: weak and mid each fail completed objective review before strong
+    # passes. Both rejected producers must retain review-escalation attribution.
+    from puppetmaster.audit import build_audit_report, collect_records
+    from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
+    from puppetmaster.store import SwarmStore
+
+    with TemporaryDirectory() as tmp:
+        store = SwarmStore(Path(tmp) / ".puppetmaster")
+        store.init()
+        job = store.create_job("retain every review escalation hop")
+        task = Task(
+            job_id=job.id,
+            role="review",
+            instruction="review through multiple producers",
+            adapter="cursor",
+            status=TaskStatus.COMPLETE,
+            payload={"router_model_id": "cursor/strong"},
+        )
+        store.save_task(task)
+        epoch = {
+            "registry_digest": "registry-a",
+            "classifier_version": "classifier-a",
+            "taxonomy_version": "taxonomy-a",
+            "adapter_version": "cursor-a",
+        }
+        events = (
+            (
+                ArtifactType.ROUTING,
+                "router",
+                "2026-08-22T13:00:00Z",
+                {
+                    "model_id": "cursor/weak",
+                    "adapter": "cursor",
+                    "policy": "balanced",
+                    **epoch,
+                },
+            ),
+            (
+                ArtifactType.GATE,
+                "review-gate",
+                "2026-08-22T13:00:10Z",
+                {
+                    "gate": "review",
+                    "passed": False,
+                    "review_status": "completed",
+                    "objective_score": 0.0,
+                    "evaluator_revision": "review-v2",
+                },
+            ),
+            (
+                ArtifactType.ROUTING,
+                "router-review-escalation",
+                "2026-08-22T13:00:20Z",
+                {
+                    "model_id": "cursor/mid",
+                    "adapter": "cursor",
+                    "policy": "quality",
+                    "review_escalated_from_model": "cursor/weak",
+                    **epoch,
+                },
+            ),
+            (
+                ArtifactType.GATE,
+                "review-gate",
+                "2026-08-22T13:00:30Z",
+                {
+                    "gate": "review",
+                    "passed": False,
+                    "review_status": "completed",
+                    "objective_score": 0.0,
+                    "evaluator_revision": "review-v2",
+                },
+            ),
+            (
+                ArtifactType.ROUTING,
+                "router-review-escalation",
+                "2026-08-22T13:00:40Z",
+                {
+                    "model_id": "cursor/strong",
+                    "adapter": "cursor",
+                    "policy": "quality",
+                    "review_escalated_from_model": "cursor/mid",
+                    **epoch,
+                },
+            ),
+            (
+                ArtifactType.GATE,
+                "review-gate",
+                "2026-08-22T13:00:50Z",
+                {
+                    "gate": "review",
+                    "passed": True,
+                    "review_status": "completed",
+                    "objective_score": 1.0,
+                    "evaluator_revision": "review-v2",
+                },
+            ),
+        )
+        for artifact_type, created_by, created_at, payload in events:
+            store.save_artifact(
+                Artifact(
+                    job_id=job.id,
+                    task_id=task.id,
+                    type=artifact_type,
+                    created_by=created_by,
+                    payload=payload,
+                    confidence=1.0,
+                    evidence=[created_by],
+                    created_at=created_at,
+                )
+            )
+
+        # Act
+        records, _ = collect_records(store)
+        report = build_audit_report(
+            records,
+            {"cursor/weak": 50, "cursor/mid": 65, "cursor/strong": 85},
+        )
+
+    # Assert
+    by_model = {model.model_id: model for model in report.models}
+    assert by_model["cursor/weak"].review_escalated_away == 1
+    assert by_model["cursor/mid"].review_escalated_away == 1
+    assert by_model["cursor/strong"].review_escalated_away == 0
+    assert by_model["cursor/weak"].runs_with_objective_outcomes == 1
+    assert by_model["cursor/mid"].runs_with_objective_outcomes == 1
+    assert by_model["cursor/strong"].runs_with_objective_outcomes == 1
+
+
+def test_review_rejection_outcome_survives_later_successful_escalated_review() -> None:
+    # Arrange: each task first fails objective review on weak, escalates, and
+    # later passes objective review on strong. The later success must not erase
+    # the rejected producer's outcome from the audit.
+    from puppetmaster.audit import build_audit_report, collect_records
+    from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
+    from puppetmaster.store import SwarmStore
+
+    with TemporaryDirectory() as tmp:
+        store = SwarmStore(Path(tmp) / ".puppetmaster")
+        store.init()
+        job = store.create_job("retain rejected review outcomes")
+        for index in range(5):
+            task = Task(
+                job_id=job.id,
+                role="review",
+                instruction=f"review patch {index}",
+                adapter="cursor",
+                status=TaskStatus.COMPLETE,
+                payload={
+                    "router_model_id": "cursor/strong",
+                    "router_capability_needed": 70,
+                },
+            )
+            store.save_task(task)
+            common_epoch = {
+                "registry_digest": "registry-a",
+                "taxonomy_version": "taxonomy-a",
+                "classifier_version": "classifier-a",
+                "adapter_version": "cursor-a",
+            }
+            store.save_artifact(
+                Artifact(
+                    job_id=job.id,
+                    task_id=task.id,
+                    type=ArtifactType.ROUTING,
+                    created_by="router",
+                    payload={
+                        "model_id": "cursor/weak",
+                        "adapter": "cursor",
+                        "policy": "balanced",
+                        "predicted_quality": 0.9,
+                        **common_epoch,
+                    },
+                    confidence=0.9,
+                    evidence=["initial"],
+                    created_at=f"2026-08-22T12:{index:02d}:00Z",
+                )
+            )
+            store.save_artifact(
+                Artifact(
+                    job_id=job.id,
+                    task_id=task.id,
+                    type=ArtifactType.GATE,
+                    created_by="review-gate",
+                    payload={
+                        "gate": "review",
+                        "passed": False,
+                        "objective_score": 0.0,
+                        "evaluator_revision": "review-v2",
+                        "review_status": "completed",
+                    },
+                    confidence=1.0,
+                    evidence=["weak-review"],
+                    created_at=f"2026-08-22T12:{index:02d}:10Z",
+                )
+            )
+            store.save_artifact(
+                Artifact(
+                    job_id=job.id,
+                    task_id=task.id,
+                    type=ArtifactType.ROUTING,
+                    created_by="router-review-escalation",
+                    payload={
+                        "model_id": "cursor/strong",
+                        "adapter": "cursor",
+                        "policy": "quality",
+                        "review_escalated_from_model": "cursor/weak",
+                        "predicted_quality": 0.98,
+                        **common_epoch,
+                    },
+                    confidence=0.9,
+                    evidence=["review-escalation"],
+                    created_at=f"2026-08-22T12:{index:02d}:20Z",
+                )
+            )
+            store.save_artifact(
+                Artifact(
+                    job_id=job.id,
+                    task_id=task.id,
+                    type=ArtifactType.GATE,
+                    created_by="review-gate",
+                    payload={
+                        "gate": "review",
+                        "passed": True,
+                        "objective_score": 1.0,
+                        "evaluator_revision": "review-v2",
+                        "review_status": "completed",
+                    },
+                    confidence=1.0,
+                    evidence=["strong-review"],
+                    created_at=f"2026-08-22T12:{index:02d}:30Z",
+                )
+            )
+
+        # Act
+        records, _ = collect_records(store)
+        report = build_audit_report(
+            records, {"cursor/weak": 55, "cursor/strong": 85}, min_sample=5
+        )
+
+    # Assert: both producer outcomes remain auditable, and only the weak review
+    # role is recommended for adjustment.
+    weak = next(model for model in report.models if model.model_id == "cursor/weak")
+    strong = next(model for model in report.models if model.model_id == "cursor/strong")
+    assert weak.runs_with_objective_outcomes == 5
+    assert weak.objective_pass_rate == pytest.approx(0.0)
+    assert strong.runs_with_objective_outcomes == 5
+    assert strong.objective_pass_rate == pytest.approx(1.0)
+    assert [
+        (item["model_id"], item["role"])
+        for item in report.role_scorecard_suggestions
+    ] == [("cursor/weak", "review")]
+    assert report.role_scorecard_suggestions[0]["last_calibrated"] == "2026-08-22"
+
+
+def test_collector_compares_predicted_quality_with_objective_evaluator_evidence() -> None:
+    # Arrange
+    from puppetmaster.audit import collect_records
+    from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
+    from puppetmaster.store import SwarmStore
+
+    with TemporaryDirectory() as tmp:
+        store = SwarmStore(Path(tmp) / ".puppetmaster")
+        store.init()
+        job = store.create_job("compare prediction to evaluator")
+        task = Task(
+            job_id=job.id,
+            role="audit",
+            instruction="audit the result",
+            adapter="cursor",
+            status=TaskStatus.COMPLETE,
+            payload={
+                "router_model_id": "cursor/model",
+                "router_capability_needed": 70,
+            },
+        )
+        store.save_task(task)
+        store.save_artifact(
+            Artifact(
+                job_id=job.id,
+                task_id=task.id,
+                type=ArtifactType.ROUTING,
+                created_by="router",
+                payload={
+                    "model_id": "cursor/model",
+                    "adapter": "cursor",
+                    "policy": "balanced",
+                    "predicted_quality": 0.95,
+                    "registry_digest": "registry-a",
+                    "taxonomy_version": "taxonomy-a",
+                    "adapter_version": "cursor-a",
+                },
+                confidence=0.9,
+                evidence=["policy:balanced"],
+            )
+        )
+        store.save_artifact(
+            Artifact(
+                job_id=job.id,
+                task_id=task.id,
+                type=ArtifactType.GATE,
+                created_by="review-gate",
+                payload={
+                    "gate": "review",
+                    "passed": False,
+                    "objective_score": 0.2,
+                    "evaluator_revision": "review-v2",
+                    "reviewed_artifact_fingerprint": "sha256:artifact-a",
+                },
+                confidence=1.0,
+                evidence=["evaluator:review-v2"],
+            )
+        )
+        store.save_artifact(
+            Artifact(
+                job_id=job.id,
+                task_id=task.id,
+                type=ArtifactType.VERIFICATION,
+                created_by="self-reporting-worker",
+                payload={"check": "self", "result": "passed"},
+                confidence=0.99,
+                evidence=["self-report"],
+            )
+        )
+
+        # Act
+        records, _ = collect_records(store)
+
+    # Assert: objective failure is retained even though the model was highly
+    # self-confident and its own verification called the work passed.
+    record = records[0]
+    assert record.predicted_quality == pytest.approx(0.95)
+    assert record.objective_quality == pytest.approx(0.2)
+    assert record.objective_passed is False
+    assert record.confidence == pytest.approx(0.99)
+    assert record.evaluator_revision == "review-v2"
+    assert record.registry_digest == "registry-a"
+    assert record.taxonomy_version == "taxonomy-a"
+    assert record.adapter_version == "cursor-a"
+
+
+def test_unavailable_review_is_not_recorded_as_an_objective_evaluator_outcome() -> None:
+    # Arrange
+    from puppetmaster.audit import collect_records
+    from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
+    from puppetmaster.quality import assess_run_quality
+    from puppetmaster.store import SwarmStore
+
+    with TemporaryDirectory() as tmp:
+        store = SwarmStore(Path(tmp) / ".puppetmaster")
+        store.init()
+        job = store.create_job("review unavailable")
+        task = Task(
+            job_id=job.id,
+            role="review",
+            instruction="review",
+            adapter="cursor",
+            status=TaskStatus.FAILED,
+            payload={"router_model_id": "cursor/model"},
+        )
+        store.save_task(task)
+        store.save_artifact(
+            Artifact(
+                job_id=job.id,
+                task_id=task.id,
+                type=ArtifactType.ROUTING,
+                created_by="router",
+                payload={
+                    "model_id": "cursor/model",
+                    "adapter": "cursor",
+                    "policy": "balanced",
+                },
+                confidence=0.9,
+                evidence=["route"],
+            )
+        )
+        unavailable = Artifact(
+            job_id=job.id,
+            task_id=task.id,
+            type=ArtifactType.GATE,
+            created_by="review-gate",
+            payload={
+                "gate": "review",
+                "passed": False,
+                "review_status": "unavailable",
+                "evaluator_revision": "review-v2",
+                "reviewed_artifact_fingerprint": "sha256:artifact-a",
+            },
+            confidence=1.0,
+            evidence=["no-judge"],
+        )
+        store.save_artifact(unavailable)
+
+        # Act
+        records, _ = collect_records(store)
+        quality = assess_run_quality([unavailable])
+
+    # Assert
+    assert records[0].objective_passed is None
+    assert records[0].objective_quality is None
+    assert quality["semantic_quality"] == "not_evaluated"
+    assert quality["objective_evaluations"] == 0
+
+
+def test_failed_objective_evaluation_keeps_objective_trust_basis() -> None:
+    # Arrange
+    from puppetmaster.models import Artifact, ArtifactType
+    from puppetmaster.quality import assess_run_quality
+
+    gate = Artifact(
+        job_id="job-quality",
+        task_id="task-quality",
+        type=ArtifactType.GATE,
+        created_by="review-gate",
+        payload={
+            "gate": "review",
+            "passed": False,
+            "review_status": "completed",
+            "objective_score": 0.0,
+            "evaluator_revision": "review-v2",
+        },
+        confidence=1.0,
+        evidence=["objective-review"],
+    )
+
+    # Act
+    quality = assess_run_quality([gate])
+
+    # Assert
+    assert quality["semantic_quality"] == "failed"
+    assert quality["objective_evaluations"] == 1
+    assert quality["trust_basis"] == "objective_evaluator"
+
+
+def _objective_record(*, role: str, passed: bool, **epoch):
+    return _legacy_record(
+        "cursor/model",
+        role=role,
+        confidence=0.99,
+        verification_result="passed",
+        gate_passed=passed,
+        predicted_quality=0.95,
+        objective_quality=1.0 if passed else 0.0,
+        objective_passed=passed,
+        **epoch,
+    )
+
+
+def test_objective_failures_drive_only_the_underperforming_role_recommendation() -> None:
+    # Arrange: the same model objectively fails audit work while objectively
+    # passing implementation work; self-confidence is 0.99 in both roles.
+    from puppetmaster.audit import build_audit_report
+
+    epoch = {
+        "registry_digest": "registry-a",
+        "taxonomy_version": "taxonomy-a",
+        "adapter_version": "cursor-a",
+        "evaluator_revision": "eval-a",
+        "evaluated_at": "2026-08-22T12:00:00Z",
+    }
+    records = [
+        *[_objective_record(role="audit", passed=False, **epoch) for _ in range(5)],
+        *[_objective_record(role="implement", passed=True, **epoch) for _ in range(5)],
+    ]
+
+    # Act
+    report = build_audit_report(records, {"cursor/model": 80}, min_sample=5)
+
+    # Assert
+    model = next(item for item in report.models if item.model_id == "cursor/model")
+    assert model.runs_with_objective_outcomes == 10
+    assert model.objective_pass_rate == pytest.approx(0.5)
+    assert model.mean_predicted_quality == pytest.approx(0.95)
+    assert model.mean_objective_quality == pytest.approx(0.5)
+    assert model.suggested_score is None
+    assert report.suggestions == []
+    assert [item["role"] for item in report.role_scorecard_suggestions] == ["audit"]
+    assert report.role_scorecard_suggestions[0]["model_id"] == "cursor/model"
+
+
+def _model_with_card(card: dict):
+    from puppetmaster.model_registry import ModelSpec
+
+    return ModelSpec(
+        id="cursor/card-model",
+        adapter="cursor",
+        adapter_model_name="card-model",
+        capability_score=50,
+        role_scorecards={"audit": card},
+    )
+
+
+def _qualified_card() -> dict:
+    return {
+        "capability": 85,
+        "sample_count": 20,
+        "last_calibrated": date.today().isoformat(),
+        "scale": "puppetmaster-capability-0-100",
+        "scale_version": "1",
+        "provenance": {
+            "source": "paired_evaluation",
+            "version": "eval-v1",
+        },
+    }
+
+
+def test_fully_qualified_role_card_affects_effective_capability() -> None:
+    # Arrange
+    from puppetmaster.scorecards import effective_capability_score
+
+    spec = _model_with_card(_qualified_card())
+
+    # Act
+    score = effective_capability_score(spec, "audit")
+
+    # Assert
+    assert score == 85
+
+
+def test_swebench_card_producer_emits_qualified_routing_authority() -> None:
+    # Arrange: the shipped benchmark importer is an existing role-card producer.
+    # New qualification rules must stamp its cards rather than silently making
+    # a successfully imported benchmark card inert.
+    from puppetmaster.model_registry import ModelSpec
+    from puppetmaster.scorecards import (
+        effective_capability_score,
+        import_community_baseline,
+    )
+    from puppetmaster.swebench_baseline import (
+        RegistryModelMapping,
+        build_swebench_bash_only_bundle,
+    )
+
+    rows = []
+    for index, resolved in enumerate((20.0, 40.0, 60.0, 80.0, 90.0), start=1):
+        rows.append(
+            {
+                "agent": "mini-SWE-agent",
+                "name": f"Model {index}",
+                "model_display": f"Model {index}",
+                "mini-swe-agent_version": "2.0.0",
+                "resolved": resolved,
+                "date": date.today().isoformat(),
+                "per_instance_details": {
+                    f"task-{index}-{sample}": {"resolved": sample % 2 == 0}
+                    for sample in range(10)
+                },
+            }
+        )
+    bundle = build_swebench_bash_only_bundle(
+        {"leaderboards": [{"name": "bash-only", "results": rows}]},
+        mappings=[
+            RegistryModelMapping(
+                "codex/model-3", "codex", "model-3", "Model 3"
+            )
+        ],
+        source_revision="abc123",
+        published=date.today().isoformat(),
+    )
+    spec = ModelSpec(
+        id="codex/model-3",
+        adapter="codex",
+        adapter_model_name="model-3",
+        capability_score=97,
+    )
+
+    # Act
+    imported, _ = import_community_baseline([spec], bundle)
+    card = imported[0].role_scorecards["implement"]
+    effective = effective_capability_score(imported[0], "implement")
+
+    # Assert
+    assert card["scale"] == "puppetmaster-capability-0-100"
+    assert card["scale_version"]
+    assert card["provenance"]["source"] == "community_benchmark"
+    assert card["provenance"]["version"]
+    assert effective == card["capability"]
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda card: card.update(provenance={}), id="missing-provenance"),
+        pytest.param(lambda card: card.update(sample_count=4), id="too-few-samples"),
+        pytest.param(lambda card: card.pop("scale"), id="missing-scale"),
+        pytest.param(lambda card: card.pop("scale_version"), id="missing-scale-version"),
+        pytest.param(
+            lambda card: card.update(last_calibrated="2000-01-01"),
+            id="stale-calibration",
+        ),
+    ],
+)
+def test_unqualified_role_card_falls_back_to_manual_capability(mutate) -> None:
+    # Arrange
+    from puppetmaster.scorecards import effective_capability_score
+
+    card = _qualified_card()
+    mutate(card)
+    spec = _model_with_card(card)
+
+    # Act
+    score = effective_capability_score(spec, "audit")
+
+    # Assert: an unqualified card is evidence, not routing authority.
+    assert score == 50
+
+
+@pytest.mark.parametrize(
+    ("epoch_field", "first", "second"),
+    [
+        ("registry_digest", "registry-a", "registry-b"),
+        ("taxonomy_version", "taxonomy-a", "taxonomy-b"),
+        ("adapter_version", "cursor-a", "cursor-b"),
+        ("evaluator_revision", "eval-a", "eval-b"),
+    ],
+)
+def test_historical_aggregation_does_not_pool_incompatible_epochs(
+    epoch_field: str, first: str, second: str
+) -> None:
+    # Arrange: each epoch has only three failures, below min_sample=5. Pooling
+    # the six would manufacture a recommendation unsupported by either epoch.
+    from puppetmaster.audit import build_audit_report
+
+    base_epoch = {
+        "registry_digest": "registry-a",
+        "taxonomy_version": "taxonomy-a",
+        "adapter_version": "cursor-a",
+        "evaluator_revision": "eval-a",
+        "evaluated_at": "2026-08-22T12:00:00Z",
+    }
+    first_epoch = {**base_epoch, epoch_field: first}
+    second_epoch = {**base_epoch, epoch_field: second}
+    records = [
+        *[
+            _objective_record(role="audit", passed=False, **first_epoch)
+            for _ in range(3)
+        ],
+        *[
+            _objective_record(role="audit", passed=False, **second_epoch)
+            for _ in range(3)
+        ],
+    ]
+
+    # Act
+    report = build_audit_report(records, {"cursor/model": 80}, min_sample=5)
+
+    # Assert
+    assert report.epoch_count == 2
+    assert report.role_scorecard_suggestions == []
+
+
+def test_incomplete_epoch_cannot_authorize_a_role_card_recommendation() -> None:
+    # Arrange: legacy records remain reportable, but missing reproducibility
+    # lineage cannot become qualified routing authority.
+    from puppetmaster.audit import build_audit_report
+
+    records = [
+        _objective_record(role="audit", passed=False)
+        for _ in range(5)
+    ]
+
+    # Act
+    report = build_audit_report(records, {"cursor/model": 80}, min_sample=5)
+
+    # Assert
+    assert report.epoch_count == 1
+    assert report.role_scorecard_suggestions == []
+
+
+def test_undated_complete_lineage_is_reportable_but_non_authoritative() -> None:
+    # Arrange: every lineage dimension is present, but there is no immutable
+    # evaluator timestamp. The outcomes belong in diagnostics, not routing
+    # authority or a recommendation which could be applied as fresh evidence.
+    from puppetmaster.audit import build_audit_report
+
+    epoch_without_date = {
+        "registry_digest": "registry-a",
+        "taxonomy_version": "taxonomy-a",
+        "classifier_version": "classifier-a",
+        "adapter_version": "cursor-a",
+        "evaluator_revision": "eval-a",
+    }
+    records = [
+        _objective_record(role="audit", passed=False, **epoch_without_date)
+        for _ in range(5)
+    ]
+
+    # Act
+    report = build_audit_report(records, {"cursor/model": 80}, min_sample=5)
+
+    # Assert: diagnostic aggregation remains available while authority fails
+    # closed at the role-card recommendation boundary.
+    model = next(item for item in report.models if item.model_id == "cursor/model")
+    assert model.runs_with_objective_outcomes == 5
+    assert model.objective_pass_rate == pytest.approx(0.0)
+    assert report.epoch_count == 1
+    assert report.role_scorecard_suggestions == []
+
+
+def test_stale_objective_history_cannot_be_re_stamped_as_a_fresh_role_card() -> None:
+    # Arrange: the run is visible in the current store, but its evaluator
+    # evidence is decades old. Applying the audit today must not launder that
+    # evidence into a newly fresh last_calibrated date.
+    from puppetmaster.audit import build_audit_report, collect_records
+    from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
+    from puppetmaster.store import SwarmStore
+
+    with TemporaryDirectory() as tmp:
+        store = SwarmStore(Path(tmp) / ".puppetmaster")
+        store.init()
+        job = store.create_job("stale objective history")
+        for index in range(5):
+            task = Task(
+                job_id=job.id,
+                role="audit",
+                instruction=f"historical audit {index}",
+                adapter="cursor",
+                status=TaskStatus.COMPLETE,
+                payload={"router_model_id": "cursor/model"},
+            )
+            store.save_task(task)
+            store.save_artifact(
+                Artifact(
+                    job_id=job.id,
+                    task_id=task.id,
+                    type=ArtifactType.ROUTING,
+                    created_by="router",
+                    payload={
+                        "model_id": "cursor/model",
+                        "adapter": "cursor",
+                        "policy": "balanced",
+                        "predicted_quality": 0.95,
+                        "registry_digest": "registry-historical",
+                        "taxonomy_version": "taxonomy-historical",
+                        "classifier_version": "classifier-historical",
+                        "adapter_version": "cursor-historical",
+                    },
+                    confidence=0.9,
+                    evidence=["historical-route"],
+                    created_at=f"1999-12-31T23:59:{index:02d}Z",
+                )
+            )
+            store.save_artifact(
+                Artifact(
+                    job_id=job.id,
+                    task_id=task.id,
+                    type=ArtifactType.GATE,
+                    created_by="review-gate",
+                    payload={
+                        "gate": "review",
+                        "passed": False,
+                        "objective_score": 0.0,
+                        "review_status": "completed",
+                        "evaluator_revision": "review-historical",
+                    },
+                    confidence=1.0,
+                    evidence=["historical-evaluation"],
+                    created_at=f"2000-01-01T00:00:{index:02d}Z",
+                )
+            )
+
+        # Act
+        records, _ = collect_records(store)
+        report = build_audit_report(
+            records, {"cursor/model": 80}, min_sample=5
+        )
+
+    # Assert
+    assert report.role_scorecard_suggestions == []
+
+
+def test_latest_qualified_epoch_wins_role_card_recommendation() -> None:
+    # Arrange: both evaluator epochs independently qualify. Deduplication must
+    # select the newest calibrated evidence, not whichever epoch key sorts first.
+    from puppetmaster.audit import build_audit_report
+
+    common = {
+        "registry_digest": "registry-a",
+        "taxonomy_version": "taxonomy-a",
+        "classifier_version": "classifier-a",
+        "adapter_version": "cursor-a",
+    }
+    records = [
+        *[
+            _objective_record(
+                role="audit",
+                passed=False,
+                evaluator_revision="eval-a",
+                evaluated_at="2026-05-20T12:00:00Z",
+                **common,
+            )
+            for _ in range(5)
+        ],
+        *[
+            _objective_record(
+                role="audit",
+                passed=False,
+                evaluator_revision="eval-b",
+                evaluated_at="2026-08-22T12:00:00Z",
+                **common,
+            )
+            for _ in range(5)
+        ],
+    ]
+
+    # Act
+    report = build_audit_report(records, {"cursor/model": 80}, min_sample=5)
+
+    # Assert
+    assert len(report.role_scorecard_suggestions) == 1
+    suggestion = report.role_scorecard_suggestions[0]
+    assert suggestion["epoch"]["evaluator_revision"] == "eval-b"
+    assert suggestion["last_calibrated"] == "2026-08-22"
+
+
+def test_legacy_audit_record_and_report_shape_remain_supported() -> None:
+    # Arrange: this is the pre-TASK-006 construction shape used by existing
+    # callers and tests. New lineage and objective fields must have safe defaults.
+    from puppetmaster.audit import build_audit_report
+
+    records = [_legacy_record("cursor/legacy") for _ in range(2)]
+
+    # Act
+    report = build_audit_report(records, {"cursor/legacy": 60})
+
+    # Assert
+    assert report.tasks_considered == 2
+    assert report.epoch_count == 1
+    assert report.suggestions == []
+    model = report.models[0]
+    assert model.model_id == "cursor/legacy"
+    assert model.selections == 2
+    assert model.runs_with_objective_outcomes == 0
+    assert model.objective_pass_rate is None

--- a/tests/test_routing_quality_evaluation.py
+++ b/tests/test_routing_quality_evaluation.py
@@ -1,0 +1,646 @@
+"""Independent TASK-007 RED contract for paired routing-quality evidence.
+
+The reviewer authored these tests before inspecting an author solution.  They
+exercise a public, provider-neutral evaluation seam and production routing
+behavior.  No test contacts a model provider or treats artifact structure as
+semantic correctness.
+"""
+from __future__ import annotations
+
+import json
+import hashlib
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+from puppetmaster.model_registry import ModelSpec
+
+
+REQUIRED_ROLES = {"implement", "explore", "audit", "plan"}
+ARM_NAMES = {"routed_balanced", "strongest_eligible"}
+
+
+def _model(
+    model_id: str,
+    *,
+    capability: int,
+    cost: float,
+    context_window: int = 16_000,
+) -> ModelSpec:
+    return ModelSpec(
+        id=model_id,
+        adapter="cursor",
+        adapter_model_name=model_id.rsplit("/", 1)[-1],
+        capability_score=capability,
+        input_per_mtok_usd=cost,
+        output_per_mtok_usd=cost,
+        context_window=context_window,
+        billing="plan",
+    )
+
+
+def _corpus_payload() -> dict:
+    cases = []
+    for role in sorted(REQUIRED_ROLES):
+        case_id = f"{role}-deterministic"
+        snapshot_files = {
+            f"fixtures/{role}/authority.txt": (
+                f"The fixture-specific accepted result is EXPECTED::{case_id}."
+            )
+        }
+        canonical_snapshot = json.dumps(
+            snapshot_files,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        snapshot_digest = "sha256:" + hashlib.sha256(canonical_snapshot).hexdigest()
+        cases.append(
+            {
+                "case_id": case_id,
+                "role": role,
+                "instruction": f"Complete the deterministic {role} fixture.",
+                "snapshot_id": f"fixture-{role}-v1",
+                "snapshot_digest": snapshot_digest,
+                "snapshot_files": snapshot_files,
+                "min_capability": 60,
+                "estimated_tokens_in": 1_000,
+                "estimated_tokens_out": 200,
+                "allowed_changed_files": [f"fixtures/{role}/allowed.txt"],
+                "criteria": [
+                    {
+                        "criterion_id": f"{case_id}-marker",
+                        "description": "The fixture-specific success marker is present.",
+                        "evaluator": {
+                            "kind": "contains",
+                            "expected": f"EXPECTED::{case_id}",
+                        },
+                    }
+                ],
+                "seeded_failures": (
+                    [
+                        {
+                            "failure_id": "missing-required-marker",
+                            "description": "Output omits the required deterministic marker.",
+                            "output_text": "A plausible answer that misses the fixture fact.",
+                            "changed_files": [],
+                            "catastrophic": False,
+                        }
+                    ]
+                    if role == "audit"
+                    else []
+                ),
+            }
+        )
+    return {
+        "schema_version": 1,
+        "corpus_id": "task-007-test-corpus",
+        "corpus_version": "2026-08-22.1",
+        "cases": cases,
+    }
+
+
+def _write_corpus(tmp_path: Path, payload: dict | None = None) -> Path:
+    path = tmp_path / "routing-quality-corpus.json"
+    path.write_text(json.dumps(payload or _corpus_payload(), indent=2), encoding="utf-8")
+    return path
+
+
+def _passing_executor(request):
+    """Return deterministic provider-neutral receipts for a runner request."""
+    return {
+        "output_text": request.case.criteria[0].expected,
+        "snapshot_digest": request.snapshot_digest,
+        "changed_files": list(request.case.allowed_changed_files[:1]),
+        "catastrophic": False,
+        "correction_cycles": 0,
+        "elapsed_seconds": 1.0,
+        "retries": 0,
+        "tokens_in": 1_000,
+        "tokens_out": 100,
+        "nominal_cost_usd": 0.01,
+        "marginal_cost_usd": 0.0,
+    }
+
+
+def test_default_corpus_is_versioned_multi_role_and_has_seeded_failures() -> None:
+    # Arrange / Act.
+    from puppetmaster.routing_evaluation import (
+        grade_case,
+        load_evaluation_corpus,
+        snapshot_digest_for_files,
+    )
+
+    corpus = load_evaluation_corpus()
+
+    # Assert: this is a real versioned quality corpus, not one generic prompt.
+    assert corpus.schema_version >= 1
+    assert corpus.corpus_id
+    assert corpus.corpus_version
+    assert {case.role for case in corpus.cases} >= REQUIRED_ROLES
+    assert len({case.case_id for case in corpus.cases}) == len(corpus.cases)
+    assert any(case.seeded_failures for case in corpus.cases)
+    assert all(case.criteria for case in corpus.cases)
+    assert all(case.snapshot_digest.startswith("sha256:") for case in corpus.cases)
+    assert all(case.snapshot_files for case in corpus.cases)
+    assert all(
+        snapshot_digest_for_files(case.snapshot_files) == case.snapshot_digest
+        for case in corpus.cases
+    )
+    assert all(
+        criterion.evaluator_kind != "llm_judge"
+        for case in corpus.cases
+        for criterion in case.criteria
+    )
+    assert all(
+        criterion.expected.casefold() not in case.instruction.casefold()
+        for case in corpus.cases
+        for criterion in case.criteria
+    )
+
+    # Seeded failures are executable negative vectors, not descriptions which
+    # have never been graded against their claimed case.
+    for case in corpus.cases:
+        for failure in case.seeded_failures:
+            grade = grade_case(
+                case,
+                output_text=failure.output_text,
+                changed_files=failure.changed_files,
+                catastrophic=failure.catastrophic,
+            )
+            assert grade.acceptance_passed is False
+
+
+def test_corpus_loader_fails_closed_without_version_or_required_roles(tmp_path: Path) -> None:
+    # Arrange.
+    from puppetmaster.routing_evaluation import load_evaluation_corpus
+
+    unversioned = _corpus_payload()
+    unversioned.pop("corpus_version")
+    unversioned_path = _write_corpus(tmp_path, unversioned)
+
+    # Act / Assert.
+    with pytest.raises(ValueError, match="corpus_version"):
+        load_evaluation_corpus(unversioned_path)
+
+    incomplete = _corpus_payload()
+    incomplete["corpus_version"] = "2026-08-22.2"
+    incomplete["cases"] = [
+        case for case in incomplete["cases"] if case["role"] != "plan"
+    ]
+    incomplete_path = tmp_path / "incomplete.json"
+    incomplete_path.write_text(json.dumps(incomplete), encoding="utf-8")
+    with pytest.raises(ValueError, match="plan"):
+        load_evaluation_corpus(incomplete_path)
+
+
+def test_corpus_loader_rejects_a_seeded_failure_that_passes_acceptance(
+    tmp_path: Path,
+) -> None:
+    # Arrange: a corpus must not gain seeded-failure credibility merely by
+    # labeling a successful vector as a failure.
+    from puppetmaster.routing_evaluation import load_evaluation_corpus
+
+    payload = _corpus_payload()
+    audit_case = next(case for case in payload["cases"] if case["role"] == "audit")
+    audit_case["seeded_failures"][0]["output_text"] = audit_case["criteria"][0][
+        "evaluator"
+    ]["expected"]
+    path = _write_corpus(tmp_path, payload)
+
+    # Act / Assert.
+    with pytest.raises(ValueError, match="seeded failure.*must fail"):
+        load_evaluation_corpus(path)
+
+
+def test_deterministic_grader_scores_criteria_and_unintended_files(tmp_path: Path) -> None:
+    # Arrange.
+    from puppetmaster.routing_evaluation import grade_case, load_evaluation_corpus
+
+    corpus = load_evaluation_corpus(_write_corpus(tmp_path))
+    case = next(item for item in corpus.cases if item.role == "implement")
+    allowed = list(case.allowed_changed_files)
+
+    # Act.
+    first = grade_case(
+        case,
+        output_text=f"done\n{case.criteria[0].expected}\n",
+        changed_files=allowed,
+        catastrophic=False,
+    )
+    repeat = grade_case(
+        case,
+        output_text=f"done\n{case.criteria[0].expected}\n",
+        changed_files=allowed,
+        catastrophic=False,
+    )
+    failed = grade_case(
+        case,
+        output_text="plausible prose without the required marker",
+        changed_files=[*allowed, "unintended.txt"],
+        catastrophic=False,
+    )
+
+    # Assert: grading is repeatable and semantic acceptance is criterion-bound.
+    assert first == repeat
+    assert first.acceptance_passed is True
+    assert first.criterion_score == pytest.approx(1.0)
+    assert first.unintended_files == ()
+    assert failed.acceptance_passed is False
+    assert failed.criterion_score == pytest.approx(0.0)
+    assert failed.unintended_files == ("unintended.txt",)
+
+
+def test_paired_runner_uses_identical_snapshots_and_strongest_eligible_baseline(
+    tmp_path: Path,
+) -> None:
+    # Arrange: the absolute strongest model cannot fit; the strongest eligible
+    # baseline must therefore pin frontier, while balanced should route bargain.
+    from puppetmaster.routing_evaluation import (
+        load_evaluation_corpus,
+        run_paired_evaluation,
+    )
+
+    corpus = load_evaluation_corpus(_write_corpus(tmp_path))
+    registry = [
+        _model("cursor/bargain", capability=70, cost=0.10),
+        _model("cursor/frontier", capability=95, cost=1.00),
+        _model(
+            "cursor/overflowing-strongest",
+            capability=100,
+            cost=2.00,
+            context_window=1_100,
+        ),
+    ]
+    calls = []
+
+    def execute(request):
+        calls.append(request)
+        return _passing_executor(request)
+
+    # Act.
+    report = run_paired_evaluation(
+        corpus,
+        registry,
+        execute=execute,
+        repetitions=3,
+        seed=41,
+    )
+
+    # Assert: every case/repetition is a pair over the same immutable baseline.
+    grouped = defaultdict(list)
+    for request in calls:
+        grouped[(request.case.case_id, request.repetition)].append(request)
+    assert len(grouped) == len(corpus.cases) * 3
+    for pair in grouped.values():
+        assert {request.arm for request in pair} == ARM_NAMES
+        assert len({request.snapshot_digest for request in pair}) == 1
+        model_by_arm = {request.arm: request.model_id for request in pair}
+        assert model_by_arm == {
+            "routed_balanced": "cursor/bargain",
+            "strongest_eligible": "cursor/frontier",
+        }
+
+    # Randomized execution order is deterministic under a seed and exercises
+    # both orderings instead of always favoring the same first arm.
+    arm_orders = {tuple(pair.arm_order) for pair in report.pairs}
+    assert arm_orders == {
+        ("routed_balanced", "strongest_eligible"),
+        ("strongest_eligible", "routed_balanced"),
+    }
+
+
+def test_paired_runner_requires_three_repetitions(tmp_path: Path) -> None:
+    # Arrange.
+    from puppetmaster.routing_evaluation import (
+        load_evaluation_corpus,
+        run_paired_evaluation,
+    )
+
+    corpus = load_evaluation_corpus(_write_corpus(tmp_path))
+    registry = [_model("cursor/model", capability=90, cost=1.0)]
+
+    # Act / Assert.
+    with pytest.raises(ValueError, match="at least 3"):
+        run_paired_evaluation(
+            corpus,
+            registry,
+            execute=_passing_executor,
+            repetitions=2,
+            seed=1,
+        )
+
+
+def test_paired_runner_rejects_unverified_or_mismatched_snapshot_receipts(
+    tmp_path: Path,
+) -> None:
+    # Arrange: sharing an asserted digest in two requests is not proof that an
+    # executor actually reset both arms to that snapshot.
+    from puppetmaster.routing_evaluation import (
+        load_evaluation_corpus,
+        run_paired_evaluation,
+    )
+
+    corpus = load_evaluation_corpus(_write_corpus(tmp_path))
+    registry = [_model("cursor/model", capability=90, cost=1.0)]
+
+    def mismatched_executor(request):
+        receipt = dict(_passing_executor(request))
+        receipt["snapshot_digest"] = "sha256:" + "0" * 64
+        return receipt
+
+    # Act / Assert: the report must not certify same-snapshot pairing from an
+    # unchecked request field alone.
+    with pytest.raises(ValueError, match="snapshot_digest"):
+        run_paired_evaluation(
+            corpus,
+            registry,
+            execute=mismatched_executor,
+            repetitions=3,
+            seed=1,
+        )
+
+
+def test_report_includes_quality_cost_failure_metrics_and_paired_uncertainty(
+    tmp_path: Path,
+) -> None:
+    # Arrange: opposite wins in different repetitions create a genuine wide,
+    # paired quality interval that must remain inconclusive.
+    from puppetmaster.routing_evaluation import (
+        load_evaluation_corpus,
+        render_evaluation_report,
+        run_paired_evaluation,
+    )
+
+    corpus = load_evaluation_corpus(_write_corpus(tmp_path))
+    registry = [
+        _model("cursor/bargain", capability=70, cost=0.10),
+        _model("cursor/frontier", capability=95, cost=1.00),
+    ]
+
+    def execute(request):
+        routed_passes = request.repetition != 1
+        baseline_passes = request.repetition != 2
+        passed = routed_passes if request.arm == "routed_balanced" else baseline_passes
+        return {
+            "output_text": request.case.criteria[0].expected if passed else "missing",
+            "snapshot_digest": request.snapshot_digest,
+            "changed_files": (
+                [*request.case.allowed_changed_files, "unintended.txt"]
+                if request.arm == "routed_balanced" and request.repetition == 1
+                else list(request.case.allowed_changed_files)
+            ),
+            "catastrophic": request.arm == "strongest_eligible" and request.repetition == 2,
+            "correction_cycles": request.repetition,
+            "elapsed_seconds": 2.0 + request.repetition,
+            "retries": 1 if request.repetition == 1 else 0,
+            "tokens_in": 1_000 + request.repetition,
+            "tokens_out": 100 + request.repetition,
+            "nominal_cost_usd": 0.02 + request.repetition / 100,
+            "marginal_cost_usd": 0.01 + request.repetition / 100,
+        }
+
+    # Act.
+    first = run_paired_evaluation(
+        corpus,
+        registry,
+        execute=execute,
+        repetitions=3,
+        seed=19,
+        noninferiority_margin=0.05,
+    )
+    repeat = run_paired_evaluation(
+        corpus,
+        registry,
+        execute=execute,
+        repetitions=3,
+        seed=19,
+        noninferiority_margin=0.05,
+    )
+    payload = first.to_dict()
+
+    # Assert: a fixed corpus, executor, and seed produce a stable sample report.
+    assert payload == repeat.to_dict()
+    assert payload["claim"]["status"] == "inconclusive"
+    assert payload["claim"]["basis"] == "paired_noninferiority"
+    required_metrics = {
+        "acceptance_pass_rate",
+        "criterion_score_mean",
+        "unintended_file_rate",
+        "catastrophic_failure_rate",
+        "correction_cycles_mean",
+        "elapsed_seconds_mean",
+        "retries_mean",
+        "tokens_in_mean",
+        "tokens_out_mean",
+        "nominal_cost_usd_mean",
+        "marginal_cost_usd_mean",
+    }
+    assert set(payload["arms"]["routed_balanced"]) >= required_metrics
+    assert set(payload["arms"]["strongest_eligible"]) >= required_metrics
+    assert set(payload["paired_deltas"]) >= required_metrics
+    for metric in required_metrics:
+        uncertainty = payload["paired_deltas"][metric]
+        assert set(uncertainty) >= {"estimate", "lower", "upper", "method"}
+        assert uncertainty["lower"] <= uncertainty["estimate"] <= uncertainty["upper"]
+
+    markdown = render_evaluation_report(first).lower()
+    assert "inconclusive" in markdown
+    assert "paired non-inferiority" in markdown
+    assert "does not establish semantic quality" in markdown
+    assert "proves that routing improves quality" not in markdown
+
+
+def test_finite_all_equal_sample_does_not_collapse_quality_uncertainty_to_zero(
+    tmp_path: Path,
+) -> None:
+    # Arrange: twelve observed ties (four cases x three repetitions) are
+    # encouraging, but a finite binary sample does not establish a population
+    # pass-rate difference of exactly zero at a five-point margin.
+    from puppetmaster.routing_evaluation import (
+        load_evaluation_corpus,
+        run_paired_evaluation,
+    )
+
+    corpus = load_evaluation_corpus(_write_corpus(tmp_path))
+    registry = [
+        _model("cursor/bargain", capability=70, cost=0.10),
+        _model("cursor/frontier", capability=95, cost=1.00),
+    ]
+
+    # Act.
+    report = run_paired_evaluation(
+        corpus,
+        registry,
+        execute=_passing_executor,
+        repetitions=3,
+        seed=7,
+        noninferiority_margin=0.05,
+    )
+    quality = report.to_dict()["paired_deltas"]["acceptance_pass_rate"]
+
+    # Assert: a variance-zero normal approximation would incorrectly emit
+    # [0, 0] and claim non-inferiority from only twelve pairs.
+    assert quality["lower"] < quality["estimate"] < quality["upper"]
+    assert report.claim["status"] == "inconclusive"
+
+
+@pytest.mark.parametrize(
+    "invalid_margin",
+    [
+        pytest.param(True, id="boolean"),
+        pytest.param(float("nan"), id="nan"),
+        pytest.param(float("inf"), id="infinite"),
+        pytest.param(1.01, id="above-pass-rate-range"),
+    ],
+)
+def test_noninferiority_margin_fails_closed_outside_finite_unit_interval(
+    tmp_path: Path,
+    invalid_margin: object,
+) -> None:
+    # Arrange.
+    from puppetmaster.routing_evaluation import (
+        load_evaluation_corpus,
+        run_paired_evaluation,
+    )
+
+    corpus = load_evaluation_corpus(_write_corpus(tmp_path))
+    registry = [_model("cursor/model", capability=90, cost=1.0)]
+
+    # Act / Assert: an invalid margin cannot manufacture a favorable claim.
+    with pytest.raises(ValueError, match="noninferiority_margin"):
+        run_paired_evaluation(
+            corpus,
+            registry,
+            execute=_passing_executor,
+            repetitions=3,
+            seed=1,
+            noninferiority_margin=invalid_margin,
+        )
+
+
+def test_shadow_routing_is_opt_in_and_cannot_change_production_selection() -> None:
+    # Arrange.
+    from puppetmaster import router
+
+    task = router.TaskSignals(
+        instruction="perform the bounded task",
+        role="explore",
+        explicit_min_capability=60,
+        estimated_tokens_in=1_000,
+        estimated_tokens_out=200,
+    )
+    registry = [
+        _model("cursor/bargain", capability=70, cost=0.10),
+        _model("cursor/frontier", capability=95, cost=1.00),
+    ]
+
+    # Act.
+    production = router.route_task(task, registry, policy="balanced")
+    shadowed = router.route_task(
+        task,
+        registry,
+        policy="balanced",
+        shadow_policy="quality",
+    )
+    production_payload = production.to_artifact_payload()
+    shadow_payload = shadowed.to_artifact_payload()
+
+    # Assert: opt-in adds counterfactual evidence only; dispatch identity is
+    # byte-for-byte the same production choice as the non-shadow route.
+    assert production.model.id == "cursor/bargain"
+    assert shadowed.model.id == production.model.id
+    assert "shadow_routing" not in production_payload
+    assert shadow_payload["model_id"] == production_payload["model_id"]
+    assert shadow_payload["adapter"] == production_payload["adapter"]
+    assert shadow_payload["policy"] == production_payload["policy"]
+    assert shadow_payload["shadow_routing"] == {
+        "enabled": True,
+        "policy": "quality",
+        "production_model_id": "cursor/bargain",
+        "counterfactual_model_id": "cursor/frontier",
+        "production_selection_changed": False,
+    }
+
+
+def test_orchestrator_shadow_opt_in_persists_evidence_without_changing_dispatch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    # Arrange: exercise the actual auto-route-to-task/artifact seam, not only a
+    # direct library call which no production caller can enable.
+    from puppetmaster.model_registry import save_registry
+    from puppetmaster.models import ArtifactType
+    from puppetmaster.orchestrator import Orchestrator
+    from puppetmaster.store_factory import create_store
+    from puppetmaster.workers import WorkerSpec
+
+    registry_path = tmp_path / "models.json"
+    save_registry(
+        [
+            _model("cursor/bargain", capability=70, cost=0.10),
+            _model("cursor/frontier", capability=95, cost=1.00),
+        ],
+        registry_path,
+    )
+    monkeypatch.setattr(
+        "puppetmaster.preflight.adapter_cli_present", lambda _adapter: True
+    )
+    store = create_store("file", tmp_path / ".puppetmaster")
+    store.init()
+    orchestrator = Orchestrator(store)
+    job = store.create_job("shadow route production seam")
+    spec = WorkerSpec(
+        role="explore",
+        instruction="perform the bounded task",
+        adapter="local",
+        payload={
+            "auto_route": True,
+            "registry_path": str(registry_path),
+            "routing_policy": "balanced",
+            "min_capability": 60,
+            "estimated_tokens_in": 1_000,
+            "estimated_tokens_out": 200,
+            "shadow_policy": "quality",
+        },
+    )
+
+    # Act.
+    task = orchestrator._create_tasks(job, [spec])[0]
+    routing = [
+        artifact
+        for artifact in store.list_artifacts(job.id)
+        if artifact.type == ArtifactType.ROUTING
+    ]
+
+    # Assert: dispatch remains the balanced pick while the durable artifact
+    # carries the quality-policy counterfactual.
+    assert task.payload["router_model_id"] == "cursor/bargain"
+    assert task.payload["model"] == "bargain"
+    assert len(routing) == 1
+    assert routing[0].payload["model_id"] == "cursor/bargain"
+    assert routing[0].payload["shadow_routing"] == {
+        "enabled": True,
+        "policy": "quality",
+        "production_model_id": "cursor/bargain",
+        "counterfactual_model_id": "cursor/frontier",
+        "production_selection_changed": False,
+    }
+
+
+def test_documentation_states_quality_claim_boundaries() -> None:
+    # Arrange / Act.
+    text = (
+        Path(__file__).resolve().parents[1]
+        / "docs"
+        / "routing-quality-evaluation.md"
+    ).read_text(encoding="utf-8").lower()
+
+    # Assert: structural presence is useful health evidence, but not semantic
+    # correctness, and a finite paired run may support only a bounded claim.
+    assert "non-inferiority" in text
+    assert "inconclusive" in text
+    assert "structural artifact presence" in text
+    assert "not semantic quality" in text
+    assert "proves that routing improves quality" not in text

--- a/tests/test_routing_role_taxonomy.py
+++ b/tests/test_routing_role_taxonomy.py
@@ -1,0 +1,345 @@
+"""Adversarial contract tests for the external routing-role taxonomy.
+
+These tests intentionally exercise behavior at the public router seam.  They
+do not read implementation-private caches and do not duplicate the production
+loader's schema validation.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.resources
+import inspect
+import json
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from puppetmaster import router
+from puppetmaster.model_registry import ModelSpec
+
+
+EXPECTED_BUILTIN_ROLES = {
+    "verify-runtime": (25, False),
+    "shell": (20, False),
+    "demo": (25, False),
+    "explore": (50, True),
+    "review": (55, True),
+    "plan": (60, True),
+    "implement": (75, True),
+    "refactor": (75, True),
+    "patch": (75, True),
+    "fix": (70, True),
+    "build": (75, True),
+    "test-coverage-reviewer": (60, True),
+    "architect": (85, True),
+    "audit": (85, True),
+    "security-review": (90, True),
+    "decision-explainer": (70, True),
+    "conflict-auditor": (75, True),
+    "pipeline-mapper": (65, True),
+}
+
+EXPECTED_ALIASES = {
+    "runtime-check": "verify-runtime",
+    "codex-review": "review",
+    "hermes-implement": "implement",
+    "routing_quality": "audit",
+    "recovery-governance": "audit",
+    "evaluation_design": "architect",
+}
+
+EXPECTED_LEGACY_OUTPUT_BUDGETS = {
+    "verify-runtime": 300,
+    "shell": 200,
+    "demo": 500,
+    "explore": 1500,
+    "review": 1500,
+    "plan": 2000,
+    "implement": 3000,
+    "refactor": 3000,
+    "patch": 3000,
+    "fix": 1500,
+    "build": 1500,
+    "test-coverage-reviewer": 1500,
+    "architect": 5000,
+    "audit": 5000,
+    "security-review": 5000,
+    "decision-explainer": 1500,
+    "conflict-auditor": 1500,
+    "pipeline-mapper": 1500,
+}
+
+
+def _required_api(name: str):
+    value = getattr(router, name, None)
+    assert value is not None, f"router must expose {name} for deterministic taxonomy use"
+    return value
+
+
+def _authority_json() -> dict:
+    resource = importlib.resources.files("puppetmaster").joinpath("routing_roles.json")
+    return json.loads(resource.read_text(encoding="utf-8"))
+
+
+def test_taxonomy_is_external_package_data_without_literal_role_tables() -> None:
+    # Arrange: resolve the authority through the installed-package resource API.
+    resource = importlib.resources.files("puppetmaster").joinpath("routing_roles.json")
+
+    # Act: inspect both the resource and assignments in router.py.
+    assert resource.is_file(), "routing_roles.json must be shipped inside puppetmaster"
+    source = inspect.getsource(router)
+    tree = ast.parse(source)
+    hardcoded_assignments = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        names = {target.id for target in targets if isinstance(target, ast.Name)}
+        value = node.value
+        if "_ROLE_BASE_SCORE" in names and isinstance(value, ast.Dict):
+            hardcoded_assignments.append("_ROLE_BASE_SCORE")
+        if "_TOOL_LOOP_ROLES" in names:
+            literal = isinstance(value, (ast.Set, ast.List, ast.Tuple))
+            literal_frozenset = (
+                isinstance(value, ast.Call)
+                and isinstance(value.func, ast.Name)
+                and value.func.id == "frozenset"
+                and bool(value.args)
+                and isinstance(value.args[0], (ast.Set, ast.List, ast.Tuple))
+            )
+            if literal or literal_frozenset:
+                hardcoded_assignments.append("_TOOL_LOOP_ROLES")
+
+    # Assert: authority is data-backed, not duplicated as Python literals, and
+    # setuptools is configured to carry root JSON resources into a wheel.
+    assert hardcoded_assignments == []
+    pyproject = Path(__file__).parents[1] / "pyproject.toml"
+    package_data = pyproject.read_text(encoding="utf-8")
+    assert (
+        '"routing_roles.json"' in package_data or '"*.json"' in package_data
+    )
+
+
+def test_external_schema_defines_every_builtin_role_and_alias() -> None:
+    # Arrange: load the independent JSON authority directly.
+    data = _authority_json()
+
+    # Act: project only the behavior required by the routing classifier.
+    roles = data.get("roles", {})
+    actual = {
+        role: (definition.get("base_capability"), definition.get("tool_loop"))
+        for role, definition in roles.items()
+        if role in EXPECTED_BUILTIN_ROLES
+    }
+    aliases = {
+        alias: role
+        for role, definition in roles.items()
+        for alias in definition.get("aliases", [])
+    }
+
+    # Assert: the schema/version identity and all formerly hardcoded authority
+    # are represented in the packaged file.
+    assert data.get("schema_version") == 1
+    assert isinstance(data.get("taxonomy_version"), str)
+    assert data["taxonomy_version"].strip()
+    unknown = data.get("unknown_role")
+    unknown_canonical = (
+        unknown.get("canonical_role") if isinstance(unknown, dict) else unknown
+    )
+    assert unknown_canonical == "unknown"
+    assert actual == EXPECTED_BUILTIN_ROLES
+    normalized_expected_aliases = {
+        alias.replace("_", "-"): canonical
+        for alias, canonical in EXPECTED_ALIASES.items()
+    }
+    assert aliases.items() >= normalized_expected_aliases.items()
+
+
+@pytest.mark.parametrize(
+    ("role", "expected_base", "expected_tool_loop"),
+    [
+        pytest.param(role, values[0], values[1], id=role)
+        for role, values in EXPECTED_BUILTIN_ROLES.items()
+    ],
+)
+def test_every_builtin_role_uses_external_capability_and_tool_classification(
+    role: str,
+    expected_base: int,
+    expected_tool_loop: bool,
+) -> None:
+    # Arrange: use signal-free instructions so only role authority contributes.
+    task = router.TaskSignals(instruction="inspect the requested target", role=role)
+
+    # Act: classify through the normal public router functions.
+    capability = router.classify_capability_needed(task)
+    needs_tools = router.task_needs_tool_calling(task)
+
+    # Assert: every legacy built-in retains its intended behavior after moving
+    # the table out of Python.
+    assert capability == expected_base
+    assert needs_tools is expected_tool_loop
+
+
+@pytest.mark.parametrize(
+    ("display_role", "canonical_role"),
+    [pytest.param(alias, canonical, id=alias) for alias, canonical in EXPECTED_ALIASES.items()],
+)
+def test_display_role_aliases_normalize_before_classification(
+    display_role: str,
+    canonical_role: str,
+) -> None:
+    # Arrange: vary case, surrounding whitespace, and underscore separators.
+    normalize = _required_api("normalize_routing_role")
+    display = f"  {display_role.upper()}  "
+    expected_base, expected_tools = EXPECTED_BUILTIN_ROLES[canonical_role]
+    task = router.TaskSignals(instruction="inspect the requested target", role=display)
+
+    # Act: normalize and classify using the unmodified display role.
+    normalized = normalize(display)
+    capability = router.classify_capability_needed(task)
+    needs_tools = router.task_needs_tool_calling(task)
+
+    # Assert: aliases cannot silently fall through to the old generic score.
+    assert normalized == canonical_role
+    assert capability == expected_base
+    assert needs_tools is expected_tools
+
+
+def test_unknown_roles_fail_safe_to_external_unknown_role() -> None:
+    # Arrange: choose a display role absent from the packaged aliases.
+    normalize = _required_api("normalize_routing_role")
+    task = router.TaskSignals(instruction="inspect the requested target", role="future-specialist")
+
+    # Act: normalize and classify it.
+    canonical = normalize(task.role)
+    capability = router.classify_capability_needed(task)
+    needs_tools = router.task_needs_tool_calling(task)
+
+    # Assert: unknown work has an explicit, conservative authority entry rather
+    # than an accidental dict.get fallback.
+    assert canonical == "unknown"
+    assert capability == 60
+    assert needs_tools is True
+
+
+@pytest.mark.parametrize(
+    ("role", "expected_tokens"),
+    [
+        pytest.param(role, tokens, id=role)
+        for role, tokens in EXPECTED_LEGACY_OUTPUT_BUDGETS.items()
+    ],
+)
+def test_externalization_preserves_existing_output_token_budgets(
+    role: str,
+    expected_tokens: int,
+) -> None:
+    # Arrange: externalization must not silently alter the cost classifier's
+    # pre-existing output reservations.
+    task = router.TaskSignals(instruction="inspect the requested target", role=role)
+
+    # Act: estimate through the public router seam.
+    tokens = router.estimate_tokens_out(task)
+
+    # Assert: this task moves authority without introducing unrelated cost
+    # behavior changes.
+    assert tokens == expected_tokens
+
+
+@pytest.mark.parametrize(
+    ("filename", "contents", "message_fragment"),
+    [
+        ("missing.json", None, "missing"),
+        ("invalid-json.json", "{not-json", "not valid json"),
+        (
+            "invalid-schema.json",
+            json.dumps({"schema_version": 1, "taxonomy_version": "test", "roles": {}}),
+            "unknown_role",
+        ),
+    ],
+)
+def test_loader_fails_explicitly_for_missing_or_malformed_authority(
+    tmp_path: Path,
+    filename: str,
+    contents: Optional[str],
+    message_fragment: str,
+) -> None:
+    # Arrange: create an isolated missing, syntactically invalid, or
+    # semantically incomplete authority path.
+    load = _required_api("load_role_taxonomy")
+    error_type = _required_api("RoleTaxonomyError")
+    authority_path = tmp_path / filename
+    if contents is not None:
+        authority_path.write_text(contents, encoding="utf-8")
+
+    # Act: load through the explicit path seam.
+    with pytest.raises(error_type) as caught:
+        load(authority_path)
+
+    # Assert: failure is deterministic and actionable; no implicit table or
+    # generic-role fallback is permitted for broken authority.
+    message = str(caught.value).lower()
+    assert str(authority_path).lower() in message
+    assert message_fragment in message
+
+
+def test_loader_rejects_alias_collision_with_reserved_unknown_role(tmp_path: Path) -> None:
+    # Arrange: make the reserved unknown canonical name also resolve to audit.
+    load = _required_api("load_role_taxonomy")
+    error_type = _required_api("RoleTaxonomyError")
+    data = _authority_json()
+    data["roles"]["audit"]["aliases"].append("unknown")
+    authority_path = tmp_path / "ambiguous-unknown.json"
+    authority_path.write_text(json.dumps(data), encoding="utf-8")
+
+    # Act / Assert: schema validation must reject a taxonomy whose fallback
+    # identity has two incompatible meanings.
+    with pytest.raises(error_type) as caught:
+        load(authority_path)
+    message = str(caught.value).lower()
+    assert str(authority_path).lower() in message
+    assert "unknown" in message
+    assert "alias" in message or "ambiguous" in message
+
+
+def test_callers_cannot_mutate_cached_authority_or_future_routing() -> None:
+    # Arrange: receive one loaded authority value and mutate the caller-owned
+    # object as an accidental or hostile consumer could.
+    load = _required_api("load_role_taxonomy")
+    first = load()
+    first["roles"]["audit"]["base_capability"] = 1
+    task = router.TaskSignals(instruction="inspect the requested target", role="audit")
+
+    # Act: load and classify again.
+    second = load()
+    capability = router.classify_capability_needed(task)
+
+    # Assert: a public read cannot corrupt the cached authority and make later
+    # routing non-deterministic inside the same process.
+    assert second["roles"]["audit"]["base_capability"] == 85
+    assert capability == 85
+
+
+def test_routing_provenance_records_original_role_canonical_role_and_version() -> None:
+    # Arrange: route a custom audit alias through a single unquestionably
+    # eligible tool-capable model.
+    taxonomy = _authority_json()
+    model = ModelSpec(
+        id="test/frontier",
+        adapter="test",
+        adapter_model_name="frontier",
+        capability_score=100,
+        tags=["tools"],
+    )
+    task = router.TaskSignals(instruction="inspect the requested target", role="routing_quality")
+
+    # Act: materialize the persisted ROUTING payload.
+    decision = router.route_task(task, [model], policy="balanced")
+    payload = decision.to_artifact_payload()
+
+    # Assert: a later audit can reproduce which taxonomy interpretation was
+    # used without erasing the user-facing display role.
+    assert payload["role"] == "routing_quality"
+    assert payload["canonical_role"] == "audit"
+    assert payload["taxonomy_version"] == taxonomy["taxonomy_version"]


### PR DESCRIPTION
## Summary

- Externalize the routing-role capability and tool-loop table into packaged,
  versioned `puppetmaster/routing_roles.json`, with canonical aliases and
  routing provenance.
- Enforce enriched context-window fit, calibrated estimates, strict capability
  handling, and cheapest-sufficient routing across Python, CLI, and MCP.
- Make explicitly requested review fail closed and bind successful review to an
  attributable independent judge and artifact.
- Validate registry identity, preserve retired-model quarantine, bind registry
  digests through pins/recovery/escalation, and make newest-failure recovery
  authoritative.
- Replace global, self-reported quality mutation with qualified objective,
  role-specific, epoch-aware scorecards and audit attribution.
- Add a versioned paired routing-quality corpus/runner plus opt-in,
  non-interfering shadow routing evidence.

## BREAKING behavior

- `cheap` now means the cheapest model that satisfies the capability need. Use
  the explicit `absolute-cheapest` policy to retain the former lowest-cost
  regardless-of-fit behavior.
- An explicitly requested review no longer passes when no adequate judge runs,
  the judge is unavailable, or there is no reviewable diff. Optional review
  remains available only when it is explicitly non-requested/non-required.
- Duplicate or ambiguous model identities are rejected at registry validation,
  and persisted routed/pinned tasks require current registry authority for
  fallback, escalation, and judge selection.

## Validation

- Seven formal focused suites: `159 passed`.
- Directly affected role-scorecard target: `19 passed`.
- Independent selective integration review: `51 passed`.
- Built wheel verified to contain:
  - `puppetmaster/routing_roles.json`
  - `puppetmaster/baselines/routing-quality-corpus-v1.json`
- Repository publication gate:
  `python -m pytest tests/test_puppetmaster.py -q` ->
  `1275 passed, 14 skipped, 1 existing warning`.

No merge, tag, or release is included in this PR.
