### PR TITLE
Promote dev: unittest-only #64 routing tests (CI)

### DIFF
--- a/tests/test_registry_retirement.py
+++ b/tests/test_registry_retirement.py
@@ -9,9 +9,17 @@ cannot be undone by catalog reconciliation.
 from __future__ import annotations
 
 import json
+import os
+import sys
+import unittest
 from dataclasses import replace
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
-import pytest
+_HERMETIC_DIR = os.path.dirname(os.path.abspath(__file__))
+if _HERMETIC_DIR not in sys.path:
+    sys.path.insert(0, _HERMETIC_DIR)
+import hermetic_env  # noqa: F401  # process-wide host-env isolation
 
 
 def _entry(
@@ -28,97 +36,10 @@ def _entry(
     }
 
 
-def _write_registry(tmp_path, payload):
+def _write_registry(tmp_path: Path, payload) -> Path:
     path = tmp_path / "models.json"
     path.write_text(json.dumps(payload), encoding="utf-8")
     return path
-
-
-@pytest.mark.parametrize(
-    "payload",
-    [
-        [_entry()],
-        {"models": [_entry()]},
-    ],
-    ids=["documented-list-form", "documented-object-form"],
-)
-def test_load_registry_accepts_both_documented_forms(tmp_path, payload) -> None:
-    # Arrange
-    from puppetmaster.model_registry import load_registry
-
-    path = _write_registry(tmp_path, payload)
-
-    # Act
-    specs = load_registry(path)
-
-    # Assert
-    assert [spec.id for spec in specs] == ["cursor/grok-4-5"]
-
-
-@pytest.mark.parametrize(
-    "payload, expected",
-    [
-        ({"unexpected": []}, "models"),
-        ({"models": ["not-an-object"]}, "entry 0"),
-        ({"models": [_entry(adapter="invented-adapter")]}, "adapter"),
-        ({"models": [{"id": "missing-required-fields"}]}, "entry 0"),
-    ],
-    ids=[
-        "unsupported-object-envelope",
-        "non-mapping-entry",
-        "invalid-adapter",
-        "missing-required-fields",
-    ],
-)
-def test_load_registry_rejects_malformed_authority_as_runtime_error(
-    tmp_path, payload, expected
-) -> None:
-    # Arrange
-    from puppetmaster.model_registry import load_registry
-
-    path = _write_registry(tmp_path, payload)
-
-    # Act / Assert
-    with pytest.raises(RuntimeError, match=expected):
-        load_registry(path)
-
-
-def test_load_registry_rejects_duplicate_registry_ids(tmp_path) -> None:
-    # Arrange
-    from puppetmaster.model_registry import load_registry
-
-    path = _write_registry(
-        tmp_path,
-        {
-            "models": [
-                _entry(),
-                _entry(adapter_model_name="grok-4.6"),
-            ]
-        },
-    )
-
-    # Act / Assert
-    with pytest.raises(RuntimeError, match="duplicate.*id"):
-        load_registry(path)
-
-
-def test_load_registry_rejects_slug_equivalent_identity_twins(tmp_path) -> None:
-    # Arrange: both entries can satisfy the same direct pin after normalization.
-    from puppetmaster.model_registry import load_registry
-
-    path = _write_registry(
-        tmp_path,
-        {
-            "models": [
-                _entry("cursor/grok-dot", adapter_model_name="grok-4.5"),
-                _entry("cursor/grok-dash", adapter_model_name="grok-4-5"),
-            ]
-        },
-    )
-
-    # Act / Assert
-    with pytest.raises(RuntimeError, match="duplicate.*identity|ambiguous.*identity"):
-        load_registry(path)
 
 
 def _retired_spec(*, adapter_model_name: str = "grok-4.5"):
@@ -136,293 +57,293 @@ def _retired_spec(*, adapter_model_name: str = "grok-4.5"):
     )
 
 
-def test_retirement_requires_reason_and_authority_metadata() -> None:
-    # Arrange
-    from puppetmaster.model_registry import ModelSpec
+class RegistryRetirementTests(unittest.TestCase):
+    def test_load_registry_accepts_both_documented_forms(self) -> None:
+        from puppetmaster.model_registry import load_registry
 
-    common = {
-        "id": "cursor/retired-grok",
-        "adapter": "cursor",
-        "adapter_model_name": "grok-4.5",
-        "enabled": False,
-        "retired": True,
-    }
+        payloads = {
+            "documented-list-form": [_entry()],
+            "documented-object-form": {"models": [_entry()]},
+        }
+        for case_id, payload in payloads.items():
+            with self.subTest(case_id), TemporaryDirectory() as tmp:
+                path = _write_registry(Path(tmp), payload)
+                specs = load_registry(path)
+                self.assertEqual([spec.id for spec in specs], ["cursor/grok-4-5"])
 
-    # Act / Assert
-    with pytest.raises(ValueError, match="reason"):
-        ModelSpec(**common, retirement_authority="user:registry-owner")
-    with pytest.raises(ValueError, match="authority"):
-        ModelSpec(**common, retirement_reason="Superseded")
+    def test_load_registry_rejects_malformed_authority_as_runtime_error(self) -> None:
+        from puppetmaster.model_registry import load_registry
+
+        cases = {
+            "unsupported-object-envelope": ({"unexpected": []}, "models"),
+            "non-mapping-entry": ({"models": ["not-an-object"]}, "entry 0"),
+            "invalid-adapter": ({"models": [_entry(adapter="invented-adapter")]}, "adapter"),
+            "missing-required-fields": ({"models": [{"id": "missing-required-fields"}]}, "entry 0"),
+        }
+        for case_id, (payload, expected) in cases.items():
+            with self.subTest(case_id), TemporaryDirectory() as tmp:
+                path = _write_registry(Path(tmp), payload)
+                with self.assertRaisesRegex(RuntimeError, expected):
+                    load_registry(path)
+
+    def test_load_registry_rejects_duplicate_registry_ids(self) -> None:
+        from puppetmaster.model_registry import load_registry
+
+        with TemporaryDirectory() as tmp:
+            path = _write_registry(
+                Path(tmp),
+                {
+                    "models": [
+                        _entry(),
+                        _entry(adapter_model_name="grok-4.6"),
+                    ]
+                },
+            )
+            with self.assertRaisesRegex(RuntimeError, "duplicate.*id"):
+                load_registry(path)
+
+    def test_load_registry_rejects_slug_equivalent_identity_twins(self) -> None:
+        from puppetmaster.model_registry import load_registry
+
+        with TemporaryDirectory() as tmp:
+            path = _write_registry(
+                Path(tmp),
+                {
+                    "models": [
+                        _entry("cursor/grok-dot", adapter_model_name="grok-4.5"),
+                        _entry("cursor/grok-dash", adapter_model_name="grok-4-5"),
+                    ]
+                },
+            )
+            with self.assertRaisesRegex(RuntimeError, "duplicate.*identity|ambiguous.*identity"):
+                load_registry(path)
+
+    def test_retirement_requires_reason_and_authority_metadata(self) -> None:
+        from puppetmaster.model_registry import ModelSpec
+
+        common = {
+            "id": "cursor/retired-grok",
+            "adapter": "cursor",
+            "adapter_model_name": "grok-4.5",
+            "enabled": False,
+            "retired": True,
+        }
+        with self.assertRaisesRegex(ValueError, "reason"):
+            ModelSpec(**common, retirement_authority="user:registry-owner")
+        with self.assertRaisesRegex(ValueError, "authority"):
+            ModelSpec(**common, retirement_reason="Superseded")
+
+    def test_retired_model_is_ineligible_for_routing_and_direct_pin(self) -> None:
+        from puppetmaster.model_registry import enabled_specs, resolve_model_pin
+
+        retired = _retired_spec()
+        routable = enabled_specs([retired])
+        pin = resolve_model_pin("cursor/retired-grok", [retired], adapter="cursor")
+        self.assertEqual(routable, [])
+        self.assertIsNone(pin)
+
+    def test_retirement_metadata_round_trips_without_losing_quarantine(self) -> None:
+        from puppetmaster.model_registry import load_registry, save_registry
+
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "models.json"
+            retired = _retired_spec()
+            save_registry([retired], path)
+            loaded = load_registry(path)
+            self.assertEqual(len(loaded), 1)
+            self.assertIs(loaded[0].retired, True)
+            self.assertIs(loaded[0].enabled, False)
+            self.assertEqual(loaded[0].retirement_reason, retired.retirement_reason)
+            self.assertEqual(loaded[0].retirement_authority, retired.retirement_authority)
+
+    def test_cursor_discovery_preserves_slug_equivalent_retirement(self) -> None:
+        from puppetmaster.cursor_discovery import merge_catalog_into_registry
+        from puppetmaster.model_registry import normalize_model_token
+
+        retired = _retired_spec(adapter_model_name="grok-4-5")
+        merged, _report = merge_catalog_into_registry(
+            [retired],
+            [{"id": "grok-4.5", "displayName": "Grok 4.5"}],
+        )
+        matches = [
+            spec
+            for spec in merged
+            if spec.adapter == "cursor"
+            and normalize_model_token(spec.adapter_model_name)
+            == normalize_model_token("grok-4.5")
+        ]
+        self.assertEqual(len(matches), 1)
+        self.assertIs(matches[0].retired, True)
+        self.assertIs(matches[0].enabled, False)
+        self.assertEqual(matches[0].retirement_authority, "user:registry-owner")
+
+    def test_curated_discovery_does_not_reenable_retired_identity(self) -> None:
+        from puppetmaster.model_registry import ModelSpec
+        from puppetmaster.static_catalog import curated_catalog, merge_curated_into_registry
+
+        catalog_model = str(curated_catalog("antigravity")[0]["model"])
+        retired = ModelSpec(
+            id="antigravity/locally-retired",
+            adapter="antigravity",
+            adapter_model_name=catalog_model,
+            enabled=False,
+            retired=True,
+            retirement_reason="Retired by local policy",
+            retirement_authority="user:registry-owner",
+        )
+        merged, _report = merge_curated_into_registry(
+            "antigravity", "plan", [retired]
+        )
+        matches = [
+            spec
+            for spec in merged
+            if spec.adapter == "antigravity"
+            and spec.adapter_model_name == catalog_model
+        ]
+        self.assertEqual(len(matches), 1)
+        self.assertIs(matches[0].retired, True)
+        self.assertIs(matches[0].enabled, False)
+        self.assertEqual(matches[0].retirement_reason, "Retired by local policy")
+
+    def test_curated_discovery_preserves_punctuation_equivalent_retirement(self) -> None:
+        from puppetmaster.model_registry import ModelSpec, normalize_model_token
+        from puppetmaster.static_catalog import curated_catalog, merge_curated_into_registry
+
+        catalog_model = next(
+            str(item["model"])
+            for item in curated_catalog("antigravity")
+            if str(item["model"]) != normalize_model_token(str(item["model"]))
+        )
+        retired = ModelSpec(
+            id="antigravity/punctuation-retired",
+            adapter="antigravity",
+            adapter_model_name=normalize_model_token(catalog_model),
+            enabled=False,
+            retired=True,
+            retirement_reason="Retired across catalog spellings",
+            retirement_authority="user:registry-owner",
+        )
+        merged, _report = merge_curated_into_registry(
+            "antigravity", "plan", [retired]
+        )
+        matches = [
+            spec
+            for spec in merged
+            if spec.adapter == "antigravity"
+            and normalize_model_token(spec.adapter_model_name)
+            == normalize_model_token(catalog_model)
+        ]
+        self.assertEqual(len(matches), 1)
+        self.assertIs(matches[0].retired, True)
+        self.assertIs(matches[0].enabled, False)
+        self.assertEqual(matches[0].retirement_authority, "user:registry-owner")
+
+    def test_api_discovery_does_not_reenable_retired_identity(self) -> None:
+        from puppetmaster.api_discovery import merge_api_catalog_into_registry
+        from puppetmaster.model_registry import ModelSpec
+
+        retired = ModelSpec(
+            id="openai/locally-retired",
+            adapter="openai",
+            adapter_model_name="gpt-retired",
+            enabled=False,
+            retired=True,
+            retirement_reason="Retired by local policy",
+            retirement_authority="user:registry-owner",
+        )
+        merged, _report = merge_api_catalog_into_registry(
+            "openai",
+            "api",
+            [retired],
+            [{"id": "gpt-retired"}],
+        )
+        matches = [spec for spec in merged if spec.adapter_model_name == "gpt-retired"]
+        self.assertEqual(len(matches), 1)
+        self.assertIs(matches[0].retired, True)
+        self.assertIs(matches[0].enabled, False)
+
+    def test_api_discovery_preserves_punctuation_equivalent_retirement(self) -> None:
+        from puppetmaster.api_discovery import merge_api_catalog_into_registry
+        from puppetmaster.model_registry import ModelSpec, normalize_model_token
+
+        retired = ModelSpec(
+            id="openai/punctuation-retired",
+            adapter="openai",
+            adapter_model_name="gpt.retired",
+            enabled=False,
+            retired=True,
+            retirement_reason="Retired across catalog spellings",
+            retirement_authority="user:registry-owner",
+        )
+        merged, _report = merge_api_catalog_into_registry(
+            "openai",
+            "api",
+            [retired],
+            [{"id": "gpt-retired"}],
+        )
+        matches = [
+            spec
+            for spec in merged
+            if spec.adapter == "openai"
+            and normalize_model_token(spec.adapter_model_name)
+            == normalize_model_token("gpt-retired")
+        ]
+        self.assertEqual(len(matches), 1)
+        self.assertIs(matches[0].retired, True)
+        self.assertIs(matches[0].enabled, False)
+        self.assertEqual(matches[0].retirement_authority, "user:registry-owner")
+
+    def test_registry_digest_and_schema_version_are_stable_across_round_trip(self) -> None:
+        import puppetmaster.model_registry as registry_module
+
+        retired = _retired_spec()
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "models.json"
+            before = registry_module.registry_digest([retired])
+            registry_module.save_registry([retired], path)
+            after = registry_module.registry_digest(registry_module.load_registry(path))
+            self.assertGreaterEqual(registry_module.REGISTRY_SCHEMA_VERSION, 1)
+            self.assertEqual(before, after)
+            self.assertEqual(len(before), 64)
+            int(before, 16)
+
+    def test_registry_digest_changes_for_routing_or_quarantine_authority(self) -> None:
+        import puppetmaster.model_registry as registry_module
+
+        retired = _retired_spec()
+        baseline = registry_module.registry_digest([retired])
+        capability_changed = registry_module.registry_digest(
+            [replace(retired, capability_score=retired.capability_score - 1)]
+        )
+        authority_changed = registry_module.registry_digest(
+            [replace(retired, retirement_authority="policy:security-team")]
+        )
+        self.assertNotEqual(baseline, capability_changed)
+        self.assertNotEqual(baseline, authority_changed)
+
+    def test_registry_digest_changes_when_routing_precedence_order_changes(self) -> None:
+        import puppetmaster.model_registry as registry_module
+
+        first = registry_module.ModelSpec(
+            id="cursor/equal-first",
+            adapter="cursor",
+            adapter_model_name="equal-first",
+            capability_score=90,
+            input_per_mtok_usd=1.0,
+            output_per_mtok_usd=1.0,
+        )
+        second = registry_module.ModelSpec(
+            id="cursor/equal-second",
+            adapter="cursor",
+            adapter_model_name="equal-second",
+            capability_score=90,
+            input_per_mtok_usd=1.0,
+            output_per_mtok_usd=1.0,
+        )
+        first_precedence = registry_module.registry_digest([first, second])
+        second_precedence = registry_module.registry_digest([second, first])
+        self.assertNotEqual(first_precedence, second_precedence)
 
 
-def test_retired_model_is_ineligible_for_routing_and_direct_pin() -> None:
-    # Arrange
-    from puppetmaster.model_registry import enabled_specs, resolve_model_pin
-
-    retired = _retired_spec()
-
-    # Act
-    routable = enabled_specs([retired])
-    pin = resolve_model_pin("cursor/retired-grok", [retired], adapter="cursor")
-
-    # Assert
-    assert routable == []
-    assert pin is None
-
-
-def test_retirement_metadata_round_trips_without_losing_quarantine(tmp_path) -> None:
-    # Arrange
-    from puppetmaster.model_registry import load_registry, save_registry
-
-    path = tmp_path / "models.json"
-    retired = _retired_spec()
-
-    # Act
-    save_registry([retired], path)
-    loaded = load_registry(path)
-
-    # Assert
-    assert len(loaded) == 1
-    assert loaded[0].retired is True
-    assert loaded[0].enabled is False
-    assert loaded[0].retirement_reason == retired.retirement_reason
-    assert loaded[0].retirement_authority == retired.retirement_authority
-
-
-def test_cursor_discovery_preserves_slug_equivalent_retirement() -> None:
-    # Arrange
-    from puppetmaster.cursor_discovery import merge_catalog_into_registry
-    from puppetmaster.model_registry import normalize_model_token
-
-    retired = _retired_spec(adapter_model_name="grok-4-5")
-
-    # Act
-    merged, _report = merge_catalog_into_registry(
-        [retired],
-        [{"id": "grok-4.5", "displayName": "Grok 4.5"}],
-    )
-
-    # Assert: discovery may refresh spelling, but cannot create an enabled twin.
-    matches = [
-        spec
-        for spec in merged
-        if spec.adapter == "cursor"
-        and normalize_model_token(spec.adapter_model_name)
-        == normalize_model_token("grok-4.5")
-    ]
-    assert len(matches) == 1
-    assert matches[0].retired is True
-    assert matches[0].enabled is False
-    assert matches[0].retirement_authority == "user:registry-owner"
-
-
-def test_curated_discovery_does_not_reenable_retired_identity() -> None:
-    # Arrange
-    from puppetmaster.model_registry import ModelSpec
-    from puppetmaster.static_catalog import curated_catalog, merge_curated_into_registry
-
-    catalog_model = str(curated_catalog("antigravity")[0]["model"])
-    retired = ModelSpec(
-        id="antigravity/locally-retired",
-        adapter="antigravity",
-        adapter_model_name=catalog_model,
-        enabled=False,
-        retired=True,
-        retirement_reason="Retired by local policy",
-        retirement_authority="user:registry-owner",
-    )
-
-    # Act
-    merged, _report = merge_curated_into_registry(
-        "antigravity", "plan", [retired]
-    )
-
-    # Assert
-    matches = [
-        spec
-        for spec in merged
-        if spec.adapter == "antigravity"
-        and spec.adapter_model_name == catalog_model
-    ]
-    assert len(matches) == 1
-    assert matches[0].retired is True
-    assert matches[0].enabled is False
-    assert matches[0].retirement_reason == "Retired by local policy"
-
-
-def test_curated_discovery_preserves_punctuation_equivalent_retirement() -> None:
-    # Arrange: curated catalogs may spell an identity with dots while a local
-    # quarantine uses its slug form. Those are the same executable identity.
-    from puppetmaster.model_registry import ModelSpec, normalize_model_token
-    from puppetmaster.static_catalog import curated_catalog, merge_curated_into_registry
-
-    catalog_model = next(
-        str(item["model"])
-        for item in curated_catalog("antigravity")
-        if str(item["model"]) != normalize_model_token(str(item["model"]))
-    )
-    retired = ModelSpec(
-        id="antigravity/punctuation-retired",
-        adapter="antigravity",
-        adapter_model_name=normalize_model_token(catalog_model),
-        enabled=False,
-        retired=True,
-        retirement_reason="Retired across catalog spellings",
-        retirement_authority="user:registry-owner",
-    )
-
-    # Act
-    merged, _report = merge_curated_into_registry(
-        "antigravity", "plan", [retired]
-    )
-
-    # Assert: refresh may adopt catalog punctuation but cannot create a twin.
-    matches = [
-        spec
-        for spec in merged
-        if spec.adapter == "antigravity"
-        and normalize_model_token(spec.adapter_model_name)
-        == normalize_model_token(catalog_model)
-    ]
-    assert len(matches) == 1
-    assert matches[0].retired is True
-    assert matches[0].enabled is False
-    assert matches[0].retirement_authority == "user:registry-owner"
-
-
-def test_api_discovery_does_not_reenable_retired_identity() -> None:
-    # Arrange
-    from puppetmaster.api_discovery import merge_api_catalog_into_registry
-    from puppetmaster.model_registry import ModelSpec
-
-    retired = ModelSpec(
-        id="openai/locally-retired",
-        adapter="openai",
-        adapter_model_name="gpt-retired",
-        enabled=False,
-        retired=True,
-        retirement_reason="Retired by local policy",
-        retirement_authority="user:registry-owner",
-    )
-
-    # Act
-    merged, _report = merge_api_catalog_into_registry(
-        "openai",
-        "api",
-        [retired],
-        [{"id": "gpt-retired"}],
-    )
-
-    # Assert
-    matches = [spec for spec in merged if spec.adapter_model_name == "gpt-retired"]
-    assert len(matches) == 1
-    assert matches[0].retired is True
-    assert matches[0].enabled is False
-
-
-def test_api_discovery_preserves_punctuation_equivalent_retirement() -> None:
-    # Arrange
-    from puppetmaster.api_discovery import merge_api_catalog_into_registry
-    from puppetmaster.model_registry import ModelSpec, normalize_model_token
-
-    retired = ModelSpec(
-        id="openai/punctuation-retired",
-        adapter="openai",
-        adapter_model_name="gpt.retired",
-        enabled=False,
-        retired=True,
-        retirement_reason="Retired across catalog spellings",
-        retirement_authority="user:registry-owner",
-    )
-
-    # Act
-    merged, _report = merge_api_catalog_into_registry(
-        "openai",
-        "api",
-        [retired],
-        [{"id": "gpt-retired"}],
-    )
-
-    # Assert
-    matches = [
-        spec
-        for spec in merged
-        if spec.adapter == "openai"
-        and normalize_model_token(spec.adapter_model_name)
-        == normalize_model_token("gpt-retired")
-    ]
-    assert len(matches) == 1
-    assert matches[0].retired is True
-    assert matches[0].enabled is False
-    assert matches[0].retirement_authority == "user:registry-owner"
-
-
-def test_registry_digest_and_schema_version_are_stable_across_round_trip(
-    tmp_path,
-) -> None:
-    # Arrange
-    import puppetmaster.model_registry as registry_module
-
-    retired = _retired_spec()
-    path = tmp_path / "models.json"
-
-    # Act
-    before = registry_module.registry_digest([retired])
-    registry_module.save_registry([retired], path)
-    after = registry_module.registry_digest(registry_module.load_registry(path))
-
-    # Assert
-    assert registry_module.REGISTRY_SCHEMA_VERSION >= 1
-    assert before == after
-    assert len(before) == 64
-    int(before, 16)
-
-
-def test_registry_digest_changes_for_routing_or_quarantine_authority() -> None:
-    # Arrange
-    import puppetmaster.model_registry as registry_module
-
-    retired = _retired_spec()
-
-    # Act
-    baseline = registry_module.registry_digest([retired])
-    capability_changed = registry_module.registry_digest(
-        [replace(retired, capability_score=retired.capability_score - 1)]
-    )
-    authority_changed = registry_module.registry_digest(
-        [replace(retired, retirement_authority="policy:security-team")]
-    )
-
-    # Assert
-    assert baseline != capability_changed
-    assert baseline != authority_changed
-
-
-def test_registry_digest_changes_when_routing_precedence_order_changes() -> None:
-    # Arrange: router min/max tie-breaking retains registry insertion order for
-    # otherwise equal candidates, so row order is material reproduction state.
-    import puppetmaster.model_registry as registry_module
-
-    first = registry_module.ModelSpec(
-        id="cursor/equal-first",
-        adapter="cursor",
-        adapter_model_name="equal-first",
-        capability_score=90,
-        input_per_mtok_usd=1.0,
-        output_per_mtok_usd=1.0,
-    )
-    second = registry_module.ModelSpec(
-        id="cursor/equal-second",
-        adapter="cursor",
-        adapter_model_name="equal-second",
-        capability_score=90,
-        input_per_mtok_usd=1.0,
-        output_per_mtok_usd=1.0,
-    )
-
-    # Act
-    first_precedence = registry_module.registry_digest([first, second])
-    second_precedence = registry_module.registry_digest([second, first])
-
-    # Assert
-    assert first_precedence != second_precedence
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_router_context_policy.py
+++ b/tests/test_router_context_policy.py
@@ -4,9 +4,18 @@ These tests were authored against the TASK-001-completed baseline before the
 TASK-002 author implementation was inspected.  They intentionally exercise
 public behavior rather than private ranking helpers.
 """
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
 from types import SimpleNamespace
 
-import pytest
+_HERMETIC_DIR = os.path.dirname(os.path.abspath(__file__))
+if _HERMETIC_DIR not in sys.path:
+    sys.path.insert(0, _HERMETIC_DIR)
+import hermetic_env  # noqa: F401  # process-wide host-env isolation
 
 from puppetmaster import router
 from puppetmaster.model_registry import ModelSpec
@@ -32,384 +41,319 @@ def _model(
     )
 
 
-def test_context_filter_reserves_output_before_selecting_cheapest_model() -> None:
-    # Arrange: input fits the bargain model, but input + output reserve does not.
-    bargain = _model(
-        "cursor/bargain", capability=60, input_cost=0.10, context_window=4_000
-    )
-    roomy = _model(
-        "cursor/roomy", capability=70, input_cost=1.00, context_window=16_000
-    )
-    task = router.TaskSignals(
-        instruction="verify the result",
-        role="verify-runtime",
-        explicit_min_capability=50,
-        estimated_tokens_in=3_000,
-        estimated_tokens_out=1_500,
-    )
+class RouterContextPolicyTests(unittest.TestCase):
+    def test_context_filter_reserves_output_before_selecting_cheapest_model(self) -> None:
+        bargain = _model(
+            "cursor/bargain", capability=60, input_cost=0.10, context_window=4_000
+        )
+        roomy = _model(
+            "cursor/roomy", capability=70, input_cost=1.00, context_window=16_000
+        )
+        task = router.TaskSignals(
+            instruction="verify the result",
+            role="verify-runtime",
+            explicit_min_capability=50,
+            estimated_tokens_in=3_000,
+            estimated_tokens_out=1_500,
+        )
+        decision = router.route_task(task, [bargain, roomy], policy="cheap")
+        self.assertEqual(decision.model.id, "cursor/roomy")
+        rejected_reason = dict((spec.id, why) for spec, why in decision.rejected)
+        self.assertIn("context", rejected_reason["cursor/bargain"].lower())
+        self.assertIn("3000", rejected_reason["cursor/bargain"])
+        self.assertIn("1500", rejected_reason["cursor/bargain"])
+        self.assertIn("4000", rejected_reason["cursor/bargain"])
 
-    # Act.
-    decision = router.route_task(task, [bargain, roomy], policy="cheap")
+    def test_context_filter_fails_when_every_known_window_overflows(self) -> None:
+        task = router.TaskSignals(
+            instruction="verify the result",
+            role="verify-runtime",
+            explicit_min_capability=20,
+            estimated_tokens_in=3_500,
+            estimated_tokens_out=1_000,
+        )
+        models = [
+            _model("cursor/a", capability=50, input_cost=0.10, context_window=4_000),
+            _model("cursor/b", capability=90, input_cost=1.00, context_window=4_499),
+        ]
+        with self.assertRaisesRegex(router.NoEligibleModelError, "(?i)context"):
+            router.route_task(task, models, policy="balanced")
 
-    # Assert: the overflowing bargain model never reaches policy ranking.
-    assert decision.model.id == "cursor/roomy"
-    rejected_reason = dict((spec.id, why) for spec, why in decision.rejected)
-    assert "context" in rejected_reason["cursor/bargain"].lower()
-    assert "3000" in rejected_reason["cursor/bargain"]
-    assert "1500" in rejected_reason["cursor/bargain"]
-    assert "4000" in rejected_reason["cursor/bargain"]
+    def test_explicit_token_estimates_fail_closed_when_invalid(self) -> None:
+        cases = (
+            ("estimated_tokens_in", -1, "negative-input"),
+            ("estimated_tokens_in", True, "boolean-input"),
+            ("estimated_tokens_in", 1.5, "non-integer-input"),
+            ("estimated_tokens_in", "1000", "malformed-input"),
+            ("estimated_tokens_out", -1, "negative-output"),
+            ("estimated_tokens_out", False, "boolean-output"),
+            ("estimated_tokens_out", 1.5, "non-integer-output"),
+            ("estimated_tokens_out", "200", "malformed-output"),
+        )
+        for field_name, invalid_value, case_id in cases:
+            with self.subTest(case_id):
+                task_values = {
+                    "instruction": "verify the result",
+                    "role": "verify-runtime",
+                    "explicit_min_capability": 20,
+                    "estimated_tokens_in": 900,
+                    "estimated_tokens_out": 200,
+                }
+                task_values[field_name] = invalid_value
+                task = router.TaskSignals(**task_values)
+                model = _model(
+                    "cursor/small-window",
+                    capability=60,
+                    input_cost=0.10,
+                    context_window=1_000,
+                )
+                with self.assertRaisesRegex(ValueError, field_name):
+                    router.route_task(task, [model], policy="balanced")
 
-
-def test_context_filter_fails_when_every_known_window_overflows() -> None:
-    # Arrange.
-    task = router.TaskSignals(
-        instruction="verify the result",
-        role="verify-runtime",
-        explicit_min_capability=20,
-        estimated_tokens_in=3_500,
-        estimated_tokens_out=1_000,
-    )
-    models = [
-        _model("cursor/a", capability=50, input_cost=0.10, context_window=4_000),
-        _model("cursor/b", capability=90, input_cost=1.00, context_window=4_499),
-    ]
-
-    # Act / Assert.
-    with pytest.raises(router.NoEligibleModelError, match="(?i)context"):
-        router.route_task(task, models, policy="balanced")
-
-
-@pytest.mark.parametrize(
-    ("field_name", "invalid_value"),
-    [
-        pytest.param("estimated_tokens_in", -1, id="negative-input"),
-        pytest.param("estimated_tokens_in", True, id="boolean-input"),
-        pytest.param("estimated_tokens_in", 1.5, id="non-integer-input"),
-        pytest.param("estimated_tokens_in", "1000", id="malformed-input"),
-        pytest.param("estimated_tokens_out", -1, id="negative-output"),
-        pytest.param("estimated_tokens_out", False, id="boolean-output"),
-        pytest.param("estimated_tokens_out", 1.5, id="non-integer-output"),
-        pytest.param("estimated_tokens_out", "200", id="malformed-output"),
-    ],
-)
-def test_explicit_token_estimates_fail_closed_when_invalid(
-    field_name: str, invalid_value: object
-) -> None:
-    # Arrange: a deliberately small window would become falsely eligible if an
-    # invalid override were clamped, bool-coerced, truncated, or subtracted.
-    task_values = {
-        "instruction": "verify the result",
-        "role": "verify-runtime",
-        "explicit_min_capability": 20,
-        "estimated_tokens_in": 900,
-        "estimated_tokens_out": 200,
-    }
-    task_values[field_name] = invalid_value
-    task = router.TaskSignals(**task_values)
-    model = _model(
-        "cursor/small-window",
-        capability=60,
-        input_cost=0.10,
-        context_window=1_000,
-    )
-
-    # Act / Assert: malformed authority must fail before context or cost math.
-    with pytest.raises(ValueError, match=field_name):
-        router.route_task(task, [model], policy="balanced")
-
-
-def test_worker_signals_count_nested_payload_and_declared_enrichment() -> None:
-    # Arrange: almost all context is below the payload's top level.
-    nested_text = "nested repository context " * 400
-    spec = SimpleNamespace(
-        instruction="inspect",
-        role="explore",
-        payload={
-            "context": {
-                "documents": [
-                    {"body": nested_text},
-                    ("secondary context", {"notes": "more evidence"}),
-                ]
+    def test_worker_signals_count_nested_payload_and_declared_enrichment(self) -> None:
+        nested_text = "nested repository context " * 400
+        spec = SimpleNamespace(
+            instruction="inspect",
+            role="explore",
+            payload={
+                "context": {
+                    "documents": [
+                        {"body": nested_text},
+                        ("secondary context", {"notes": "more evidence"}),
+                    ]
+                },
+                "adapter_enrichment_tokens": 1_200,
             },
-            "adapter_enrichment_tokens": 1_200,
-        },
-    )
+        )
+        signals = router.signals_from_worker_spec(spec)
+        estimate = router.estimate_tokens_in(signals)
+        self.assertGreaterEqual(signals.payload_size_chars, len(nested_text))
+        self.assertEqual(signals.adapter_enrichment_tokens, 1_200)
+        un_enriched_floor = max(
+            500,
+            (len(spec.instruction) + signals.payload_size_chars) // 4 + 500,
+        )
+        self.assertGreaterEqual(estimate, un_enriched_floor + 1_200)
 
-    # Act.
-    signals = router.signals_from_worker_spec(spec)
-    estimate = router.estimate_tokens_in(signals)
-
-    # Assert: recursive payload context and explicit adapter overhead both count.
-    assert signals.payload_size_chars >= len(nested_text)
-    assert signals.adapter_enrichment_tokens == 1_200
-    un_enriched_floor = max(
-        500,
-        (len(spec.instruction) + signals.payload_size_chars) // 4 + 500,
-    )
-    assert estimate >= un_enriched_floor + 1_200
-
-
-def test_measured_calibration_is_explicit_attributable_and_policy_neutral() -> None:
-    # Arrange: three measurements establish a stable 2x estimate/actual drift.
-    measurements = [
-        {"estimated_tokens_in": 1_000, "actual_tokens_in": 2_000},
-        {"estimated_tokens_in": 2_000, "actual_tokens_in": 4_000},
-        {"estimated_tokens_in": 3_000, "actual_tokens_in": 6_000},
-    ]
-    calibration = router.calibration_from_measurements(
-        measurements,
-        adapter="cursor",
-        model_id="cursor/calibrated",
-        role="verify-runtime",
-        source="measured_usage",
-    )
-    task = router.TaskSignals(
-        instruction="verify",
-        role="verify-runtime",
-        estimated_tokens_in=1_000,
-        estimated_tokens_out=200,
-    )
-    model = _model(
-        "cursor/calibrated", capability=60, input_cost=0.10, context_window=8_000
-    )
-
-    # Act.
-    calibrated_estimate = router.estimate_tokens_in(task, calibration=calibration)
-    decision = router.route_task(
-        task,
-        [model],
-        policy="cheap",
-        calibration=calibration,
-    )
-    payload = decision.to_artifact_payload()
-
-    # Assert: measured data changes only the explicit estimate, not policy.
-    assert calibration.multiplier == pytest.approx(2.0)
-    assert calibration.sample_count == 3
-    assert calibrated_estimate == 2_000
-    assert decision.estimated_tokens_in == 2_000
-    assert decision.policy == "cheap"
-    assert payload["token_estimate_calibration"] == {
-        "adapter": "cursor",
-        "model_id": "cursor/calibrated",
-        "canonical_role": "verify-runtime",
-        "source": "measured_usage",
-        "sample_count": 3,
-        "multiplier": 2.0,
-    }
-
-
-def test_model_scoped_calibration_does_not_distort_other_candidates() -> None:
-    # Arrange: only cursor/calibrated has measured 2x drift. Its calibrated
-    # request overflows, while the uncalibrated alternative safely fits its
-    # own smaller window at the base estimate.
-    calibration = router.calibration_from_measurements(
-        [
+    def test_measured_calibration_is_explicit_attributable_and_policy_neutral(self) -> None:
+        measurements = [
             {"estimated_tokens_in": 1_000, "actual_tokens_in": 2_000},
             {"estimated_tokens_in": 2_000, "actual_tokens_in": 4_000},
-        ],
-        adapter="cursor",
-        model_id="cursor/calibrated",
-        role="verify-runtime",
-        source="measured_usage",
-    )
-    task = router.TaskSignals(
-        instruction="verify",
-        role="verify-runtime",
-        explicit_min_capability=40,
-        estimated_tokens_in=1_000,
-        estimated_tokens_out=200,
-    )
-    calibrated = _model(
-        "cursor/calibrated", capability=60, input_cost=0.01, context_window=1_900
-    )
-    uncalibrated = _model(
-        "cursor/uncalibrated", capability=60, input_cost=0.10, context_window=1_500
-    )
+            {"estimated_tokens_in": 3_000, "actual_tokens_in": 6_000},
+        ]
+        calibration = router.calibration_from_measurements(
+            measurements,
+            adapter="cursor",
+            model_id="cursor/calibrated",
+            role="verify-runtime",
+            source="measured_usage",
+        )
+        task = router.TaskSignals(
+            instruction="verify",
+            role="verify-runtime",
+            estimated_tokens_in=1_000,
+            estimated_tokens_out=200,
+        )
+        model = _model(
+            "cursor/calibrated", capability=60, input_cost=0.10, context_window=8_000
+        )
+        calibrated_estimate = router.estimate_tokens_in(task, calibration=calibration)
+        decision = router.route_task(
+            task,
+            [model],
+            policy="cheap",
+            calibration=calibration,
+        )
+        payload = decision.to_artifact_payload()
+        self.assertAlmostEqual(calibration.multiplier, 2.0)
+        self.assertEqual(calibration.sample_count, 3)
+        self.assertEqual(calibrated_estimate, 2_000)
+        self.assertEqual(decision.estimated_tokens_in, 2_000)
+        self.assertEqual(decision.policy, "cheap")
+        self.assertEqual(
+            payload["token_estimate_calibration"],
+            {
+                "adapter": "cursor",
+                "model_id": "cursor/calibrated",
+                "canonical_role": "verify-runtime",
+                "source": "measured_usage",
+                "sample_count": 3,
+                "multiplier": 2.0,
+            },
+        )
 
-    # Act.
-    decision = router.route_task(
-        task,
-        [calibrated, uncalibrated],
-        policy="cheap",
-        calibration=calibration,
-    )
+    def test_model_scoped_calibration_does_not_distort_other_candidates(self) -> None:
+        calibration = router.calibration_from_measurements(
+            [
+                {"estimated_tokens_in": 1_000, "actual_tokens_in": 2_000},
+                {"estimated_tokens_in": 2_000, "actual_tokens_in": 4_000},
+            ],
+            adapter="cursor",
+            model_id="cursor/calibrated",
+            role="verify-runtime",
+            source="measured_usage",
+        )
+        task = router.TaskSignals(
+            instruction="verify",
+            role="verify-runtime",
+            explicit_min_capability=40,
+            estimated_tokens_in=1_000,
+            estimated_tokens_out=200,
+        )
+        calibrated = _model(
+            "cursor/calibrated", capability=60, input_cost=0.01, context_window=1_900
+        )
+        uncalibrated = _model(
+            "cursor/uncalibrated", capability=60, input_cost=0.10, context_window=1_500
+        )
+        decision = router.route_task(
+            task,
+            [calibrated, uncalibrated],
+            policy="cheap",
+            calibration=calibration,
+        )
+        self.assertEqual(decision.model.id, "cursor/uncalibrated")
+        self.assertEqual(decision.estimated_tokens_in, 1_000)
+        self.assertNotIn("token_estimate_calibration", decision.to_artifact_payload())
 
-    # Assert: model-scoped evidence applies only to its named model. Applying
-    # 2x globally would incorrectly reject the safe uncalibrated alternative.
-    assert decision.model.id == "cursor/uncalibrated"
-    assert decision.estimated_tokens_in == 1_000
-    assert "token_estimate_calibration" not in decision.to_artifact_payload()
+    def test_cheap_selects_cheapest_sufficient_model(self) -> None:
+        task = router.TaskSignals(
+            instruction="perform the bounded task",
+            role="verify-runtime",
+            explicit_min_capability=70,
+            estimated_tokens_in=1_000,
+            estimated_tokens_out=200,
+        )
+        bargain_but_weak = _model(
+            "cursor/weak", capability=40, input_cost=0.01
+        )
+        cheapest_sufficient = _model(
+            "cursor/sufficient", capability=75, input_cost=0.10
+        )
+        costly_frontier = _model(
+            "cursor/frontier", capability=95, input_cost=1.00
+        )
+        decision = router.route_task(
+            task,
+            [bargain_but_weak, cheapest_sufficient, costly_frontier],
+            policy="cheap",
+        )
+        self.assertEqual(decision.model.id, "cursor/sufficient")
+        self.assertIn("cheapest sufficient", decision.reason.lower())
+        rejected_reason = dict((spec.id, why) for spec, why in decision.rejected)
+        self.assertIn("capability", rejected_reason["cursor/weak"].lower())
+
+    def test_absolute_cheapest_requires_explicit_policy_opt_in(self) -> None:
+        task = router.TaskSignals(
+            instruction="perform the bounded task",
+            role="verify-runtime",
+            explicit_min_capability=70,
+            estimated_tokens_in=1_000,
+            estimated_tokens_out=200,
+        )
+        weak = _model("cursor/weak", capability=40, input_cost=0.01)
+        sufficient = _model("cursor/sufficient", capability=75, input_cost=0.10)
+        decision = router.route_task(
+            task, [weak, sufficient], policy="absolute-cheapest"
+        )
+        self.assertEqual(decision.model.id, "cursor/weak")
+        self.assertEqual(decision.policy, "absolute-cheapest")
+        self.assertIn("absolute", decision.reason.lower())
+
+    def test_absolute_cheapest_is_reachable_through_every_cli_policy_flag(self) -> None:
+        from puppetmaster.cli._parser import build_parser
+
+        parser = build_parser()
+        policy_actions = []
+        pending = [parser]
+        seen = set()
+        while pending:
+            current = pending.pop()
+            if id(current) in seen:
+                continue
+            seen.add(id(current))
+            for action in current._actions:
+                if action.dest in {"policy", "routing_policy"} and action.choices:
+                    policy_actions.append(action)
+                choices = getattr(action, "choices", None)
+                if isinstance(choices, dict):
+                    pending.extend(choices.values())
+        self.assertTrue(policy_actions)
+        missing = [action.dest for action in policy_actions if "absolute-cheapest" not in action.choices]
+        self.assertEqual(missing, [])
+
+    def test_absolute_cheapest_is_reachable_through_every_mcp_policy_enum(self) -> None:
+        from puppetmaster import mcp_server
+
+        schemas = {
+            "route_task": mcp_server.route_task_schema(),
+            "auto_route": {"properties": mcp_server._auto_route_schema_properties()},
+            "swarm": mcp_server.swarm_schema(),
+            "cursor_swarm": mcp_server.cursor_swarm_schema(),
+            "codex": mcp_server.codex_schema(),
+            "claude": mcp_server.claude_schema(),
+            "cursor_implement": mcp_server.cursor_implement_schema(),
+            "implement": mcp_server.implement_schema(),
+            "edit": mcp_server.edit_schema(),
+            "browser_swarm": mcp_server.browser_swarm_schema(),
+            "agentic": mcp_server.agentic_schema(),
+            "openai": mcp_server.openai_schema(),
+        }
+        found = []
+
+        def visit(value, schema_name: str) -> None:
+            if isinstance(value, dict):
+                properties = value.get("properties")
+                if isinstance(properties, dict):
+                    for property_name in ("policy", "routing_policy"):
+                        property_schema = properties.get(property_name)
+                        if isinstance(property_schema, dict) and "enum" in property_schema:
+                            found.append((schema_name, property_name, property_schema["enum"]))
+                for child in value.values():
+                    visit(child, schema_name)
+            elif isinstance(value, list):
+                for child in value:
+                    visit(child, schema_name)
+
+        for name, schema in schemas.items():
+            visit(schema, name)
+        self.assertTrue(found)
+        missing = [f"{name}.{property_name}" for name, property_name, enum in found if "absolute-cheapest" not in enum]
+        self.assertEqual(missing, [])
+
+    def test_strict_capability_fails_closed_when_catalog_is_insufficient(self) -> None:
+        task = router.TaskSignals(
+            instruction="perform the critical task",
+            role="verify-runtime",
+            explicit_min_capability=95,
+            strict_capability=True,
+            estimated_tokens_in=1_000,
+            estimated_tokens_out=200,
+        )
+        models = [
+            _model("cursor/mid", capability=60, input_cost=0.10),
+            _model("cursor/best", capability=85, input_cost=1.00),
+        ]
+        with self.assertRaisesRegex(router.NoEligibleModelError, "(?i)capability.*95"):
+            router.route_task(task, models, policy="balanced")
+
+    def test_non_strict_balanced_fallback_remains_explicit_and_compatible(self) -> None:
+        task = router.TaskSignals(
+            instruction="perform the task",
+            role="verify-runtime",
+            explicit_min_capability=95,
+            estimated_tokens_in=1_000,
+            estimated_tokens_out=200,
+        )
+        models = [
+            _model("cursor/mid", capability=60, input_cost=0.10),
+            _model("cursor/best", capability=85, input_cost=1.00),
+        ]
+        decision = router.route_task(task, models, policy="balanced")
+        self.assertEqual(decision.model.id, "cursor/best")
+        self.assertIn("no model meets capability need (95)", decision.reason.lower())
+        self.assertIn("falling back", decision.reason.lower())
 
 
-def test_cheap_selects_cheapest_sufficient_model() -> None:
-    # Arrange.
-    task = router.TaskSignals(
-        instruction="perform the bounded task",
-        role="verify-runtime",
-        explicit_min_capability=70,
-        estimated_tokens_in=1_000,
-        estimated_tokens_out=200,
-    )
-    bargain_but_weak = _model(
-        "cursor/weak", capability=40, input_cost=0.01
-    )
-    cheapest_sufficient = _model(
-        "cursor/sufficient", capability=75, input_cost=0.10
-    )
-    costly_frontier = _model(
-        "cursor/frontier", capability=95, input_cost=1.00
-    )
-
-    # Act.
-    decision = router.route_task(
-        task,
-        [bargain_but_weak, cheapest_sufficient, costly_frontier],
-        policy="cheap",
-    )
-
-    # Assert.
-    assert decision.model.id == "cursor/sufficient"
-    assert "cheapest sufficient" in decision.reason.lower()
-    rejected_reason = dict((spec.id, why) for spec, why in decision.rejected)
-    assert "capability" in rejected_reason["cursor/weak"].lower()
-
-
-def test_absolute_cheapest_requires_explicit_policy_opt_in() -> None:
-    # Arrange.
-    task = router.TaskSignals(
-        instruction="perform the bounded task",
-        role="verify-runtime",
-        explicit_min_capability=70,
-        estimated_tokens_in=1_000,
-        estimated_tokens_out=200,
-    )
-    weak = _model("cursor/weak", capability=40, input_cost=0.01)
-    sufficient = _model("cursor/sufficient", capability=75, input_cost=0.10)
-
-    # Act.
-    decision = router.route_task(
-        task, [weak, sufficient], policy="absolute-cheapest"
-    )
-
-    # Assert.
-    assert decision.model.id == "cursor/weak"
-    assert decision.policy == "absolute-cheapest"
-    assert "absolute" in decision.reason.lower()
-
-
-def test_absolute_cheapest_is_reachable_through_every_cli_policy_flag() -> None:
-    # Arrange: inspect the parser's public policy choices recursively, including
-    # direct adapters, edit, swarm, browser, and the route dry-run command.
-    from puppetmaster.cli._parser import build_parser
-
-    parser = build_parser()
-    policy_actions = []
-    pending = [parser]
-    seen = set()
-    while pending:
-        current = pending.pop()
-        if id(current) in seen:
-            continue
-        seen.add(id(current))
-        for action in current._actions:
-            if action.dest in {"policy", "routing_policy"} and action.choices:
-                policy_actions.append(action)
-            choices = getattr(action, "choices", None)
-            if isinstance(choices, dict):
-                pending.extend(choices.values())
-
-    # Act / Assert: an internal router policy is not an available user opt-in
-    # while any public routing flag rejects it at argument parsing.
-    assert policy_actions
-    missing = [action.dest for action in policy_actions if "absolute-cheapest" not in action.choices]
-    assert missing == []
-
-
-def test_absolute_cheapest_is_reachable_through_every_mcp_policy_enum() -> None:
-    # Arrange: exercise every public MCP schema family with a routing policy.
-    from puppetmaster import mcp_server
-
-    schemas = {
-        "route_task": mcp_server.route_task_schema(),
-        "auto_route": {"properties": mcp_server._auto_route_schema_properties()},
-        "swarm": mcp_server.swarm_schema(),
-        "cursor_swarm": mcp_server.cursor_swarm_schema(),
-        "codex": mcp_server.codex_schema(),
-        "claude": mcp_server.claude_schema(),
-        "cursor_implement": mcp_server.cursor_implement_schema(),
-        "implement": mcp_server.implement_schema(),
-        "edit": mcp_server.edit_schema(),
-        "browser_swarm": mcp_server.browser_swarm_schema(),
-        "agentic": mcp_server.agentic_schema(),
-        "openai": mcp_server.openai_schema(),
-    }
-
-    # Act: collect each schema property whose public name denotes routing
-    # policy; recurse because some tool schemas compose nested definitions.
-    found = []
-
-    def visit(value, schema_name: str) -> None:
-        if isinstance(value, dict):
-            properties = value.get("properties")
-            if isinstance(properties, dict):
-                for property_name in ("policy", "routing_policy"):
-                    property_schema = properties.get(property_name)
-                    if isinstance(property_schema, dict) and "enum" in property_schema:
-                        found.append((schema_name, property_name, property_schema["enum"]))
-            for child in value.values():
-                visit(child, schema_name)
-        elif isinstance(value, list):
-            for child in value:
-                visit(child, schema_name)
-
-    for name, schema in schemas.items():
-        visit(schema, name)
-
-    # Assert.
-    assert found
-    missing = [f"{name}.{property_name}" for name, property_name, enum in found if "absolute-cheapest" not in enum]
-    assert missing == []
-
-
-def test_strict_capability_fails_closed_when_catalog_is_insufficient() -> None:
-    # Arrange.
-    task = router.TaskSignals(
-        instruction="perform the critical task",
-        role="verify-runtime",
-        explicit_min_capability=95,
-        strict_capability=True,
-        estimated_tokens_in=1_000,
-        estimated_tokens_out=200,
-    )
-    models = [
-        _model("cursor/mid", capability=60, input_cost=0.10),
-        _model("cursor/best", capability=85, input_cost=1.00),
-    ]
-
-    # Act / Assert.
-    with pytest.raises(router.NoEligibleModelError, match="(?i)capability.*95"):
-        router.route_task(task, models, policy="balanced")
-
-
-def test_non_strict_balanced_fallback_remains_explicit_and_compatible() -> None:
-    # Arrange.
-    task = router.TaskSignals(
-        instruction="perform the task",
-        role="verify-runtime",
-        explicit_min_capability=95,
-        estimated_tokens_in=1_000,
-        estimated_tokens_out=200,
-    )
-    models = [
-        _model("cursor/mid", capability=60, input_cost=0.10),
-        _model("cursor/best", capability=85, input_cost=1.00),
-    ]
-
-    # Act.
-    decision = router.route_task(task, models, policy="balanced")
-
-    # Assert.
-    assert decision.model.id == "cursor/best"
-    assert "no model meets capability need (95)" in decision.reason.lower()
-    assert "falling back" in decision.reason.lower()
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_routing_audit_quality.py
+++ b/tests/test_routing_audit_quality.py
@@ -6,12 +6,17 @@ evidence to remain attributable and qualified before it affects routing.
 """
 from __future__ import annotations
 
-from dataclasses import replace
+import os
+import sys
+import unittest
 from datetime import date
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-import pytest
+_HERMETIC_DIR = os.path.dirname(os.path.abspath(__file__))
+if _HERMETIC_DIR not in sys.path:
+    sys.path.insert(0, _HERMETIC_DIR)
+import hermetic_env  # noqa: F401  # process-wide host-env isolation
 
 
 def _legacy_record(model_id: str, *, role: str = "implement", **overrides):
@@ -102,564 +107,6 @@ def _save_routed_task_with_reroute(*, reroute_created_by: str, reroute_payload: 
     return root, store
 
 
-def test_ordinary_fallback_is_attributed_to_the_rejected_model() -> None:
-    # Arrange
-    from puppetmaster.audit import build_audit_report, collect_records
-
-    root, store = _save_routed_task_with_reroute(
-        reroute_created_by="router-fallback",
-        reroute_payload={
-            "fallback_from_model": "cursor/weak",
-            "fallback_reason": "model_unavailable",
-        },
-    )
-
-    try:
-        # Act
-        records, _ = collect_records(store)
-        report = build_audit_report(
-            records, {"cursor/weak": 55, "cursor/strong": 85}
-        )
-
-        # Assert
-        assert records[0].fallback_from == "cursor/weak"
-        weak = next(model for model in report.models if model.model_id == "cursor/weak")
-        assert weak.fell_back_away == 1
-    finally:
-        root.cleanup()
-
-
-def test_review_escalation_is_attributed_to_the_review_rejected_model() -> None:
-    # Arrange
-    from puppetmaster.audit import build_audit_report, collect_records
-
-    root, store = _save_routed_task_with_reroute(
-        reroute_created_by="router-review-escalation",
-        reroute_payload={"review_escalated_from_model": "cursor/weak"},
-    )
-
-    try:
-        # Act
-        records, _ = collect_records(store)
-        report = build_audit_report(
-            records, {"cursor/weak": 55, "cursor/strong": 85}
-        )
-
-        # Assert
-        assert records[0].review_escalated_from == "cursor/weak"
-        weak = next(model for model in report.models if model.model_id == "cursor/weak")
-        assert weak.review_escalated_away == 1
-    finally:
-        root.cleanup()
-
-
-def test_two_step_fallback_attributes_every_rejected_model() -> None:
-    # Arrange: weak fails over to mid, then mid fails over to strong. A single
-    # latest fallback_from field must not erase the first rejected producer.
-    from puppetmaster.audit import build_audit_report, collect_records
-    from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
-    from puppetmaster.store import SwarmStore
-
-    with TemporaryDirectory() as tmp:
-        store = SwarmStore(Path(tmp) / ".puppetmaster")
-        store.init()
-        job = store.create_job("retain every fallback hop")
-        task = Task(
-            job_id=job.id,
-            role="implement",
-            instruction="implement with fallbacks",
-            adapter="cursor",
-            status=TaskStatus.COMPLETE,
-            payload={"router_model_id": "cursor/strong"},
-        )
-        store.save_task(task)
-        for created_by, created_at, payload in (
-            (
-                "router",
-                "2026-08-22T12:00:00Z",
-                {"model_id": "cursor/weak", "policy": "balanced"},
-            ),
-            (
-                "router-fallback",
-                "2026-08-22T12:01:00Z",
-                {
-                    "model_id": "cursor/mid",
-                    "policy": "balanced",
-                    "fallback_from_model": "cursor/weak",
-                },
-            ),
-            (
-                "router-fallback",
-                "2026-08-22T12:02:00Z",
-                {
-                    "model_id": "cursor/strong",
-                    "policy": "balanced",
-                    "fallback_from_model": "cursor/mid",
-                },
-            ),
-        ):
-            store.save_artifact(
-                Artifact(
-                    job_id=job.id,
-                    task_id=task.id,
-                    type=ArtifactType.ROUTING,
-                    created_by=created_by,
-                    payload={"adapter": "cursor", **payload},
-                    confidence=0.9,
-                    evidence=[created_by],
-                    created_at=created_at,
-                )
-            )
-
-        # Act
-        records, _ = collect_records(store)
-        report = build_audit_report(
-            records,
-            {"cursor/weak": 50, "cursor/mid": 65, "cursor/strong": 85},
-        )
-
-    # Assert
-    by_model = {model.model_id: model for model in report.models}
-    assert by_model["cursor/weak"].fell_back_away == 1
-    assert by_model["cursor/mid"].fell_back_away == 1
-    assert by_model["cursor/strong"].fell_back_away == 0
-
-
-def test_two_step_review_escalation_attributes_every_rejected_model() -> None:
-    # Arrange: weak and mid each fail completed objective review before strong
-    # passes. Both rejected producers must retain review-escalation attribution.
-    from puppetmaster.audit import build_audit_report, collect_records
-    from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
-    from puppetmaster.store import SwarmStore
-
-    with TemporaryDirectory() as tmp:
-        store = SwarmStore(Path(tmp) / ".puppetmaster")
-        store.init()
-        job = store.create_job("retain every review escalation hop")
-        task = Task(
-            job_id=job.id,
-            role="review",
-            instruction="review through multiple producers",
-            adapter="cursor",
-            status=TaskStatus.COMPLETE,
-            payload={"router_model_id": "cursor/strong"},
-        )
-        store.save_task(task)
-        epoch = {
-            "registry_digest": "registry-a",
-            "classifier_version": "classifier-a",
-            "taxonomy_version": "taxonomy-a",
-            "adapter_version": "cursor-a",
-        }
-        events = (
-            (
-                ArtifactType.ROUTING,
-                "router",
-                "2026-08-22T13:00:00Z",
-                {
-                    "model_id": "cursor/weak",
-                    "adapter": "cursor",
-                    "policy": "balanced",
-                    **epoch,
-                },
-            ),
-            (
-                ArtifactType.GATE,
-                "review-gate",
-                "2026-08-22T13:00:10Z",
-                {
-                    "gate": "review",
-                    "passed": False,
-                    "review_status": "completed",
-                    "objective_score": 0.0,
-                    "evaluator_revision": "review-v2",
-                },
-            ),
-            (
-                ArtifactType.ROUTING,
-                "router-review-escalation",
-                "2026-08-22T13:00:20Z",
-                {
-                    "model_id": "cursor/mid",
-                    "adapter": "cursor",
-                    "policy": "quality",
-                    "review_escalated_from_model": "cursor/weak",
-                    **epoch,
-                },
-            ),
-            (
-                ArtifactType.GATE,
-                "review-gate",
-                "2026-08-22T13:00:30Z",
-                {
-                    "gate": "review",
-                    "passed": False,
-                    "review_status": "completed",
-                    "objective_score": 0.0,
-                    "evaluator_revision": "review-v2",
-                },
-            ),
-            (
-                ArtifactType.ROUTING,
-                "router-review-escalation",
-                "2026-08-22T13:00:40Z",
-                {
-                    "model_id": "cursor/strong",
-                    "adapter": "cursor",
-                    "policy": "quality",
-                    "review_escalated_from_model": "cursor/mid",
-                    **epoch,
-                },
-            ),
-            (
-                ArtifactType.GATE,
-                "review-gate",
-                "2026-08-22T13:00:50Z",
-                {
-                    "gate": "review",
-                    "passed": True,
-                    "review_status": "completed",
-                    "objective_score": 1.0,
-                    "evaluator_revision": "review-v2",
-                },
-            ),
-        )
-        for artifact_type, created_by, created_at, payload in events:
-            store.save_artifact(
-                Artifact(
-                    job_id=job.id,
-                    task_id=task.id,
-                    type=artifact_type,
-                    created_by=created_by,
-                    payload=payload,
-                    confidence=1.0,
-                    evidence=[created_by],
-                    created_at=created_at,
-                )
-            )
-
-        # Act
-        records, _ = collect_records(store)
-        report = build_audit_report(
-            records,
-            {"cursor/weak": 50, "cursor/mid": 65, "cursor/strong": 85},
-        )
-
-    # Assert
-    by_model = {model.model_id: model for model in report.models}
-    assert by_model["cursor/weak"].review_escalated_away == 1
-    assert by_model["cursor/mid"].review_escalated_away == 1
-    assert by_model["cursor/strong"].review_escalated_away == 0
-    assert by_model["cursor/weak"].runs_with_objective_outcomes == 1
-    assert by_model["cursor/mid"].runs_with_objective_outcomes == 1
-    assert by_model["cursor/strong"].runs_with_objective_outcomes == 1
-
-
-def test_review_rejection_outcome_survives_later_successful_escalated_review() -> None:
-    # Arrange: each task first fails objective review on weak, escalates, and
-    # later passes objective review on strong. The later success must not erase
-    # the rejected producer's outcome from the audit.
-    from puppetmaster.audit import build_audit_report, collect_records
-    from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
-    from puppetmaster.store import SwarmStore
-
-    with TemporaryDirectory() as tmp:
-        store = SwarmStore(Path(tmp) / ".puppetmaster")
-        store.init()
-        job = store.create_job("retain rejected review outcomes")
-        for index in range(5):
-            task = Task(
-                job_id=job.id,
-                role="review",
-                instruction=f"review patch {index}",
-                adapter="cursor",
-                status=TaskStatus.COMPLETE,
-                payload={
-                    "router_model_id": "cursor/strong",
-                    "router_capability_needed": 70,
-                },
-            )
-            store.save_task(task)
-            common_epoch = {
-                "registry_digest": "registry-a",
-                "taxonomy_version": "taxonomy-a",
-                "classifier_version": "classifier-a",
-                "adapter_version": "cursor-a",
-            }
-            store.save_artifact(
-                Artifact(
-                    job_id=job.id,
-                    task_id=task.id,
-                    type=ArtifactType.ROUTING,
-                    created_by="router",
-                    payload={
-                        "model_id": "cursor/weak",
-                        "adapter": "cursor",
-                        "policy": "balanced",
-                        "predicted_quality": 0.9,
-                        **common_epoch,
-                    },
-                    confidence=0.9,
-                    evidence=["initial"],
-                    created_at=f"2026-08-22T12:{index:02d}:00Z",
-                )
-            )
-            store.save_artifact(
-                Artifact(
-                    job_id=job.id,
-                    task_id=task.id,
-                    type=ArtifactType.GATE,
-                    created_by="review-gate",
-                    payload={
-                        "gate": "review",
-                        "passed": False,
-                        "objective_score": 0.0,
-                        "evaluator_revision": "review-v2",
-                        "review_status": "completed",
-                    },
-                    confidence=1.0,
-                    evidence=["weak-review"],
-                    created_at=f"2026-08-22T12:{index:02d}:10Z",
-                )
-            )
-            store.save_artifact(
-                Artifact(
-                    job_id=job.id,
-                    task_id=task.id,
-                    type=ArtifactType.ROUTING,
-                    created_by="router-review-escalation",
-                    payload={
-                        "model_id": "cursor/strong",
-                        "adapter": "cursor",
-                        "policy": "quality",
-                        "review_escalated_from_model": "cursor/weak",
-                        "predicted_quality": 0.98,
-                        **common_epoch,
-                    },
-                    confidence=0.9,
-                    evidence=["review-escalation"],
-                    created_at=f"2026-08-22T12:{index:02d}:20Z",
-                )
-            )
-            store.save_artifact(
-                Artifact(
-                    job_id=job.id,
-                    task_id=task.id,
-                    type=ArtifactType.GATE,
-                    created_by="review-gate",
-                    payload={
-                        "gate": "review",
-                        "passed": True,
-                        "objective_score": 1.0,
-                        "evaluator_revision": "review-v2",
-                        "review_status": "completed",
-                    },
-                    confidence=1.0,
-                    evidence=["strong-review"],
-                    created_at=f"2026-08-22T12:{index:02d}:30Z",
-                )
-            )
-
-        # Act
-        records, _ = collect_records(store)
-        report = build_audit_report(
-            records, {"cursor/weak": 55, "cursor/strong": 85}, min_sample=5
-        )
-
-    # Assert: both producer outcomes remain auditable, and only the weak review
-    # role is recommended for adjustment.
-    weak = next(model for model in report.models if model.model_id == "cursor/weak")
-    strong = next(model for model in report.models if model.model_id == "cursor/strong")
-    assert weak.runs_with_objective_outcomes == 5
-    assert weak.objective_pass_rate == pytest.approx(0.0)
-    assert strong.runs_with_objective_outcomes == 5
-    assert strong.objective_pass_rate == pytest.approx(1.0)
-    assert [
-        (item["model_id"], item["role"])
-        for item in report.role_scorecard_suggestions
-    ] == [("cursor/weak", "review")]
-    assert report.role_scorecard_suggestions[0]["last_calibrated"] == "2026-08-22"
-
-
-def test_collector_compares_predicted_quality_with_objective_evaluator_evidence() -> None:
-    # Arrange
-    from puppetmaster.audit import collect_records
-    from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
-    from puppetmaster.store import SwarmStore
-
-    with TemporaryDirectory() as tmp:
-        store = SwarmStore(Path(tmp) / ".puppetmaster")
-        store.init()
-        job = store.create_job("compare prediction to evaluator")
-        task = Task(
-            job_id=job.id,
-            role="audit",
-            instruction="audit the result",
-            adapter="cursor",
-            status=TaskStatus.COMPLETE,
-            payload={
-                "router_model_id": "cursor/model",
-                "router_capability_needed": 70,
-            },
-        )
-        store.save_task(task)
-        store.save_artifact(
-            Artifact(
-                job_id=job.id,
-                task_id=task.id,
-                type=ArtifactType.ROUTING,
-                created_by="router",
-                payload={
-                    "model_id": "cursor/model",
-                    "adapter": "cursor",
-                    "policy": "balanced",
-                    "predicted_quality": 0.95,
-                    "registry_digest": "registry-a",
-                    "taxonomy_version": "taxonomy-a",
-                    "adapter_version": "cursor-a",
-                },
-                confidence=0.9,
-                evidence=["policy:balanced"],
-            )
-        )
-        store.save_artifact(
-            Artifact(
-                job_id=job.id,
-                task_id=task.id,
-                type=ArtifactType.GATE,
-                created_by="review-gate",
-                payload={
-                    "gate": "review",
-                    "passed": False,
-                    "objective_score": 0.2,
-                    "evaluator_revision": "review-v2",
-                    "reviewed_artifact_fingerprint": "sha256:artifact-a",
-                },
-                confidence=1.0,
-                evidence=["evaluator:review-v2"],
-            )
-        )
-        store.save_artifact(
-            Artifact(
-                job_id=job.id,
-                task_id=task.id,
-                type=ArtifactType.VERIFICATION,
-                created_by="self-reporting-worker",
-                payload={"check": "self", "result": "passed"},
-                confidence=0.99,
-                evidence=["self-report"],
-            )
-        )
-
-        # Act
-        records, _ = collect_records(store)
-
-    # Assert: objective failure is retained even though the model was highly
-    # self-confident and its own verification called the work passed.
-    record = records[0]
-    assert record.predicted_quality == pytest.approx(0.95)
-    assert record.objective_quality == pytest.approx(0.2)
-    assert record.objective_passed is False
-    assert record.confidence == pytest.approx(0.99)
-    assert record.evaluator_revision == "review-v2"
-    assert record.registry_digest == "registry-a"
-    assert record.taxonomy_version == "taxonomy-a"
-    assert record.adapter_version == "cursor-a"
-
-
-def test_unavailable_review_is_not_recorded_as_an_objective_evaluator_outcome() -> None:
-    # Arrange
-    from puppetmaster.audit import collect_records
-    from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
-    from puppetmaster.quality import assess_run_quality
-    from puppetmaster.store import SwarmStore
-
-    with TemporaryDirectory() as tmp:
-        store = SwarmStore(Path(tmp) / ".puppetmaster")
-        store.init()
-        job = store.create_job("review unavailable")
-        task = Task(
-            job_id=job.id,
-            role="review",
-            instruction="review",
-            adapter="cursor",
-            status=TaskStatus.FAILED,
-            payload={"router_model_id": "cursor/model"},
-        )
-        store.save_task(task)
-        store.save_artifact(
-            Artifact(
-                job_id=job.id,
-                task_id=task.id,
-                type=ArtifactType.ROUTING,
-                created_by="router",
-                payload={
-                    "model_id": "cursor/model",
-                    "adapter": "cursor",
-                    "policy": "balanced",
-                },
-                confidence=0.9,
-                evidence=["route"],
-            )
-        )
-        unavailable = Artifact(
-            job_id=job.id,
-            task_id=task.id,
-            type=ArtifactType.GATE,
-            created_by="review-gate",
-            payload={
-                "gate": "review",
-                "passed": False,
-                "review_status": "unavailable",
-                "evaluator_revision": "review-v2",
-                "reviewed_artifact_fingerprint": "sha256:artifact-a",
-            },
-            confidence=1.0,
-            evidence=["no-judge"],
-        )
-        store.save_artifact(unavailable)
-
-        # Act
-        records, _ = collect_records(store)
-        quality = assess_run_quality([unavailable])
-
-    # Assert
-    assert records[0].objective_passed is None
-    assert records[0].objective_quality is None
-    assert quality["semantic_quality"] == "not_evaluated"
-    assert quality["objective_evaluations"] == 0
-
-
-def test_failed_objective_evaluation_keeps_objective_trust_basis() -> None:
-    # Arrange
-    from puppetmaster.models import Artifact, ArtifactType
-    from puppetmaster.quality import assess_run_quality
-
-    gate = Artifact(
-        job_id="job-quality",
-        task_id="task-quality",
-        type=ArtifactType.GATE,
-        created_by="review-gate",
-        payload={
-            "gate": "review",
-            "passed": False,
-            "review_status": "completed",
-            "objective_score": 0.0,
-            "evaluator_revision": "review-v2",
-        },
-        confidence=1.0,
-        evidence=["objective-review"],
-    )
-
-    # Act
-    quality = assess_run_quality([gate])
-
-    # Assert
-    assert quality["semantic_quality"] == "failed"
-    assert quality["objective_evaluations"] == 1
-    assert quality["trust_basis"] == "objective_evaluator"
-
-
 def _objective_record(*, role: str, passed: bool, **epoch):
     return _legacy_record(
         "cursor/model",
@@ -672,38 +119,6 @@ def _objective_record(*, role: str, passed: bool, **epoch):
         objective_passed=passed,
         **epoch,
     )
-
-
-def test_objective_failures_drive_only_the_underperforming_role_recommendation() -> None:
-    # Arrange: the same model objectively fails audit work while objectively
-    # passing implementation work; self-confidence is 0.99 in both roles.
-    from puppetmaster.audit import build_audit_report
-
-    epoch = {
-        "registry_digest": "registry-a",
-        "taxonomy_version": "taxonomy-a",
-        "adapter_version": "cursor-a",
-        "evaluator_revision": "eval-a",
-        "evaluated_at": "2026-08-22T12:00:00Z",
-    }
-    records = [
-        *[_objective_record(role="audit", passed=False, **epoch) for _ in range(5)],
-        *[_objective_record(role="implement", passed=True, **epoch) for _ in range(5)],
-    ]
-
-    # Act
-    report = build_audit_report(records, {"cursor/model": 80}, min_sample=5)
-
-    # Assert
-    model = next(item for item in report.models if item.model_id == "cursor/model")
-    assert model.runs_with_objective_outcomes == 10
-    assert model.objective_pass_rate == pytest.approx(0.5)
-    assert model.mean_predicted_quality == pytest.approx(0.95)
-    assert model.mean_objective_quality == pytest.approx(0.5)
-    assert model.suggested_score is None
-    assert report.suggestions == []
-    assert [item["role"] for item in report.role_scorecard_suggestions] == ["audit"]
-    assert report.role_scorecard_suggestions[0]["model_id"] == "cursor/model"
 
 
 def _model_with_card(card: dict):
@@ -732,219 +147,373 @@ def _qualified_card() -> dict:
     }
 
 
-def test_fully_qualified_role_card_affects_effective_capability() -> None:
-    # Arrange
-    from puppetmaster.scorecards import effective_capability_score
+class RoutingAuditQualityTests(unittest.TestCase):
+    def test_ordinary_fallback_is_attributed_to_the_rejected_model(self) -> None:
+        from puppetmaster.audit import build_audit_report, collect_records
 
-    spec = _model_with_card(_qualified_card())
-
-    # Act
-    score = effective_capability_score(spec, "audit")
-
-    # Assert
-    assert score == 85
-
-
-def test_swebench_card_producer_emits_qualified_routing_authority() -> None:
-    # Arrange: the shipped benchmark importer is an existing role-card producer.
-    # New qualification rules must stamp its cards rather than silently making
-    # a successfully imported benchmark card inert.
-    from puppetmaster.model_registry import ModelSpec
-    from puppetmaster.scorecards import (
-        effective_capability_score,
-        import_community_baseline,
-    )
-    from puppetmaster.swebench_baseline import (
-        RegistryModelMapping,
-        build_swebench_bash_only_bundle,
-    )
-
-    rows = []
-    for index, resolved in enumerate((20.0, 40.0, 60.0, 80.0, 90.0), start=1):
-        rows.append(
-            {
-                "agent": "mini-SWE-agent",
-                "name": f"Model {index}",
-                "model_display": f"Model {index}",
-                "mini-swe-agent_version": "2.0.0",
-                "resolved": resolved,
-                "date": date.today().isoformat(),
-                "per_instance_details": {
-                    f"task-{index}-{sample}": {"resolved": sample % 2 == 0}
-                    for sample in range(10)
-                },
-            }
+        root, store = _save_routed_task_with_reroute(
+            reroute_created_by="router-fallback",
+            reroute_payload={
+                "fallback_from_model": "cursor/weak",
+                "fallback_reason": "model_unavailable",
+            },
         )
-    bundle = build_swebench_bash_only_bundle(
-        {"leaderboards": [{"name": "bash-only", "results": rows}]},
-        mappings=[
-            RegistryModelMapping(
-                "codex/model-3", "codex", "model-3", "Model 3"
+        try:
+            records, _ = collect_records(store)
+            report = build_audit_report(
+                records, {"cursor/weak": 55, "cursor/strong": 85}
             )
-        ],
-        source_revision="abc123",
-        published=date.today().isoformat(),
-    )
-    spec = ModelSpec(
-        id="codex/model-3",
-        adapter="codex",
-        adapter_model_name="model-3",
-        capability_score=97,
-    )
+            self.assertEqual(records[0].fallback_from, "cursor/weak")
+            weak = next(model for model in report.models if model.model_id == "cursor/weak")
+            self.assertEqual(weak.fell_back_away, 1)
+        finally:
+            root.cleanup()
 
-    # Act
-    imported, _ = import_community_baseline([spec], bundle)
-    card = imported[0].role_scorecards["implement"]
-    effective = effective_capability_score(imported[0], "implement")
+    def test_review_escalation_is_attributed_to_the_review_rejected_model(self) -> None:
+        from puppetmaster.audit import build_audit_report, collect_records
 
-    # Assert
-    assert card["scale"] == "puppetmaster-capability-0-100"
-    assert card["scale_version"]
-    assert card["provenance"]["source"] == "community_benchmark"
-    assert card["provenance"]["version"]
-    assert effective == card["capability"]
+        root, store = _save_routed_task_with_reroute(
+            reroute_created_by="router-review-escalation",
+            reroute_payload={"review_escalated_from_model": "cursor/weak"},
+        )
+        try:
+            records, _ = collect_records(store)
+            report = build_audit_report(
+                records, {"cursor/weak": 55, "cursor/strong": 85}
+            )
+            self.assertEqual(records[0].review_escalated_from, "cursor/weak")
+            weak = next(model for model in report.models if model.model_id == "cursor/weak")
+            self.assertEqual(weak.review_escalated_away, 1)
+        finally:
+            root.cleanup()
 
+    def test_two_step_fallback_attributes_every_rejected_model(self) -> None:
+        from puppetmaster.audit import build_audit_report, collect_records
+        from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
+        from puppetmaster.store import SwarmStore
 
-@pytest.mark.parametrize(
-    "mutate",
-    [
-        pytest.param(lambda card: card.update(provenance={}), id="missing-provenance"),
-        pytest.param(lambda card: card.update(sample_count=4), id="too-few-samples"),
-        pytest.param(lambda card: card.pop("scale"), id="missing-scale"),
-        pytest.param(lambda card: card.pop("scale_version"), id="missing-scale-version"),
-        pytest.param(
-            lambda card: card.update(last_calibrated="2000-01-01"),
-            id="stale-calibration",
-        ),
-    ],
-)
-def test_unqualified_role_card_falls_back_to_manual_capability(mutate) -> None:
-    # Arrange
-    from puppetmaster.scorecards import effective_capability_score
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            store.init()
+            job = store.create_job("retain every fallback hop")
+            task = Task(
+                job_id=job.id,
+                role="implement",
+                instruction="implement with fallbacks",
+                adapter="cursor",
+                status=TaskStatus.COMPLETE,
+                payload={"router_model_id": "cursor/strong"},
+            )
+            store.save_task(task)
+            for created_by, created_at, payload in (
+                (
+                    "router",
+                    "2026-08-22T12:00:00Z",
+                    {"model_id": "cursor/weak", "policy": "balanced"},
+                ),
+                (
+                    "router-fallback",
+                    "2026-08-22T12:01:00Z",
+                    {
+                        "model_id": "cursor/mid",
+                        "policy": "balanced",
+                        "fallback_from_model": "cursor/weak",
+                    },
+                ),
+                (
+                    "router-fallback",
+                    "2026-08-22T12:02:00Z",
+                    {
+                        "model_id": "cursor/strong",
+                        "policy": "balanced",
+                        "fallback_from_model": "cursor/mid",
+                    },
+                ),
+            ):
+                store.save_artifact(
+                    Artifact(
+                        job_id=job.id,
+                        task_id=task.id,
+                        type=ArtifactType.ROUTING,
+                        created_by=created_by,
+                        payload={"adapter": "cursor", **payload},
+                        confidence=0.9,
+                        evidence=[created_by],
+                        created_at=created_at,
+                    )
+                )
+            records, _ = collect_records(store)
+            report = build_audit_report(
+                records,
+                {"cursor/weak": 50, "cursor/mid": 65, "cursor/strong": 85},
+            )
+        by_model = {model.model_id: model for model in report.models}
+        self.assertEqual(by_model["cursor/weak"].fell_back_away, 1)
+        self.assertEqual(by_model["cursor/mid"].fell_back_away, 1)
+        self.assertEqual(by_model["cursor/strong"].fell_back_away, 0)
 
-    card = _qualified_card()
-    mutate(card)
-    spec = _model_with_card(card)
+    def test_two_step_review_escalation_attributes_every_rejected_model(self) -> None:
+        from puppetmaster.audit import build_audit_report, collect_records
+        from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
+        from puppetmaster.store import SwarmStore
 
-    # Act
-    score = effective_capability_score(spec, "audit")
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            store.init()
+            job = store.create_job("retain every review escalation hop")
+            task = Task(
+                job_id=job.id,
+                role="review",
+                instruction="review through multiple producers",
+                adapter="cursor",
+                status=TaskStatus.COMPLETE,
+                payload={"router_model_id": "cursor/strong"},
+            )
+            store.save_task(task)
+            epoch = {
+                "registry_digest": "registry-a",
+                "classifier_version": "classifier-a",
+                "taxonomy_version": "taxonomy-a",
+                "adapter_version": "cursor-a",
+            }
+            events = (
+                (
+                    ArtifactType.ROUTING,
+                    "router",
+                    "2026-08-22T13:00:00Z",
+                    {
+                        "model_id": "cursor/weak",
+                        "adapter": "cursor",
+                        "policy": "balanced",
+                        **epoch,
+                    },
+                ),
+                (
+                    ArtifactType.GATE,
+                    "review-gate",
+                    "2026-08-22T13:00:10Z",
+                    {
+                        "gate": "review",
+                        "passed": False,
+                        "review_status": "completed",
+                        "objective_score": 0.0,
+                        "evaluator_revision": "review-v2",
+                    },
+                ),
+                (
+                    ArtifactType.ROUTING,
+                    "router-review-escalation",
+                    "2026-08-22T13:00:20Z",
+                    {
+                        "model_id": "cursor/mid",
+                        "adapter": "cursor",
+                        "policy": "quality",
+                        "review_escalated_from_model": "cursor/weak",
+                        **epoch,
+                    },
+                ),
+                (
+                    ArtifactType.GATE,
+                    "review-gate",
+                    "2026-08-22T13:00:30Z",
+                    {
+                        "gate": "review",
+                        "passed": False,
+                        "review_status": "completed",
+                        "objective_score": 0.0,
+                        "evaluator_revision": "review-v2",
+                    },
+                ),
+                (
+                    ArtifactType.ROUTING,
+                    "router-review-escalation",
+                    "2026-08-22T13:00:40Z",
+                    {
+                        "model_id": "cursor/strong",
+                        "adapter": "cursor",
+                        "policy": "quality",
+                        "review_escalated_from_model": "cursor/mid",
+                        **epoch,
+                    },
+                ),
+                (
+                    ArtifactType.GATE,
+                    "review-gate",
+                    "2026-08-22T13:00:50Z",
+                    {
+                        "gate": "review",
+                        "passed": True,
+                        "review_status": "completed",
+                        "objective_score": 1.0,
+                        "evaluator_revision": "review-v2",
+                    },
+                ),
+            )
+            for artifact_type, created_by, created_at, payload in events:
+                store.save_artifact(
+                    Artifact(
+                        job_id=job.id,
+                        task_id=task.id,
+                        type=artifact_type,
+                        created_by=created_by,
+                        payload=payload,
+                        confidence=1.0,
+                        evidence=[created_by],
+                        created_at=created_at,
+                    )
+                )
+            records, _ = collect_records(store)
+            report = build_audit_report(
+                records,
+                {"cursor/weak": 50, "cursor/mid": 65, "cursor/strong": 85},
+            )
+        by_model = {model.model_id: model for model in report.models}
+        self.assertEqual(by_model["cursor/weak"].review_escalated_away, 1)
+        self.assertEqual(by_model["cursor/mid"].review_escalated_away, 1)
+        self.assertEqual(by_model["cursor/strong"].review_escalated_away, 0)
+        self.assertEqual(by_model["cursor/weak"].runs_with_objective_outcomes, 1)
+        self.assertEqual(by_model["cursor/mid"].runs_with_objective_outcomes, 1)
+        self.assertEqual(by_model["cursor/strong"].runs_with_objective_outcomes, 1)
 
-    # Assert: an unqualified card is evidence, not routing authority.
-    assert score == 50
+    def test_review_rejection_outcome_survives_later_successful_escalated_review(self) -> None:
+        from puppetmaster.audit import build_audit_report, collect_records
+        from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
+        from puppetmaster.store import SwarmStore
 
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            store.init()
+            job = store.create_job("retain rejected review outcomes")
+            for index in range(5):
+                task = Task(
+                    job_id=job.id,
+                    role="review",
+                    instruction=f"review patch {index}",
+                    adapter="cursor",
+                    status=TaskStatus.COMPLETE,
+                    payload={
+                        "router_model_id": "cursor/strong",
+                        "router_capability_needed": 70,
+                    },
+                )
+                store.save_task(task)
+                common_epoch = {
+                    "registry_digest": "registry-a",
+                    "taxonomy_version": "taxonomy-a",
+                    "classifier_version": "classifier-a",
+                    "adapter_version": "cursor-a",
+                }
+                store.save_artifact(
+                    Artifact(
+                        job_id=job.id,
+                        task_id=task.id,
+                        type=ArtifactType.ROUTING,
+                        created_by="router",
+                        payload={
+                            "model_id": "cursor/weak",
+                            "adapter": "cursor",
+                            "policy": "balanced",
+                            "predicted_quality": 0.9,
+                            **common_epoch,
+                        },
+                        confidence=0.9,
+                        evidence=["initial"],
+                        created_at=f"2026-08-22T12:{index:02d}:00Z",
+                    )
+                )
+                store.save_artifact(
+                    Artifact(
+                        job_id=job.id,
+                        task_id=task.id,
+                        type=ArtifactType.GATE,
+                        created_by="review-gate",
+                        payload={
+                            "gate": "review",
+                            "passed": False,
+                            "objective_score": 0.0,
+                            "evaluator_revision": "review-v2",
+                            "review_status": "completed",
+                        },
+                        confidence=1.0,
+                        evidence=["weak-review"],
+                        created_at=f"2026-08-22T12:{index:02d}:10Z",
+                    )
+                )
+                store.save_artifact(
+                    Artifact(
+                        job_id=job.id,
+                        task_id=task.id,
+                        type=ArtifactType.ROUTING,
+                        created_by="router-review-escalation",
+                        payload={
+                            "model_id": "cursor/strong",
+                            "adapter": "cursor",
+                            "policy": "quality",
+                            "review_escalated_from_model": "cursor/weak",
+                            "predicted_quality": 0.98,
+                            **common_epoch,
+                        },
+                        confidence=0.9,
+                        evidence=["review-escalation"],
+                        created_at=f"2026-08-22T12:{index:02d}:20Z",
+                    )
+                )
+                store.save_artifact(
+                    Artifact(
+                        job_id=job.id,
+                        task_id=task.id,
+                        type=ArtifactType.GATE,
+                        created_by="review-gate",
+                        payload={
+                            "gate": "review",
+                            "passed": True,
+                            "objective_score": 1.0,
+                            "evaluator_revision": "review-v2",
+                            "review_status": "completed",
+                        },
+                        confidence=1.0,
+                        evidence=["strong-review"],
+                        created_at=f"2026-08-22T12:{index:02d}:30Z",
+                    )
+                )
+            records, _ = collect_records(store)
+            report = build_audit_report(
+                records, {"cursor/weak": 55, "cursor/strong": 85}, min_sample=5
+            )
+        weak = next(model for model in report.models if model.model_id == "cursor/weak")
+        strong = next(model for model in report.models if model.model_id == "cursor/strong")
+        self.assertEqual(weak.runs_with_objective_outcomes, 5)
+        self.assertAlmostEqual(weak.objective_pass_rate, 0.0)
+        self.assertEqual(strong.runs_with_objective_outcomes, 5)
+        self.assertAlmostEqual(strong.objective_pass_rate, 1.0)
+        self.assertEqual(
+            [
+                (item["model_id"], item["role"])
+                for item in report.role_scorecard_suggestions
+            ],
+            [("cursor/weak", "review")],
+        )
+        self.assertEqual(report.role_scorecard_suggestions[0]["last_calibrated"], "2026-08-22")
 
-@pytest.mark.parametrize(
-    ("epoch_field", "first", "second"),
-    [
-        ("registry_digest", "registry-a", "registry-b"),
-        ("taxonomy_version", "taxonomy-a", "taxonomy-b"),
-        ("adapter_version", "cursor-a", "cursor-b"),
-        ("evaluator_revision", "eval-a", "eval-b"),
-    ],
-)
-def test_historical_aggregation_does_not_pool_incompatible_epochs(
-    epoch_field: str, first: str, second: str
-) -> None:
-    # Arrange: each epoch has only three failures, below min_sample=5. Pooling
-    # the six would manufacture a recommendation unsupported by either epoch.
-    from puppetmaster.audit import build_audit_report
+    def test_collector_compares_predicted_quality_with_objective_evaluator_evidence(self) -> None:
+        from puppetmaster.audit import collect_records
+        from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
+        from puppetmaster.store import SwarmStore
 
-    base_epoch = {
-        "registry_digest": "registry-a",
-        "taxonomy_version": "taxonomy-a",
-        "adapter_version": "cursor-a",
-        "evaluator_revision": "eval-a",
-        "evaluated_at": "2026-08-22T12:00:00Z",
-    }
-    first_epoch = {**base_epoch, epoch_field: first}
-    second_epoch = {**base_epoch, epoch_field: second}
-    records = [
-        *[
-            _objective_record(role="audit", passed=False, **first_epoch)
-            for _ in range(3)
-        ],
-        *[
-            _objective_record(role="audit", passed=False, **second_epoch)
-            for _ in range(3)
-        ],
-    ]
-
-    # Act
-    report = build_audit_report(records, {"cursor/model": 80}, min_sample=5)
-
-    # Assert
-    assert report.epoch_count == 2
-    assert report.role_scorecard_suggestions == []
-
-
-def test_incomplete_epoch_cannot_authorize_a_role_card_recommendation() -> None:
-    # Arrange: legacy records remain reportable, but missing reproducibility
-    # lineage cannot become qualified routing authority.
-    from puppetmaster.audit import build_audit_report
-
-    records = [
-        _objective_record(role="audit", passed=False)
-        for _ in range(5)
-    ]
-
-    # Act
-    report = build_audit_report(records, {"cursor/model": 80}, min_sample=5)
-
-    # Assert
-    assert report.epoch_count == 1
-    assert report.role_scorecard_suggestions == []
-
-
-def test_undated_complete_lineage_is_reportable_but_non_authoritative() -> None:
-    # Arrange: every lineage dimension is present, but there is no immutable
-    # evaluator timestamp. The outcomes belong in diagnostics, not routing
-    # authority or a recommendation which could be applied as fresh evidence.
-    from puppetmaster.audit import build_audit_report
-
-    epoch_without_date = {
-        "registry_digest": "registry-a",
-        "taxonomy_version": "taxonomy-a",
-        "classifier_version": "classifier-a",
-        "adapter_version": "cursor-a",
-        "evaluator_revision": "eval-a",
-    }
-    records = [
-        _objective_record(role="audit", passed=False, **epoch_without_date)
-        for _ in range(5)
-    ]
-
-    # Act
-    report = build_audit_report(records, {"cursor/model": 80}, min_sample=5)
-
-    # Assert: diagnostic aggregation remains available while authority fails
-    # closed at the role-card recommendation boundary.
-    model = next(item for item in report.models if item.model_id == "cursor/model")
-    assert model.runs_with_objective_outcomes == 5
-    assert model.objective_pass_rate == pytest.approx(0.0)
-    assert report.epoch_count == 1
-    assert report.role_scorecard_suggestions == []
-
-
-def test_stale_objective_history_cannot_be_re_stamped_as_a_fresh_role_card() -> None:
-    # Arrange: the run is visible in the current store, but its evaluator
-    # evidence is decades old. Applying the audit today must not launder that
-    # evidence into a newly fresh last_calibrated date.
-    from puppetmaster.audit import build_audit_report, collect_records
-    from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
-    from puppetmaster.store import SwarmStore
-
-    with TemporaryDirectory() as tmp:
-        store = SwarmStore(Path(tmp) / ".puppetmaster")
-        store.init()
-        job = store.create_job("stale objective history")
-        for index in range(5):
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            store.init()
+            job = store.create_job("compare prediction to evaluator")
             task = Task(
                 job_id=job.id,
                 role="audit",
-                instruction=f"historical audit {index}",
+                instruction="audit the result",
                 adapter="cursor",
                 status=TaskStatus.COMPLETE,
-                payload={"router_model_id": "cursor/model"},
+                payload={
+                    "router_model_id": "cursor/model",
+                    "router_capability_needed": 70,
+                },
             )
             store.save_task(task)
             store.save_artifact(
@@ -958,14 +527,12 @@ def test_stale_objective_history_cannot_be_re_stamped_as_a_fresh_role_card() -> 
                         "adapter": "cursor",
                         "policy": "balanced",
                         "predicted_quality": 0.95,
-                        "registry_digest": "registry-historical",
-                        "taxonomy_version": "taxonomy-historical",
-                        "classifier_version": "classifier-historical",
-                        "adapter_version": "cursor-historical",
+                        "registry_digest": "registry-a",
+                        "taxonomy_version": "taxonomy-a",
+                        "adapter_version": "cursor-a",
                     },
                     confidence=0.9,
-                    evidence=["historical-route"],
-                    created_at=f"1999-12-31T23:59:{index:02d}Z",
+                    evidence=["policy:balanced"],
                 )
             )
             store.save_artifact(
@@ -977,86 +544,400 @@ def test_stale_objective_history_cannot_be_re_stamped_as_a_fresh_role_card() -> 
                     payload={
                         "gate": "review",
                         "passed": False,
-                        "objective_score": 0.0,
-                        "review_status": "completed",
-                        "evaluator_revision": "review-historical",
+                        "objective_score": 0.2,
+                        "evaluator_revision": "review-v2",
+                        "reviewed_artifact_fingerprint": "sha256:artifact-a",
                     },
                     confidence=1.0,
-                    evidence=["historical-evaluation"],
-                    created_at=f"2000-01-01T00:00:{index:02d}Z",
+                    evidence=["evaluator:review-v2"],
                 )
             )
+            store.save_artifact(
+                Artifact(
+                    job_id=job.id,
+                    task_id=task.id,
+                    type=ArtifactType.VERIFICATION,
+                    created_by="self-reporting-worker",
+                    payload={"check": "self", "result": "passed"},
+                    confidence=0.99,
+                    evidence=["self-report"],
+                )
+            )
+            records, _ = collect_records(store)
+        record = records[0]
+        self.assertAlmostEqual(record.predicted_quality, 0.95)
+        self.assertAlmostEqual(record.objective_quality, 0.2)
+        self.assertIs(record.objective_passed, False)
+        self.assertAlmostEqual(record.confidence, 0.99)
+        self.assertEqual(record.evaluator_revision, "review-v2")
+        self.assertEqual(record.registry_digest, "registry-a")
+        self.assertEqual(record.taxonomy_version, "taxonomy-a")
+        self.assertEqual(record.adapter_version, "cursor-a")
 
-        # Act
-        records, _ = collect_records(store)
-        report = build_audit_report(
-            records, {"cursor/model": 80}, min_sample=5
+    def test_unavailable_review_is_not_recorded_as_an_objective_evaluator_outcome(self) -> None:
+        from puppetmaster.audit import collect_records
+        from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
+        from puppetmaster.quality import assess_run_quality
+        from puppetmaster.store import SwarmStore
+
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            store.init()
+            job = store.create_job("review unavailable")
+            task = Task(
+                job_id=job.id,
+                role="review",
+                instruction="review",
+                adapter="cursor",
+                status=TaskStatus.FAILED,
+                payload={"router_model_id": "cursor/model"},
+            )
+            store.save_task(task)
+            store.save_artifact(
+                Artifact(
+                    job_id=job.id,
+                    task_id=task.id,
+                    type=ArtifactType.ROUTING,
+                    created_by="router",
+                    payload={
+                        "model_id": "cursor/model",
+                        "adapter": "cursor",
+                        "policy": "balanced",
+                    },
+                    confidence=0.9,
+                    evidence=["route"],
+                )
+            )
+            unavailable = Artifact(
+                job_id=job.id,
+                task_id=task.id,
+                type=ArtifactType.GATE,
+                created_by="review-gate",
+                payload={
+                    "gate": "review",
+                    "passed": False,
+                    "review_status": "unavailable",
+                    "evaluator_revision": "review-v2",
+                    "reviewed_artifact_fingerprint": "sha256:artifact-a",
+                },
+                confidence=1.0,
+                evidence=["no-judge"],
+            )
+            store.save_artifact(unavailable)
+            records, _ = collect_records(store)
+            quality = assess_run_quality([unavailable])
+        self.assertIsNone(records[0].objective_passed)
+        self.assertIsNone(records[0].objective_quality)
+        self.assertEqual(quality["semantic_quality"], "not_evaluated")
+        self.assertEqual(quality["objective_evaluations"], 0)
+
+    def test_failed_objective_evaluation_keeps_objective_trust_basis(self) -> None:
+        from puppetmaster.models import Artifact, ArtifactType
+        from puppetmaster.quality import assess_run_quality
+
+        gate = Artifact(
+            job_id="job-quality",
+            task_id="task-quality",
+            type=ArtifactType.GATE,
+            created_by="review-gate",
+            payload={
+                "gate": "review",
+                "passed": False,
+                "review_status": "completed",
+                "objective_score": 0.0,
+                "evaluator_revision": "review-v2",
+            },
+            confidence=1.0,
+            evidence=["objective-review"],
+        )
+        quality = assess_run_quality([gate])
+        self.assertEqual(quality["semantic_quality"], "failed")
+        self.assertEqual(quality["objective_evaluations"], 1)
+        self.assertEqual(quality["trust_basis"], "objective_evaluator")
+
+    def test_objective_failures_drive_only_the_underperforming_role_recommendation(self) -> None:
+        from puppetmaster.audit import build_audit_report
+
+        epoch = {
+            "registry_digest": "registry-a",
+            "taxonomy_version": "taxonomy-a",
+            "adapter_version": "cursor-a",
+            "evaluator_revision": "eval-a",
+            "evaluated_at": "2026-08-22T12:00:00Z",
+        }
+        records = [
+            *[_objective_record(role="audit", passed=False, **epoch) for _ in range(5)],
+            *[_objective_record(role="implement", passed=True, **epoch) for _ in range(5)],
+        ]
+        report = build_audit_report(records, {"cursor/model": 80}, min_sample=5)
+        model = next(item for item in report.models if item.model_id == "cursor/model")
+        self.assertEqual(model.runs_with_objective_outcomes, 10)
+        self.assertAlmostEqual(model.objective_pass_rate, 0.5)
+        self.assertAlmostEqual(model.mean_predicted_quality, 0.95)
+        self.assertAlmostEqual(model.mean_objective_quality, 0.5)
+        self.assertIsNone(model.suggested_score)
+        self.assertEqual(report.suggestions, [])
+        self.assertEqual([item["role"] for item in report.role_scorecard_suggestions], ["audit"])
+        self.assertEqual(report.role_scorecard_suggestions[0]["model_id"], "cursor/model")
+
+    def test_fully_qualified_role_card_affects_effective_capability(self) -> None:
+        from puppetmaster.scorecards import effective_capability_score
+
+        spec = _model_with_card(_qualified_card())
+        score = effective_capability_score(spec, "audit")
+        self.assertEqual(score, 85)
+
+    def test_swebench_card_producer_emits_qualified_routing_authority(self) -> None:
+        from puppetmaster.model_registry import ModelSpec
+        from puppetmaster.scorecards import (
+            effective_capability_score,
+            import_community_baseline,
+        )
+        from puppetmaster.swebench_baseline import (
+            RegistryModelMapping,
+            build_swebench_bash_only_bundle,
         )
 
-    # Assert
-    assert report.role_scorecard_suggestions == []
-
-
-def test_latest_qualified_epoch_wins_role_card_recommendation() -> None:
-    # Arrange: both evaluator epochs independently qualify. Deduplication must
-    # select the newest calibrated evidence, not whichever epoch key sorts first.
-    from puppetmaster.audit import build_audit_report
-
-    common = {
-        "registry_digest": "registry-a",
-        "taxonomy_version": "taxonomy-a",
-        "classifier_version": "classifier-a",
-        "adapter_version": "cursor-a",
-    }
-    records = [
-        *[
-            _objective_record(
-                role="audit",
-                passed=False,
-                evaluator_revision="eval-a",
-                evaluated_at="2026-05-20T12:00:00Z",
-                **common,
+        rows = []
+        for index, resolved in enumerate((20.0, 40.0, 60.0, 80.0, 90.0), start=1):
+            rows.append(
+                {
+                    "agent": "mini-SWE-agent",
+                    "name": f"Model {index}",
+                    "model_display": f"Model {index}",
+                    "mini-swe-agent_version": "2.0.0",
+                    "resolved": resolved,
+                    "date": date.today().isoformat(),
+                    "per_instance_details": {
+                        f"task-{index}-{sample}": {"resolved": sample % 2 == 0}
+                        for sample in range(10)
+                    },
+                }
             )
+        bundle = build_swebench_bash_only_bundle(
+            {"leaderboards": [{"name": "bash-only", "results": rows}]},
+            mappings=[
+                RegistryModelMapping(
+                    "codex/model-3", "codex", "model-3", "Model 3"
+                )
+            ],
+            source_revision="abc123",
+            published=date.today().isoformat(),
+        )
+        spec = ModelSpec(
+            id="codex/model-3",
+            adapter="codex",
+            adapter_model_name="model-3",
+            capability_score=97,
+        )
+        imported, _ = import_community_baseline([spec], bundle)
+        card = imported[0].role_scorecards["implement"]
+        effective = effective_capability_score(imported[0], "implement")
+        self.assertEqual(card["scale"], "puppetmaster-capability-0-100")
+        self.assertTrue(card["scale_version"])
+        self.assertEqual(card["provenance"]["source"], "community_benchmark")
+        self.assertTrue(card["provenance"]["version"])
+        self.assertEqual(effective, card["capability"])
+
+    def test_unqualified_role_card_falls_back_to_manual_capability(self) -> None:
+        from puppetmaster.scorecards import effective_capability_score
+
+        mutators = {
+            "missing-provenance": lambda card: card.update(provenance={}),
+            "too-few-samples": lambda card: card.update(sample_count=4),
+            "missing-scale": lambda card: card.pop("scale"),
+            "missing-scale-version": lambda card: card.pop("scale_version"),
+            "stale-calibration": lambda card: card.update(last_calibrated="2000-01-01"),
+        }
+        for case_id, mutate in mutators.items():
+            with self.subTest(case_id):
+                card = _qualified_card()
+                mutate(card)
+                spec = _model_with_card(card)
+                score = effective_capability_score(spec, "audit")
+                self.assertEqual(score, 50)
+
+    def test_historical_aggregation_does_not_pool_incompatible_epochs(self) -> None:
+        from puppetmaster.audit import build_audit_report
+
+        cases = (
+            ("registry_digest", "registry-a", "registry-b"),
+            ("taxonomy_version", "taxonomy-a", "taxonomy-b"),
+            ("adapter_version", "cursor-a", "cursor-b"),
+            ("evaluator_revision", "eval-a", "eval-b"),
+        )
+        for epoch_field, first, second in cases:
+            with self.subTest(epoch_field):
+                base_epoch = {
+                    "registry_digest": "registry-a",
+                    "taxonomy_version": "taxonomy-a",
+                    "adapter_version": "cursor-a",
+                    "evaluator_revision": "eval-a",
+                    "evaluated_at": "2026-08-22T12:00:00Z",
+                }
+                first_epoch = {**base_epoch, epoch_field: first}
+                second_epoch = {**base_epoch, epoch_field: second}
+                records = [
+                    *[
+                        _objective_record(role="audit", passed=False, **first_epoch)
+                        for _ in range(3)
+                    ],
+                    *[
+                        _objective_record(role="audit", passed=False, **second_epoch)
+                        for _ in range(3)
+                    ],
+                ]
+                report = build_audit_report(records, {"cursor/model": 80}, min_sample=5)
+                self.assertEqual(report.epoch_count, 2)
+                self.assertEqual(report.role_scorecard_suggestions, [])
+
+    def test_incomplete_epoch_cannot_authorize_a_role_card_recommendation(self) -> None:
+        from puppetmaster.audit import build_audit_report
+
+        records = [
+            _objective_record(role="audit", passed=False)
             for _ in range(5)
-        ],
-        *[
-            _objective_record(
-                role="audit",
-                passed=False,
-                evaluator_revision="eval-b",
-                evaluated_at="2026-08-22T12:00:00Z",
-                **common,
+        ]
+        report = build_audit_report(records, {"cursor/model": 80}, min_sample=5)
+        self.assertEqual(report.epoch_count, 1)
+        self.assertEqual(report.role_scorecard_suggestions, [])
+
+    def test_undated_complete_lineage_is_reportable_but_non_authoritative(self) -> None:
+        from puppetmaster.audit import build_audit_report
+
+        epoch_without_date = {
+            "registry_digest": "registry-a",
+            "taxonomy_version": "taxonomy-a",
+            "classifier_version": "classifier-a",
+            "adapter_version": "cursor-a",
+            "evaluator_revision": "eval-a",
+        }
+        records = [
+            _objective_record(role="audit", passed=False, **epoch_without_date)
+            for _ in range(5)
+        ]
+        report = build_audit_report(records, {"cursor/model": 80}, min_sample=5)
+        model = next(item for item in report.models if item.model_id == "cursor/model")
+        self.assertEqual(model.runs_with_objective_outcomes, 5)
+        self.assertAlmostEqual(model.objective_pass_rate, 0.0)
+        self.assertEqual(report.epoch_count, 1)
+        self.assertEqual(report.role_scorecard_suggestions, [])
+
+    def test_stale_objective_history_cannot_be_re_stamped_as_a_fresh_role_card(self) -> None:
+        from puppetmaster.audit import build_audit_report, collect_records
+        from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
+        from puppetmaster.store import SwarmStore
+
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            store.init()
+            job = store.create_job("stale objective history")
+            for index in range(5):
+                task = Task(
+                    job_id=job.id,
+                    role="audit",
+                    instruction=f"historical audit {index}",
+                    adapter="cursor",
+                    status=TaskStatus.COMPLETE,
+                    payload={"router_model_id": "cursor/model"},
+                )
+                store.save_task(task)
+                store.save_artifact(
+                    Artifact(
+                        job_id=job.id,
+                        task_id=task.id,
+                        type=ArtifactType.ROUTING,
+                        created_by="router",
+                        payload={
+                            "model_id": "cursor/model",
+                            "adapter": "cursor",
+                            "policy": "balanced",
+                            "predicted_quality": 0.95,
+                            "registry_digest": "registry-historical",
+                            "taxonomy_version": "taxonomy-historical",
+                            "classifier_version": "classifier-historical",
+                            "adapter_version": "cursor-historical",
+                        },
+                        confidence=0.9,
+                        evidence=["historical-route"],
+                        created_at=f"1999-12-31T23:59:{index:02d}Z",
+                    )
+                )
+                store.save_artifact(
+                    Artifact(
+                        job_id=job.id,
+                        task_id=task.id,
+                        type=ArtifactType.GATE,
+                        created_by="review-gate",
+                        payload={
+                            "gate": "review",
+                            "passed": False,
+                            "objective_score": 0.0,
+                            "review_status": "completed",
+                            "evaluator_revision": "review-historical",
+                        },
+                        confidence=1.0,
+                        evidence=["historical-evaluation"],
+                        created_at=f"2000-01-01T00:00:{index:02d}Z",
+                    )
+                )
+            records, _ = collect_records(store)
+            report = build_audit_report(
+                records, {"cursor/model": 80}, min_sample=5
             )
-            for _ in range(5)
-        ],
-    ]
+        self.assertEqual(report.role_scorecard_suggestions, [])
 
-    # Act
-    report = build_audit_report(records, {"cursor/model": 80}, min_sample=5)
+    def test_latest_qualified_epoch_wins_role_card_recommendation(self) -> None:
+        from puppetmaster.audit import build_audit_report
 
-    # Assert
-    assert len(report.role_scorecard_suggestions) == 1
-    suggestion = report.role_scorecard_suggestions[0]
-    assert suggestion["epoch"]["evaluator_revision"] == "eval-b"
-    assert suggestion["last_calibrated"] == "2026-08-22"
+        common = {
+            "registry_digest": "registry-a",
+            "taxonomy_version": "taxonomy-a",
+            "classifier_version": "classifier-a",
+            "adapter_version": "cursor-a",
+        }
+        records = [
+            *[
+                _objective_record(
+                    role="audit",
+                    passed=False,
+                    evaluator_revision="eval-a",
+                    evaluated_at="2026-05-20T12:00:00Z",
+                    **common,
+                )
+                for _ in range(5)
+            ],
+            *[
+                _objective_record(
+                    role="audit",
+                    passed=False,
+                    evaluator_revision="eval-b",
+                    evaluated_at="2026-08-22T12:00:00Z",
+                    **common,
+                )
+                for _ in range(5)
+            ],
+        ]
+        report = build_audit_report(records, {"cursor/model": 80}, min_sample=5)
+        self.assertEqual(len(report.role_scorecard_suggestions), 1)
+        suggestion = report.role_scorecard_suggestions[0]
+        self.assertEqual(suggestion["epoch"]["evaluator_revision"], "eval-b")
+        self.assertEqual(suggestion["last_calibrated"], "2026-08-22")
+
+    def test_legacy_audit_record_and_report_shape_remain_supported(self) -> None:
+        from puppetmaster.audit import build_audit_report
+
+        records = [_legacy_record("cursor/legacy") for _ in range(2)]
+        report = build_audit_report(records, {"cursor/legacy": 60})
+        self.assertEqual(report.tasks_considered, 2)
+        self.assertEqual(report.epoch_count, 1)
+        self.assertEqual(report.suggestions, [])
+        model = report.models[0]
+        self.assertEqual(model.model_id, "cursor/legacy")
+        self.assertEqual(model.selections, 2)
+        self.assertEqual(model.runs_with_objective_outcomes, 0)
+        self.assertIsNone(model.objective_pass_rate)
 
 
-def test_legacy_audit_record_and_report_shape_remain_supported() -> None:
-    # Arrange: this is the pre-TASK-006 construction shape used by existing
-    # callers and tests. New lineage and objective fields must have safe defaults.
-    from puppetmaster.audit import build_audit_report
-
-    records = [_legacy_record("cursor/legacy") for _ in range(2)]
-
-    # Act
-    report = build_audit_report(records, {"cursor/legacy": 60})
-
-    # Assert
-    assert report.tasks_considered == 2
-    assert report.epoch_count == 1
-    assert report.suggestions == []
-    model = report.models[0]
-    assert model.model_id == "cursor/legacy"
-    assert model.selections == 2
-    assert model.runs_with_objective_outcomes == 0
-    assert model.objective_pass_rate is None
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_routing_quality_evaluation.py
+++ b/tests/test_routing_quality_evaluation.py
@@ -7,12 +7,20 @@ semantic correctness.
 """
 from __future__ import annotations
 
-import json
 import hashlib
+import json
+import os
+import sys
+import unittest
 from collections import defaultdict
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
-import pytest
+_HERMETIC_DIR = os.path.dirname(os.path.abspath(__file__))
+if _HERMETIC_DIR not in sys.path:
+    sys.path.insert(0, _HERMETIC_DIR)
+import hermetic_env  # noqa: F401  # process-wide host-env isolation
 
 from puppetmaster.model_registry import ModelSpec
 
@@ -124,523 +132,466 @@ def _passing_executor(request):
     }
 
 
-def test_default_corpus_is_versioned_multi_role_and_has_seeded_failures() -> None:
-    # Arrange / Act.
-    from puppetmaster.routing_evaluation import (
-        grade_case,
-        load_evaluation_corpus,
-        snapshot_digest_for_files,
-    )
+class RoutingQualityEvaluationTests(unittest.TestCase):
+    def test_default_corpus_is_versioned_multi_role_and_has_seeded_failures(self) -> None:
+        from puppetmaster.routing_evaluation import (
+            grade_case,
+            load_evaluation_corpus,
+            snapshot_digest_for_files,
+        )
 
-    corpus = load_evaluation_corpus()
-
-    # Assert: this is a real versioned quality corpus, not one generic prompt.
-    assert corpus.schema_version >= 1
-    assert corpus.corpus_id
-    assert corpus.corpus_version
-    assert {case.role for case in corpus.cases} >= REQUIRED_ROLES
-    assert len({case.case_id for case in corpus.cases}) == len(corpus.cases)
-    assert any(case.seeded_failures for case in corpus.cases)
-    assert all(case.criteria for case in corpus.cases)
-    assert all(case.snapshot_digest.startswith("sha256:") for case in corpus.cases)
-    assert all(case.snapshot_files for case in corpus.cases)
-    assert all(
-        snapshot_digest_for_files(case.snapshot_files) == case.snapshot_digest
-        for case in corpus.cases
-    )
-    assert all(
-        criterion.evaluator_kind != "llm_judge"
-        for case in corpus.cases
-        for criterion in case.criteria
-    )
-    assert all(
-        criterion.expected.casefold() not in case.instruction.casefold()
-        for case in corpus.cases
-        for criterion in case.criteria
-    )
-
-    # Seeded failures are executable negative vectors, not descriptions which
-    # have never been graded against their claimed case.
-    for case in corpus.cases:
-        for failure in case.seeded_failures:
-            grade = grade_case(
-                case,
-                output_text=failure.output_text,
-                changed_files=failure.changed_files,
-                catastrophic=failure.catastrophic,
+        corpus = load_evaluation_corpus()
+        self.assertGreaterEqual(corpus.schema_version, 1)
+        self.assertTrue(corpus.corpus_id)
+        self.assertTrue(corpus.corpus_version)
+        self.assertGreaterEqual({case.role for case in corpus.cases}, REQUIRED_ROLES)
+        self.assertEqual(len({case.case_id for case in corpus.cases}), len(corpus.cases))
+        self.assertTrue(any(case.seeded_failures for case in corpus.cases))
+        self.assertTrue(all(case.criteria for case in corpus.cases))
+        self.assertTrue(all(case.snapshot_digest.startswith("sha256:") for case in corpus.cases))
+        self.assertTrue(all(case.snapshot_files for case in corpus.cases))
+        self.assertTrue(
+            all(
+                snapshot_digest_for_files(case.snapshot_files) == case.snapshot_digest
+                for case in corpus.cases
             )
-            assert grade.acceptance_passed is False
+        )
+        self.assertTrue(
+            all(
+                criterion.evaluator_kind != "llm_judge"
+                for case in corpus.cases
+                for criterion in case.criteria
+            )
+        )
+        self.assertTrue(
+            all(
+                criterion.expected.casefold() not in case.instruction.casefold()
+                for case in corpus.cases
+                for criterion in case.criteria
+            )
+        )
+        for case in corpus.cases:
+            for failure in case.seeded_failures:
+                grade = grade_case(
+                    case,
+                    output_text=failure.output_text,
+                    changed_files=failure.changed_files,
+                    catastrophic=failure.catastrophic,
+                )
+                self.assertIs(grade.acceptance_passed, False)
 
+    def test_corpus_loader_fails_closed_without_version_or_required_roles(self) -> None:
+        from puppetmaster.routing_evaluation import load_evaluation_corpus
 
-def test_corpus_loader_fails_closed_without_version_or_required_roles(tmp_path: Path) -> None:
-    # Arrange.
-    from puppetmaster.routing_evaluation import load_evaluation_corpus
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            unversioned = _corpus_payload()
+            unversioned.pop("corpus_version")
+            unversioned_path = _write_corpus(tmp_path, unversioned)
+            with self.assertRaisesRegex(ValueError, "corpus_version"):
+                load_evaluation_corpus(unversioned_path)
 
-    unversioned = _corpus_payload()
-    unversioned.pop("corpus_version")
-    unversioned_path = _write_corpus(tmp_path, unversioned)
+            incomplete = _corpus_payload()
+            incomplete["corpus_version"] = "2026-08-22.2"
+            incomplete["cases"] = [
+                case for case in incomplete["cases"] if case["role"] != "plan"
+            ]
+            incomplete_path = tmp_path / "incomplete.json"
+            incomplete_path.write_text(json.dumps(incomplete), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "plan"):
+                load_evaluation_corpus(incomplete_path)
 
-    # Act / Assert.
-    with pytest.raises(ValueError, match="corpus_version"):
-        load_evaluation_corpus(unversioned_path)
+    def test_corpus_loader_rejects_a_seeded_failure_that_passes_acceptance(self) -> None:
+        from puppetmaster.routing_evaluation import load_evaluation_corpus
 
-    incomplete = _corpus_payload()
-    incomplete["corpus_version"] = "2026-08-22.2"
-    incomplete["cases"] = [
-        case for case in incomplete["cases"] if case["role"] != "plan"
-    ]
-    incomplete_path = tmp_path / "incomplete.json"
-    incomplete_path.write_text(json.dumps(incomplete), encoding="utf-8")
-    with pytest.raises(ValueError, match="plan"):
-        load_evaluation_corpus(incomplete_path)
+        payload = _corpus_payload()
+        audit_case = next(case for case in payload["cases"] if case["role"] == "audit")
+        audit_case["seeded_failures"][0]["output_text"] = audit_case["criteria"][0][
+            "evaluator"
+        ]["expected"]
+        with TemporaryDirectory() as tmp:
+            path = _write_corpus(Path(tmp), payload)
+            with self.assertRaisesRegex(ValueError, "seeded failure.*must fail"):
+                load_evaluation_corpus(path)
 
+    def test_deterministic_grader_scores_criteria_and_unintended_files(self) -> None:
+        from puppetmaster.routing_evaluation import grade_case, load_evaluation_corpus
 
-def test_corpus_loader_rejects_a_seeded_failure_that_passes_acceptance(
-    tmp_path: Path,
-) -> None:
-    # Arrange: a corpus must not gain seeded-failure credibility merely by
-    # labeling a successful vector as a failure.
-    from puppetmaster.routing_evaluation import load_evaluation_corpus
+        with TemporaryDirectory() as tmp:
+            corpus = load_evaluation_corpus(_write_corpus(Path(tmp)))
+        case = next(item for item in corpus.cases if item.role == "implement")
+        allowed = list(case.allowed_changed_files)
+        first = grade_case(
+            case,
+            output_text=f"done\n{case.criteria[0].expected}\n",
+            changed_files=allowed,
+            catastrophic=False,
+        )
+        repeat = grade_case(
+            case,
+            output_text=f"done\n{case.criteria[0].expected}\n",
+            changed_files=allowed,
+            catastrophic=False,
+        )
+        failed = grade_case(
+            case,
+            output_text="plausible prose without the required marker",
+            changed_files=[*allowed, "unintended.txt"],
+            catastrophic=False,
+        )
+        self.assertEqual(first, repeat)
+        self.assertIs(first.acceptance_passed, True)
+        self.assertAlmostEqual(first.criterion_score, 1.0)
+        self.assertEqual(first.unintended_files, ())
+        self.assertIs(failed.acceptance_passed, False)
+        self.assertAlmostEqual(failed.criterion_score, 0.0)
+        self.assertEqual(failed.unintended_files, ("unintended.txt",))
 
-    payload = _corpus_payload()
-    audit_case = next(case for case in payload["cases"] if case["role"] == "audit")
-    audit_case["seeded_failures"][0]["output_text"] = audit_case["criteria"][0][
-        "evaluator"
-    ]["expected"]
-    path = _write_corpus(tmp_path, payload)
-
-    # Act / Assert.
-    with pytest.raises(ValueError, match="seeded failure.*must fail"):
-        load_evaluation_corpus(path)
-
-
-def test_deterministic_grader_scores_criteria_and_unintended_files(tmp_path: Path) -> None:
-    # Arrange.
-    from puppetmaster.routing_evaluation import grade_case, load_evaluation_corpus
-
-    corpus = load_evaluation_corpus(_write_corpus(tmp_path))
-    case = next(item for item in corpus.cases if item.role == "implement")
-    allowed = list(case.allowed_changed_files)
-
-    # Act.
-    first = grade_case(
-        case,
-        output_text=f"done\n{case.criteria[0].expected}\n",
-        changed_files=allowed,
-        catastrophic=False,
-    )
-    repeat = grade_case(
-        case,
-        output_text=f"done\n{case.criteria[0].expected}\n",
-        changed_files=allowed,
-        catastrophic=False,
-    )
-    failed = grade_case(
-        case,
-        output_text="plausible prose without the required marker",
-        changed_files=[*allowed, "unintended.txt"],
-        catastrophic=False,
-    )
-
-    # Assert: grading is repeatable and semantic acceptance is criterion-bound.
-    assert first == repeat
-    assert first.acceptance_passed is True
-    assert first.criterion_score == pytest.approx(1.0)
-    assert first.unintended_files == ()
-    assert failed.acceptance_passed is False
-    assert failed.criterion_score == pytest.approx(0.0)
-    assert failed.unintended_files == ("unintended.txt",)
-
-
-def test_paired_runner_uses_identical_snapshots_and_strongest_eligible_baseline(
-    tmp_path: Path,
-) -> None:
-    # Arrange: the absolute strongest model cannot fit; the strongest eligible
-    # baseline must therefore pin frontier, while balanced should route bargain.
-    from puppetmaster.routing_evaluation import (
-        load_evaluation_corpus,
-        run_paired_evaluation,
-    )
-
-    corpus = load_evaluation_corpus(_write_corpus(tmp_path))
-    registry = [
-        _model("cursor/bargain", capability=70, cost=0.10),
-        _model("cursor/frontier", capability=95, cost=1.00),
-        _model(
-            "cursor/overflowing-strongest",
-            capability=100,
-            cost=2.00,
-            context_window=1_100,
-        ),
-    ]
-    calls = []
-
-    def execute(request):
-        calls.append(request)
-        return _passing_executor(request)
-
-    # Act.
-    report = run_paired_evaluation(
-        corpus,
-        registry,
-        execute=execute,
-        repetitions=3,
-        seed=41,
-    )
-
-    # Assert: every case/repetition is a pair over the same immutable baseline.
-    grouped = defaultdict(list)
-    for request in calls:
-        grouped[(request.case.case_id, request.repetition)].append(request)
-    assert len(grouped) == len(corpus.cases) * 3
-    for pair in grouped.values():
-        assert {request.arm for request in pair} == ARM_NAMES
-        assert len({request.snapshot_digest for request in pair}) == 1
-        model_by_arm = {request.arm: request.model_id for request in pair}
-        assert model_by_arm == {
-            "routed_balanced": "cursor/bargain",
-            "strongest_eligible": "cursor/frontier",
-        }
-
-    # Randomized execution order is deterministic under a seed and exercises
-    # both orderings instead of always favoring the same first arm.
-    arm_orders = {tuple(pair.arm_order) for pair in report.pairs}
-    assert arm_orders == {
-        ("routed_balanced", "strongest_eligible"),
-        ("strongest_eligible", "routed_balanced"),
-    }
-
-
-def test_paired_runner_requires_three_repetitions(tmp_path: Path) -> None:
-    # Arrange.
-    from puppetmaster.routing_evaluation import (
-        load_evaluation_corpus,
-        run_paired_evaluation,
-    )
-
-    corpus = load_evaluation_corpus(_write_corpus(tmp_path))
-    registry = [_model("cursor/model", capability=90, cost=1.0)]
-
-    # Act / Assert.
-    with pytest.raises(ValueError, match="at least 3"):
-        run_paired_evaluation(
-            corpus,
-            registry,
-            execute=_passing_executor,
-            repetitions=2,
-            seed=1,
+    def test_paired_runner_uses_identical_snapshots_and_strongest_eligible_baseline(self) -> None:
+        from puppetmaster.routing_evaluation import (
+            load_evaluation_corpus,
+            run_paired_evaluation,
         )
 
-
-def test_paired_runner_rejects_unverified_or_mismatched_snapshot_receipts(
-    tmp_path: Path,
-) -> None:
-    # Arrange: sharing an asserted digest in two requests is not proof that an
-    # executor actually reset both arms to that snapshot.
-    from puppetmaster.routing_evaluation import (
-        load_evaluation_corpus,
-        run_paired_evaluation,
-    )
-
-    corpus = load_evaluation_corpus(_write_corpus(tmp_path))
-    registry = [_model("cursor/model", capability=90, cost=1.0)]
-
-    def mismatched_executor(request):
-        receipt = dict(_passing_executor(request))
-        receipt["snapshot_digest"] = "sha256:" + "0" * 64
-        return receipt
-
-    # Act / Assert: the report must not certify same-snapshot pairing from an
-    # unchecked request field alone.
-    with pytest.raises(ValueError, match="snapshot_digest"):
-        run_paired_evaluation(
-            corpus,
-            registry,
-            execute=mismatched_executor,
-            repetitions=3,
-            seed=1,
-        )
-
-
-def test_report_includes_quality_cost_failure_metrics_and_paired_uncertainty(
-    tmp_path: Path,
-) -> None:
-    # Arrange: opposite wins in different repetitions create a genuine wide,
-    # paired quality interval that must remain inconclusive.
-    from puppetmaster.routing_evaluation import (
-        load_evaluation_corpus,
-        render_evaluation_report,
-        run_paired_evaluation,
-    )
-
-    corpus = load_evaluation_corpus(_write_corpus(tmp_path))
-    registry = [
-        _model("cursor/bargain", capability=70, cost=0.10),
-        _model("cursor/frontier", capability=95, cost=1.00),
-    ]
-
-    def execute(request):
-        routed_passes = request.repetition != 1
-        baseline_passes = request.repetition != 2
-        passed = routed_passes if request.arm == "routed_balanced" else baseline_passes
-        return {
-            "output_text": request.case.criteria[0].expected if passed else "missing",
-            "snapshot_digest": request.snapshot_digest,
-            "changed_files": (
-                [*request.case.allowed_changed_files, "unintended.txt"]
-                if request.arm == "routed_balanced" and request.repetition == 1
-                else list(request.case.allowed_changed_files)
-            ),
-            "catastrophic": request.arm == "strongest_eligible" and request.repetition == 2,
-            "correction_cycles": request.repetition,
-            "elapsed_seconds": 2.0 + request.repetition,
-            "retries": 1 if request.repetition == 1 else 0,
-            "tokens_in": 1_000 + request.repetition,
-            "tokens_out": 100 + request.repetition,
-            "nominal_cost_usd": 0.02 + request.repetition / 100,
-            "marginal_cost_usd": 0.01 + request.repetition / 100,
-        }
-
-    # Act.
-    first = run_paired_evaluation(
-        corpus,
-        registry,
-        execute=execute,
-        repetitions=3,
-        seed=19,
-        noninferiority_margin=0.05,
-    )
-    repeat = run_paired_evaluation(
-        corpus,
-        registry,
-        execute=execute,
-        repetitions=3,
-        seed=19,
-        noninferiority_margin=0.05,
-    )
-    payload = first.to_dict()
-
-    # Assert: a fixed corpus, executor, and seed produce a stable sample report.
-    assert payload == repeat.to_dict()
-    assert payload["claim"]["status"] == "inconclusive"
-    assert payload["claim"]["basis"] == "paired_noninferiority"
-    required_metrics = {
-        "acceptance_pass_rate",
-        "criterion_score_mean",
-        "unintended_file_rate",
-        "catastrophic_failure_rate",
-        "correction_cycles_mean",
-        "elapsed_seconds_mean",
-        "retries_mean",
-        "tokens_in_mean",
-        "tokens_out_mean",
-        "nominal_cost_usd_mean",
-        "marginal_cost_usd_mean",
-    }
-    assert set(payload["arms"]["routed_balanced"]) >= required_metrics
-    assert set(payload["arms"]["strongest_eligible"]) >= required_metrics
-    assert set(payload["paired_deltas"]) >= required_metrics
-    for metric in required_metrics:
-        uncertainty = payload["paired_deltas"][metric]
-        assert set(uncertainty) >= {"estimate", "lower", "upper", "method"}
-        assert uncertainty["lower"] <= uncertainty["estimate"] <= uncertainty["upper"]
-
-    markdown = render_evaluation_report(first).lower()
-    assert "inconclusive" in markdown
-    assert "paired non-inferiority" in markdown
-    assert "does not establish semantic quality" in markdown
-    assert "proves that routing improves quality" not in markdown
-
-
-def test_finite_all_equal_sample_does_not_collapse_quality_uncertainty_to_zero(
-    tmp_path: Path,
-) -> None:
-    # Arrange: twelve observed ties (four cases x three repetitions) are
-    # encouraging, but a finite binary sample does not establish a population
-    # pass-rate difference of exactly zero at a five-point margin.
-    from puppetmaster.routing_evaluation import (
-        load_evaluation_corpus,
-        run_paired_evaluation,
-    )
-
-    corpus = load_evaluation_corpus(_write_corpus(tmp_path))
-    registry = [
-        _model("cursor/bargain", capability=70, cost=0.10),
-        _model("cursor/frontier", capability=95, cost=1.00),
-    ]
-
-    # Act.
-    report = run_paired_evaluation(
-        corpus,
-        registry,
-        execute=_passing_executor,
-        repetitions=3,
-        seed=7,
-        noninferiority_margin=0.05,
-    )
-    quality = report.to_dict()["paired_deltas"]["acceptance_pass_rate"]
-
-    # Assert: a variance-zero normal approximation would incorrectly emit
-    # [0, 0] and claim non-inferiority from only twelve pairs.
-    assert quality["lower"] < quality["estimate"] < quality["upper"]
-    assert report.claim["status"] == "inconclusive"
-
-
-@pytest.mark.parametrize(
-    "invalid_margin",
-    [
-        pytest.param(True, id="boolean"),
-        pytest.param(float("nan"), id="nan"),
-        pytest.param(float("inf"), id="infinite"),
-        pytest.param(1.01, id="above-pass-rate-range"),
-    ],
-)
-def test_noninferiority_margin_fails_closed_outside_finite_unit_interval(
-    tmp_path: Path,
-    invalid_margin: object,
-) -> None:
-    # Arrange.
-    from puppetmaster.routing_evaluation import (
-        load_evaluation_corpus,
-        run_paired_evaluation,
-    )
-
-    corpus = load_evaluation_corpus(_write_corpus(tmp_path))
-    registry = [_model("cursor/model", capability=90, cost=1.0)]
-
-    # Act / Assert: an invalid margin cannot manufacture a favorable claim.
-    with pytest.raises(ValueError, match="noninferiority_margin"):
-        run_paired_evaluation(
-            corpus,
-            registry,
-            execute=_passing_executor,
-            repetitions=3,
-            seed=1,
-            noninferiority_margin=invalid_margin,
-        )
-
-
-def test_shadow_routing_is_opt_in_and_cannot_change_production_selection() -> None:
-    # Arrange.
-    from puppetmaster import router
-
-    task = router.TaskSignals(
-        instruction="perform the bounded task",
-        role="explore",
-        explicit_min_capability=60,
-        estimated_tokens_in=1_000,
-        estimated_tokens_out=200,
-    )
-    registry = [
-        _model("cursor/bargain", capability=70, cost=0.10),
-        _model("cursor/frontier", capability=95, cost=1.00),
-    ]
-
-    # Act.
-    production = router.route_task(task, registry, policy="balanced")
-    shadowed = router.route_task(
-        task,
-        registry,
-        policy="balanced",
-        shadow_policy="quality",
-    )
-    production_payload = production.to_artifact_payload()
-    shadow_payload = shadowed.to_artifact_payload()
-
-    # Assert: opt-in adds counterfactual evidence only; dispatch identity is
-    # byte-for-byte the same production choice as the non-shadow route.
-    assert production.model.id == "cursor/bargain"
-    assert shadowed.model.id == production.model.id
-    assert "shadow_routing" not in production_payload
-    assert shadow_payload["model_id"] == production_payload["model_id"]
-    assert shadow_payload["adapter"] == production_payload["adapter"]
-    assert shadow_payload["policy"] == production_payload["policy"]
-    assert shadow_payload["shadow_routing"] == {
-        "enabled": True,
-        "policy": "quality",
-        "production_model_id": "cursor/bargain",
-        "counterfactual_model_id": "cursor/frontier",
-        "production_selection_changed": False,
-    }
-
-
-def test_orchestrator_shadow_opt_in_persists_evidence_without_changing_dispatch(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    # Arrange: exercise the actual auto-route-to-task/artifact seam, not only a
-    # direct library call which no production caller can enable.
-    from puppetmaster.model_registry import save_registry
-    from puppetmaster.models import ArtifactType
-    from puppetmaster.orchestrator import Orchestrator
-    from puppetmaster.store_factory import create_store
-    from puppetmaster.workers import WorkerSpec
-
-    registry_path = tmp_path / "models.json"
-    save_registry(
-        [
+        with TemporaryDirectory() as tmp:
+            corpus = load_evaluation_corpus(_write_corpus(Path(tmp)))
+        registry = [
             _model("cursor/bargain", capability=70, cost=0.10),
             _model("cursor/frontier", capability=95, cost=1.00),
-        ],
-        registry_path,
-    )
-    monkeypatch.setattr(
-        "puppetmaster.preflight.adapter_cli_present", lambda _adapter: True
-    )
-    store = create_store("file", tmp_path / ".puppetmaster")
-    store.init()
-    orchestrator = Orchestrator(store)
-    job = store.create_job("shadow route production seam")
-    spec = WorkerSpec(
-        role="explore",
-        instruction="perform the bounded task",
-        adapter="local",
-        payload={
-            "auto_route": True,
-            "registry_path": str(registry_path),
-            "routing_policy": "balanced",
-            "min_capability": 60,
-            "estimated_tokens_in": 1_000,
-            "estimated_tokens_out": 200,
-            "shadow_policy": "quality",
-        },
-    )
+            _model(
+                "cursor/overflowing-strongest",
+                capability=100,
+                cost=2.00,
+                context_window=1_100,
+            ),
+        ]
+        calls = []
 
-    # Act.
-    task = orchestrator._create_tasks(job, [spec])[0]
-    routing = [
-        artifact
-        for artifact in store.list_artifacts(job.id)
-        if artifact.type == ArtifactType.ROUTING
-    ]
+        def execute(request):
+            calls.append(request)
+            return _passing_executor(request)
 
-    # Assert: dispatch remains the balanced pick while the durable artifact
-    # carries the quality-policy counterfactual.
-    assert task.payload["router_model_id"] == "cursor/bargain"
-    assert task.payload["model"] == "bargain"
-    assert len(routing) == 1
-    assert routing[0].payload["model_id"] == "cursor/bargain"
-    assert routing[0].payload["shadow_routing"] == {
-        "enabled": True,
-        "policy": "quality",
-        "production_model_id": "cursor/bargain",
-        "counterfactual_model_id": "cursor/frontier",
-        "production_selection_changed": False,
-    }
+        report = run_paired_evaluation(
+            corpus,
+            registry,
+            execute=execute,
+            repetitions=3,
+            seed=41,
+        )
+        grouped = defaultdict(list)
+        for request in calls:
+            grouped[(request.case.case_id, request.repetition)].append(request)
+        self.assertEqual(len(grouped), len(corpus.cases) * 3)
+        for pair in grouped.values():
+            self.assertEqual({request.arm for request in pair}, ARM_NAMES)
+            self.assertEqual(len({request.snapshot_digest for request in pair}), 1)
+            model_by_arm = {request.arm: request.model_id for request in pair}
+            self.assertEqual(
+                model_by_arm,
+                {
+                    "routed_balanced": "cursor/bargain",
+                    "strongest_eligible": "cursor/frontier",
+                },
+            )
+        arm_orders = {tuple(pair.arm_order) for pair in report.pairs}
+        self.assertEqual(
+            arm_orders,
+            {
+                ("routed_balanced", "strongest_eligible"),
+                ("strongest_eligible", "routed_balanced"),
+            },
+        )
+
+    def test_paired_runner_requires_three_repetitions(self) -> None:
+        from puppetmaster.routing_evaluation import (
+            load_evaluation_corpus,
+            run_paired_evaluation,
+        )
+
+        with TemporaryDirectory() as tmp:
+            corpus = load_evaluation_corpus(_write_corpus(Path(tmp)))
+        registry = [_model("cursor/model", capability=90, cost=1.0)]
+        with self.assertRaisesRegex(ValueError, "at least 3"):
+            run_paired_evaluation(
+                corpus,
+                registry,
+                execute=_passing_executor,
+                repetitions=2,
+                seed=1,
+            )
+
+    def test_paired_runner_rejects_unverified_or_mismatched_snapshot_receipts(self) -> None:
+        from puppetmaster.routing_evaluation import (
+            load_evaluation_corpus,
+            run_paired_evaluation,
+        )
+
+        with TemporaryDirectory() as tmp:
+            corpus = load_evaluation_corpus(_write_corpus(Path(tmp)))
+        registry = [_model("cursor/model", capability=90, cost=1.0)]
+
+        def mismatched_executor(request):
+            receipt = dict(_passing_executor(request))
+            receipt["snapshot_digest"] = "sha256:" + "0" * 64
+            return receipt
+
+        with self.assertRaisesRegex(ValueError, "snapshot_digest"):
+            run_paired_evaluation(
+                corpus,
+                registry,
+                execute=mismatched_executor,
+                repetitions=3,
+                seed=1,
+            )
+
+    def test_report_includes_quality_cost_failure_metrics_and_paired_uncertainty(self) -> None:
+        from puppetmaster.routing_evaluation import (
+            load_evaluation_corpus,
+            render_evaluation_report,
+            run_paired_evaluation,
+        )
+
+        with TemporaryDirectory() as tmp:
+            corpus = load_evaluation_corpus(_write_corpus(Path(tmp)))
+        registry = [
+            _model("cursor/bargain", capability=70, cost=0.10),
+            _model("cursor/frontier", capability=95, cost=1.00),
+        ]
+
+        def execute(request):
+            routed_passes = request.repetition != 1
+            baseline_passes = request.repetition != 2
+            passed = routed_passes if request.arm == "routed_balanced" else baseline_passes
+            return {
+                "output_text": request.case.criteria[0].expected if passed else "missing",
+                "snapshot_digest": request.snapshot_digest,
+                "changed_files": (
+                    [*request.case.allowed_changed_files, "unintended.txt"]
+                    if request.arm == "routed_balanced" and request.repetition == 1
+                    else list(request.case.allowed_changed_files)
+                ),
+                "catastrophic": request.arm == "strongest_eligible" and request.repetition == 2,
+                "correction_cycles": request.repetition,
+                "elapsed_seconds": 2.0 + request.repetition,
+                "retries": 1 if request.repetition == 1 else 0,
+                "tokens_in": 1_000 + request.repetition,
+                "tokens_out": 100 + request.repetition,
+                "nominal_cost_usd": 0.02 + request.repetition / 100,
+                "marginal_cost_usd": 0.01 + request.repetition / 100,
+            }
+
+        first = run_paired_evaluation(
+            corpus,
+            registry,
+            execute=execute,
+            repetitions=3,
+            seed=19,
+            noninferiority_margin=0.05,
+        )
+        repeat = run_paired_evaluation(
+            corpus,
+            registry,
+            execute=execute,
+            repetitions=3,
+            seed=19,
+            noninferiority_margin=0.05,
+        )
+        payload = first.to_dict()
+        self.assertEqual(payload, repeat.to_dict())
+        self.assertEqual(payload["claim"]["status"], "inconclusive")
+        self.assertEqual(payload["claim"]["basis"], "paired_noninferiority")
+        required_metrics = {
+            "acceptance_pass_rate",
+            "criterion_score_mean",
+            "unintended_file_rate",
+            "catastrophic_failure_rate",
+            "correction_cycles_mean",
+            "elapsed_seconds_mean",
+            "retries_mean",
+            "tokens_in_mean",
+            "tokens_out_mean",
+            "nominal_cost_usd_mean",
+            "marginal_cost_usd_mean",
+        }
+        self.assertGreaterEqual(set(payload["arms"]["routed_balanced"]), required_metrics)
+        self.assertGreaterEqual(set(payload["arms"]["strongest_eligible"]), required_metrics)
+        self.assertGreaterEqual(set(payload["paired_deltas"]), required_metrics)
+        for metric in required_metrics:
+            uncertainty = payload["paired_deltas"][metric]
+            self.assertGreaterEqual(set(uncertainty), {"estimate", "lower", "upper", "method"})
+            self.assertLessEqual(uncertainty["lower"], uncertainty["estimate"])
+            self.assertLessEqual(uncertainty["estimate"], uncertainty["upper"])
+
+        markdown = render_evaluation_report(first).lower()
+        self.assertIn("inconclusive", markdown)
+        self.assertIn("paired non-inferiority", markdown)
+        self.assertIn("does not establish semantic quality", markdown)
+        self.assertNotIn("proves that routing improves quality", markdown)
+
+    def test_finite_all_equal_sample_does_not_collapse_quality_uncertainty_to_zero(self) -> None:
+        from puppetmaster.routing_evaluation import (
+            load_evaluation_corpus,
+            run_paired_evaluation,
+        )
+
+        with TemporaryDirectory() as tmp:
+            corpus = load_evaluation_corpus(_write_corpus(Path(tmp)))
+        registry = [
+            _model("cursor/bargain", capability=70, cost=0.10),
+            _model("cursor/frontier", capability=95, cost=1.00),
+        ]
+        report = run_paired_evaluation(
+            corpus,
+            registry,
+            execute=_passing_executor,
+            repetitions=3,
+            seed=7,
+            noninferiority_margin=0.05,
+        )
+        quality = report.to_dict()["paired_deltas"]["acceptance_pass_rate"]
+        self.assertLess(quality["lower"], quality["estimate"])
+        self.assertLess(quality["estimate"], quality["upper"])
+        self.assertEqual(report.claim["status"], "inconclusive")
+
+    def test_noninferiority_margin_fails_closed_outside_finite_unit_interval(self) -> None:
+        from puppetmaster.routing_evaluation import (
+            load_evaluation_corpus,
+            run_paired_evaluation,
+        )
+
+        cases = (
+            (True, "boolean"),
+            (float("nan"), "nan"),
+            (float("inf"), "infinite"),
+            (1.01, "above-pass-rate-range"),
+        )
+        with TemporaryDirectory() as tmp:
+            corpus = load_evaluation_corpus(_write_corpus(Path(tmp)))
+        registry = [_model("cursor/model", capability=90, cost=1.0)]
+        for invalid_margin, case_id in cases:
+            with self.subTest(case_id):
+                with self.assertRaisesRegex(ValueError, "noninferiority_margin"):
+                    run_paired_evaluation(
+                        corpus,
+                        registry,
+                        execute=_passing_executor,
+                        repetitions=3,
+                        seed=1,
+                        noninferiority_margin=invalid_margin,
+                    )
+
+    def test_shadow_routing_is_opt_in_and_cannot_change_production_selection(self) -> None:
+        from puppetmaster import router
+
+        task = router.TaskSignals(
+            instruction="perform the bounded task",
+            role="explore",
+            explicit_min_capability=60,
+            estimated_tokens_in=1_000,
+            estimated_tokens_out=200,
+        )
+        registry = [
+            _model("cursor/bargain", capability=70, cost=0.10),
+            _model("cursor/frontier", capability=95, cost=1.00),
+        ]
+        production = router.route_task(task, registry, policy="balanced")
+        shadowed = router.route_task(
+            task,
+            registry,
+            policy="balanced",
+            shadow_policy="quality",
+        )
+        production_payload = production.to_artifact_payload()
+        shadow_payload = shadowed.to_artifact_payload()
+        self.assertEqual(production.model.id, "cursor/bargain")
+        self.assertEqual(shadowed.model.id, production.model.id)
+        self.assertNotIn("shadow_routing", production_payload)
+        self.assertEqual(shadow_payload["model_id"], production_payload["model_id"])
+        self.assertEqual(shadow_payload["adapter"], production_payload["adapter"])
+        self.assertEqual(shadow_payload["policy"], production_payload["policy"])
+        self.assertEqual(
+            shadow_payload["shadow_routing"],
+            {
+                "enabled": True,
+                "policy": "quality",
+                "production_model_id": "cursor/bargain",
+                "counterfactual_model_id": "cursor/frontier",
+                "production_selection_changed": False,
+            },
+        )
+
+    def test_orchestrator_shadow_opt_in_persists_evidence_without_changing_dispatch(self) -> None:
+        from puppetmaster.model_registry import save_registry
+        from puppetmaster.models import ArtifactType
+        from puppetmaster.orchestrator import Orchestrator
+        from puppetmaster.store_factory import create_store
+        from puppetmaster.workers import WorkerSpec
+
+        with TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            registry_path = tmp_path / "models.json"
+            save_registry(
+                [
+                    _model("cursor/bargain", capability=70, cost=0.10),
+                    _model("cursor/frontier", capability=95, cost=1.00),
+                ],
+                registry_path,
+            )
+            store = create_store("file", tmp_path / ".puppetmaster")
+            store.init()
+            orchestrator = Orchestrator(store)
+            job = store.create_job("shadow route production seam")
+            spec = WorkerSpec(
+                role="explore",
+                instruction="perform the bounded task",
+                adapter="local",
+                payload={
+                    "auto_route": True,
+                    "registry_path": str(registry_path),
+                    "routing_policy": "balanced",
+                    "min_capability": 60,
+                    "estimated_tokens_in": 1_000,
+                    "estimated_tokens_out": 200,
+                    "shadow_policy": "quality",
+                },
+            )
+            with patch(
+                "puppetmaster.preflight.adapter_cli_present",
+                lambda _adapter: True,
+            ):
+                task = orchestrator._create_tasks(job, [spec])[0]
+            routing = [
+                artifact
+                for artifact in store.list_artifacts(job.id)
+                if artifact.type == ArtifactType.ROUTING
+            ]
+            self.assertEqual(task.payload["router_model_id"], "cursor/bargain")
+            self.assertEqual(task.payload["model"], "bargain")
+            self.assertEqual(len(routing), 1)
+            self.assertEqual(routing[0].payload["model_id"], "cursor/bargain")
+            self.assertEqual(
+                routing[0].payload["shadow_routing"],
+                {
+                    "enabled": True,
+                    "policy": "quality",
+                    "production_model_id": "cursor/bargain",
+                    "counterfactual_model_id": "cursor/frontier",
+                    "production_selection_changed": False,
+                },
+            )
+
+    def test_documentation_states_quality_claim_boundaries(self) -> None:
+        text = (
+            Path(__file__).resolve().parents[1]
+            / "docs"
+            / "routing-quality-evaluation.md"
+        ).read_text(encoding="utf-8").lower()
+        self.assertIn("non-inferiority", text)
+        self.assertIn("inconclusive", text)
+        self.assertIn("structural artifact presence", text)
+        self.assertIn("not semantic quality", text)
+        self.assertNotIn("proves that routing improves quality", text)
 
 
-def test_documentation_states_quality_claim_boundaries() -> None:
-    # Arrange / Act.
-    text = (
-        Path(__file__).resolve().parents[1]
-        / "docs"
-        / "routing-quality-evaluation.md"
-    ).read_text(encoding="utf-8").lower()
-
-    # Assert: structural presence is useful health evidence, but not semantic
-    # correctness, and a finite paired run may support only a bounded claim.
-    assert "non-inferiority" in text
-    assert "inconclusive" in text
-    assert "structural artifact presence" in text
-    assert "not semantic quality" in text
-    assert "proves that routing improves quality" not in text
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_routing_role_taxonomy.py
+++ b/tests/test_routing_role_taxonomy.py
@@ -11,10 +11,17 @@ import ast
 import importlib.resources
 import inspect
 import json
+import os
+import sys
+import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Optional
 
-import pytest
+_HERMETIC_DIR = os.path.dirname(os.path.abspath(__file__))
+if _HERMETIC_DIR not in sys.path:
+    sys.path.insert(0, _HERMETIC_DIR)
+import hermetic_env  # noqa: F401  # process-wide host-env isolation
 
 from puppetmaster import router
 from puppetmaster.model_registry import ModelSpec
@@ -83,263 +90,173 @@ def _authority_json() -> dict:
     return json.loads(resource.read_text(encoding="utf-8"))
 
 
-def test_taxonomy_is_external_package_data_without_literal_role_tables() -> None:
-    # Arrange: resolve the authority through the installed-package resource API.
-    resource = importlib.resources.files("puppetmaster").joinpath("routing_roles.json")
+class RoutingRoleTaxonomyTests(unittest.TestCase):
+    def test_taxonomy_is_external_package_data_without_literal_role_tables(self) -> None:
+        resource = importlib.resources.files("puppetmaster").joinpath("routing_roles.json")
+        self.assertTrue(resource.is_file(), "routing_roles.json must be shipped inside puppetmaster")
+        source = inspect.getsource(router)
+        tree = ast.parse(source)
+        hardcoded_assignments = []
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+                continue
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            names = {target.id for target in targets if isinstance(target, ast.Name)}
+            value = node.value
+            if "_ROLE_BASE_SCORE" in names and isinstance(value, ast.Dict):
+                hardcoded_assignments.append("_ROLE_BASE_SCORE")
+            if "_TOOL_LOOP_ROLES" in names:
+                literal = isinstance(value, (ast.Set, ast.List, ast.Tuple))
+                literal_frozenset = (
+                    isinstance(value, ast.Call)
+                    and isinstance(value.func, ast.Name)
+                    and value.func.id == "frozenset"
+                    and bool(value.args)
+                    and isinstance(value.args[0], (ast.Set, ast.List, ast.Tuple))
+                )
+                if literal or literal_frozenset:
+                    hardcoded_assignments.append("_TOOL_LOOP_ROLES")
+        self.assertEqual(hardcoded_assignments, [])
+        pyproject = Path(__file__).parents[1] / "pyproject.toml"
+        package_data = pyproject.read_text(encoding="utf-8")
+        self.assertTrue(
+            '"routing_roles.json"' in package_data or '"*.json"' in package_data
+        )
 
-    # Act: inspect both the resource and assignments in router.py.
-    assert resource.is_file(), "routing_roles.json must be shipped inside puppetmaster"
-    source = inspect.getsource(router)
-    tree = ast.parse(source)
-    hardcoded_assignments = []
-    for node in ast.walk(tree):
-        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
-            continue
-        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
-        names = {target.id for target in targets if isinstance(target, ast.Name)}
-        value = node.value
-        if "_ROLE_BASE_SCORE" in names and isinstance(value, ast.Dict):
-            hardcoded_assignments.append("_ROLE_BASE_SCORE")
-        if "_TOOL_LOOP_ROLES" in names:
-            literal = isinstance(value, (ast.Set, ast.List, ast.Tuple))
-            literal_frozenset = (
-                isinstance(value, ast.Call)
-                and isinstance(value.func, ast.Name)
-                and value.func.id == "frozenset"
-                and bool(value.args)
-                and isinstance(value.args[0], (ast.Set, ast.List, ast.Tuple))
-            )
-            if literal or literal_frozenset:
-                hardcoded_assignments.append("_TOOL_LOOP_ROLES")
+    def test_external_schema_defines_every_builtin_role_and_alias(self) -> None:
+        data = _authority_json()
+        roles = data.get("roles", {})
+        actual = {
+            role: (definition.get("base_capability"), definition.get("tool_loop"))
+            for role, definition in roles.items()
+            if role in EXPECTED_BUILTIN_ROLES
+        }
+        aliases = {
+            alias: role
+            for role, definition in roles.items()
+            for alias in definition.get("aliases", [])
+        }
+        self.assertEqual(data.get("schema_version"), 1)
+        self.assertIsInstance(data.get("taxonomy_version"), str)
+        self.assertTrue(data["taxonomy_version"].strip())
+        unknown = data.get("unknown_role")
+        unknown_canonical = (
+            unknown.get("canonical_role") if isinstance(unknown, dict) else unknown
+        )
+        self.assertEqual(unknown_canonical, "unknown")
+        self.assertEqual(actual, EXPECTED_BUILTIN_ROLES)
+        normalized_expected_aliases = {
+            alias.replace("_", "-"): canonical
+            for alias, canonical in EXPECTED_ALIASES.items()
+        }
+        self.assertTrue(aliases.items() >= normalized_expected_aliases.items())
 
-    # Assert: authority is data-backed, not duplicated as Python literals, and
-    # setuptools is configured to carry root JSON resources into a wheel.
-    assert hardcoded_assignments == []
-    pyproject = Path(__file__).parents[1] / "pyproject.toml"
-    package_data = pyproject.read_text(encoding="utf-8")
-    assert (
-        '"routing_roles.json"' in package_data or '"*.json"' in package_data
-    )
+    def test_every_builtin_role_uses_external_capability_and_tool_classification(self) -> None:
+        for role, (expected_base, expected_tool_loop) in EXPECTED_BUILTIN_ROLES.items():
+            with self.subTest(role):
+                task = router.TaskSignals(instruction="inspect the requested target", role=role)
+                capability = router.classify_capability_needed(task)
+                needs_tools = router.task_needs_tool_calling(task)
+                self.assertEqual(capability, expected_base)
+                self.assertIs(needs_tools, expected_tool_loop)
 
+    def test_display_role_aliases_normalize_before_classification(self) -> None:
+        for display_role, canonical_role in EXPECTED_ALIASES.items():
+            with self.subTest(display_role):
+                normalize = _required_api("normalize_routing_role")
+                display = f"  {display_role.upper()}  "
+                expected_base, expected_tools = EXPECTED_BUILTIN_ROLES[canonical_role]
+                task = router.TaskSignals(instruction="inspect the requested target", role=display)
+                normalized = normalize(display)
+                capability = router.classify_capability_needed(task)
+                needs_tools = router.task_needs_tool_calling(task)
+                self.assertEqual(normalized, canonical_role)
+                self.assertEqual(capability, expected_base)
+                self.assertEqual(needs_tools, expected_tools)
 
-def test_external_schema_defines_every_builtin_role_and_alias() -> None:
-    # Arrange: load the independent JSON authority directly.
-    data = _authority_json()
+    def test_unknown_roles_fail_safe_to_external_unknown_role(self) -> None:
+        normalize = _required_api("normalize_routing_role")
+        task = router.TaskSignals(instruction="inspect the requested target", role="future-specialist")
+        canonical = normalize(task.role)
+        capability = router.classify_capability_needed(task)
+        needs_tools = router.task_needs_tool_calling(task)
+        self.assertEqual(canonical, "unknown")
+        self.assertEqual(capability, 60)
+        self.assertIs(needs_tools, True)
 
-    # Act: project only the behavior required by the routing classifier.
-    roles = data.get("roles", {})
-    actual = {
-        role: (definition.get("base_capability"), definition.get("tool_loop"))
-        for role, definition in roles.items()
-        if role in EXPECTED_BUILTIN_ROLES
-    }
-    aliases = {
-        alias: role
-        for role, definition in roles.items()
-        for alias in definition.get("aliases", [])
-    }
+    def test_externalization_preserves_existing_output_token_budgets(self) -> None:
+        for role, expected_tokens in EXPECTED_LEGACY_OUTPUT_BUDGETS.items():
+            with self.subTest(role):
+                task = router.TaskSignals(instruction="inspect the requested target", role=role)
+                tokens = router.estimate_tokens_out(task)
+                self.assertEqual(tokens, expected_tokens)
 
-    # Assert: the schema/version identity and all formerly hardcoded authority
-    # are represented in the packaged file.
-    assert data.get("schema_version") == 1
-    assert isinstance(data.get("taxonomy_version"), str)
-    assert data["taxonomy_version"].strip()
-    unknown = data.get("unknown_role")
-    unknown_canonical = (
-        unknown.get("canonical_role") if isinstance(unknown, dict) else unknown
-    )
-    assert unknown_canonical == "unknown"
-    assert actual == EXPECTED_BUILTIN_ROLES
-    normalized_expected_aliases = {
-        alias.replace("_", "-"): canonical
-        for alias, canonical in EXPECTED_ALIASES.items()
-    }
-    assert aliases.items() >= normalized_expected_aliases.items()
+    def test_loader_fails_explicitly_for_missing_or_malformed_authority(self) -> None:
+        cases = (
+            ("missing.json", None, "missing"),
+            ("invalid-json.json", "{not-json", "not valid json"),
+            (
+                "invalid-schema.json",
+                json.dumps({"schema_version": 1, "taxonomy_version": "test", "roles": {}}),
+                "unknown_role",
+            ),
+        )
+        for filename, contents, message_fragment in cases:
+            with self.subTest(filename):
+                load = _required_api("load_role_taxonomy")
+                error_type = _required_api("RoleTaxonomyError")
+                with TemporaryDirectory() as tmp:
+                    authority_path = Path(tmp) / filename
+                    if contents is not None:
+                        authority_path.write_text(contents, encoding="utf-8")
+                    with self.assertRaises(error_type) as caught:
+                        load(authority_path)
+                    message = str(caught.exception).lower()
+                    self.assertIn(str(authority_path).lower(), message)
+                    self.assertIn(message_fragment, message)
 
+    def test_loader_rejects_alias_collision_with_reserved_unknown_role(self) -> None:
+        load = _required_api("load_role_taxonomy")
+        error_type = _required_api("RoleTaxonomyError")
+        data = _authority_json()
+        data["roles"]["audit"]["aliases"].append("unknown")
+        with TemporaryDirectory() as tmp:
+            authority_path = Path(tmp) / "ambiguous-unknown.json"
+            authority_path.write_text(json.dumps(data), encoding="utf-8")
+            with self.assertRaises(error_type) as caught:
+                load(authority_path)
+            message = str(caught.exception).lower()
+            self.assertIn(str(authority_path).lower(), message)
+            self.assertIn("unknown", message)
+            self.assertTrue("alias" in message or "ambiguous" in message)
 
-@pytest.mark.parametrize(
-    ("role", "expected_base", "expected_tool_loop"),
-    [
-        pytest.param(role, values[0], values[1], id=role)
-        for role, values in EXPECTED_BUILTIN_ROLES.items()
-    ],
-)
-def test_every_builtin_role_uses_external_capability_and_tool_classification(
-    role: str,
-    expected_base: int,
-    expected_tool_loop: bool,
-) -> None:
-    # Arrange: use signal-free instructions so only role authority contributes.
-    task = router.TaskSignals(instruction="inspect the requested target", role=role)
+    def test_callers_cannot_mutate_cached_authority_or_future_routing(self) -> None:
+        load = _required_api("load_role_taxonomy")
+        first = load()
+        first["roles"]["audit"]["base_capability"] = 1
+        task = router.TaskSignals(instruction="inspect the requested target", role="audit")
+        second = load()
+        capability = router.classify_capability_needed(task)
+        self.assertEqual(second["roles"]["audit"]["base_capability"], 85)
+        self.assertEqual(capability, 85)
 
-    # Act: classify through the normal public router functions.
-    capability = router.classify_capability_needed(task)
-    needs_tools = router.task_needs_tool_calling(task)
-
-    # Assert: every legacy built-in retains its intended behavior after moving
-    # the table out of Python.
-    assert capability == expected_base
-    assert needs_tools is expected_tool_loop
-
-
-@pytest.mark.parametrize(
-    ("display_role", "canonical_role"),
-    [pytest.param(alias, canonical, id=alias) for alias, canonical in EXPECTED_ALIASES.items()],
-)
-def test_display_role_aliases_normalize_before_classification(
-    display_role: str,
-    canonical_role: str,
-) -> None:
-    # Arrange: vary case, surrounding whitespace, and underscore separators.
-    normalize = _required_api("normalize_routing_role")
-    display = f"  {display_role.upper()}  "
-    expected_base, expected_tools = EXPECTED_BUILTIN_ROLES[canonical_role]
-    task = router.TaskSignals(instruction="inspect the requested target", role=display)
-
-    # Act: normalize and classify using the unmodified display role.
-    normalized = normalize(display)
-    capability = router.classify_capability_needed(task)
-    needs_tools = router.task_needs_tool_calling(task)
-
-    # Assert: aliases cannot silently fall through to the old generic score.
-    assert normalized == canonical_role
-    assert capability == expected_base
-    assert needs_tools is expected_tools
-
-
-def test_unknown_roles_fail_safe_to_external_unknown_role() -> None:
-    # Arrange: choose a display role absent from the packaged aliases.
-    normalize = _required_api("normalize_routing_role")
-    task = router.TaskSignals(instruction="inspect the requested target", role="future-specialist")
-
-    # Act: normalize and classify it.
-    canonical = normalize(task.role)
-    capability = router.classify_capability_needed(task)
-    needs_tools = router.task_needs_tool_calling(task)
-
-    # Assert: unknown work has an explicit, conservative authority entry rather
-    # than an accidental dict.get fallback.
-    assert canonical == "unknown"
-    assert capability == 60
-    assert needs_tools is True
-
-
-@pytest.mark.parametrize(
-    ("role", "expected_tokens"),
-    [
-        pytest.param(role, tokens, id=role)
-        for role, tokens in EXPECTED_LEGACY_OUTPUT_BUDGETS.items()
-    ],
-)
-def test_externalization_preserves_existing_output_token_budgets(
-    role: str,
-    expected_tokens: int,
-) -> None:
-    # Arrange: externalization must not silently alter the cost classifier's
-    # pre-existing output reservations.
-    task = router.TaskSignals(instruction="inspect the requested target", role=role)
-
-    # Act: estimate through the public router seam.
-    tokens = router.estimate_tokens_out(task)
-
-    # Assert: this task moves authority without introducing unrelated cost
-    # behavior changes.
-    assert tokens == expected_tokens
-
-
-@pytest.mark.parametrize(
-    ("filename", "contents", "message_fragment"),
-    [
-        ("missing.json", None, "missing"),
-        ("invalid-json.json", "{not-json", "not valid json"),
-        (
-            "invalid-schema.json",
-            json.dumps({"schema_version": 1, "taxonomy_version": "test", "roles": {}}),
-            "unknown_role",
-        ),
-    ],
-)
-def test_loader_fails_explicitly_for_missing_or_malformed_authority(
-    tmp_path: Path,
-    filename: str,
-    contents: Optional[str],
-    message_fragment: str,
-) -> None:
-    # Arrange: create an isolated missing, syntactically invalid, or
-    # semantically incomplete authority path.
-    load = _required_api("load_role_taxonomy")
-    error_type = _required_api("RoleTaxonomyError")
-    authority_path = tmp_path / filename
-    if contents is not None:
-        authority_path.write_text(contents, encoding="utf-8")
-
-    # Act: load through the explicit path seam.
-    with pytest.raises(error_type) as caught:
-        load(authority_path)
-
-    # Assert: failure is deterministic and actionable; no implicit table or
-    # generic-role fallback is permitted for broken authority.
-    message = str(caught.value).lower()
-    assert str(authority_path).lower() in message
-    assert message_fragment in message
+    def test_routing_provenance_records_original_role_canonical_role_and_version(self) -> None:
+        taxonomy = _authority_json()
+        model = ModelSpec(
+            id="test/frontier",
+            adapter="test",
+            adapter_model_name="frontier",
+            capability_score=100,
+            tags=["tools"],
+        )
+        task = router.TaskSignals(instruction="inspect the requested target", role="routing_quality")
+        decision = router.route_task(task, [model], policy="balanced")
+        payload = decision.to_artifact_payload()
+        self.assertEqual(payload["role"], "routing_quality")
+        self.assertEqual(payload["canonical_role"], "audit")
+        self.assertEqual(payload["taxonomy_version"], taxonomy["taxonomy_version"])
 
 
-def test_loader_rejects_alias_collision_with_reserved_unknown_role(tmp_path: Path) -> None:
-    # Arrange: make the reserved unknown canonical name also resolve to audit.
-    load = _required_api("load_role_taxonomy")
-    error_type = _required_api("RoleTaxonomyError")
-    data = _authority_json()
-    data["roles"]["audit"]["aliases"].append("unknown")
-    authority_path = tmp_path / "ambiguous-unknown.json"
-    authority_path.write_text(json.dumps(data), encoding="utf-8")
 
-    # Act / Assert: schema validation must reject a taxonomy whose fallback
-    # identity has two incompatible meanings.
-    with pytest.raises(error_type) as caught:
-        load(authority_path)
-    message = str(caught.value).lower()
-    assert str(authority_path).lower() in message
-    assert "unknown" in message
-    assert "alias" in message or "ambiguous" in message
-
-
-def test_callers_cannot_mutate_cached_authority_or_future_routing() -> None:
-    # Arrange: receive one loaded authority value and mutate the caller-owned
-    # object as an accidental or hostile consumer could.
-    load = _required_api("load_role_taxonomy")
-    first = load()
-    first["roles"]["audit"]["base_capability"] = 1
-    task = router.TaskSignals(instruction="inspect the requested target", role="audit")
-
-    # Act: load and classify again.
-    second = load()
-    capability = router.classify_capability_needed(task)
-
-    # Assert: a public read cannot corrupt the cached authority and make later
-    # routing non-deterministic inside the same process.
-    assert second["roles"]["audit"]["base_capability"] == 85
-    assert capability == 85
-
-
-def test_routing_provenance_records_original_role_canonical_role_and_version() -> None:
-    # Arrange: route a custom audit alias through a single unquestionably
-    # eligible tool-capable model.
-    taxonomy = _authority_json()
-    model = ModelSpec(
-        id="test/frontier",
-        adapter="test",
-        adapter_model_name="frontier",
-        capability_score=100,
-        tags=["tools"],
-    )
-    task = router.TaskSignals(instruction="inspect the requested target", role="routing_quality")
-
-    # Act: materialize the persisted ROUTING payload.
-    decision = router.route_task(task, [model], policy="balanced")
-    payload = decision.to_artifact_payload()
-
-    # Assert: a later audit can reproduce which taxonomy interpretation was
-    # used without erasing the user-facing display role.
-    assert payload["role"] == "routing_quality"
-    assert payload["canonical_role"] == "audit"
-    assert payload["taxonomy_version"] == taxonomy["taxonomy_version"]
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Promote `dev` to `main` after merging #67: rewrite five #64 routing tests to unittest so CI `python -m unittest discover` no longer errors on missing pytest.

## Test plan
- [x] Local unittest on the five modules
- [ ] CI on main after merge