### PR TITLE
Add configurable default reviewer platform

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,9 @@ For any request that involves more than a single trivial change, start a Puppetm
 
 Default routing:
 
-1. `puppetmaster_start_cursor_swarm` — multi-role read-only analysis (the daily-driver entry point).
+1. `puppetmaster_start_swarm` — multi-role read-only analysis. Use `puppetmaster_start_review` for one focused review on the explicit or configured reviewer platform; Cursor-specific verbs are opt-in.
 2. `puppetmaster_start_implement` — durable, patch-producing implementation that runs on whatever platform the lock enables (cursor preferred, then claude-code). Use this as the default implement verb so it works regardless of platform lock. `puppetmaster_start_cursor_implement` / `puppetmaster_start_claude_implement` force a specific platform.
-3. `puppetmaster_start_cursor_review` / `puppetmaster_start_cursor_plan` — lightweight single-pass review or plan.
+3. `puppetmaster_start_review` / `puppetmaster_start_cursor_plan` — lightweight single-pass review or plan. Generic review uses an explicit platform or the user's configured default reviewer and fails closed when neither is set; `puppetmaster_start_cursor_review` remains the explicit Cursor-only path.
 
 Every implement verb runs full-edit in a clean worktree (clean-tree guard; set `allow_dirty` to override) and captures the resulting diff as a `PATCH` artifact.
 
@@ -142,7 +142,7 @@ Puppetmaster keeps a **read-only, local, numbers-only** ledger of what it saved,
 
 ## MCP surface (quick reference)
 
-Orchestration: `puppetmaster_doctor`, `puppetmaster_start_swarm`, `puppetmaster_start_cursor_swarm`, `puppetmaster_start_cursor_review`, `puppetmaster_start_cursor_plan`, `puppetmaster_start_claude_implement`, `puppetmaster_start_browser_swarm`, `puppetmaster_status`, `puppetmaster_logs`, `puppetmaster_live_artifacts`, `puppetmaster_live_artifacts_follow`, `puppetmaster_partial_summary`, `puppetmaster_artifacts`, `puppetmaster_show`, `puppetmaster_job_cost`, `puppetmaster_job_receipt`, `puppetmaster_last_job`, `puppetmaster_dashboard`.
+Orchestration: `puppetmaster_doctor`, `puppetmaster_review`, `puppetmaster_start_review`, `puppetmaster_start_swarm`, `puppetmaster_start_cursor_swarm`, `puppetmaster_start_cursor_review`, `puppetmaster_start_cursor_plan`, `puppetmaster_start_claude_implement`, `puppetmaster_start_browser_swarm`, `puppetmaster_status`, `puppetmaster_logs`, `puppetmaster_live_artifacts`, `puppetmaster_live_artifacts_follow`, `puppetmaster_partial_summary`, `puppetmaster_artifacts`, `puppetmaster_show`, `puppetmaster_job_cost`, `puppetmaster_job_receipt`, `puppetmaster_last_job`, `puppetmaster_dashboard`.
 
 Bundled CodeGraph: `puppetmaster_codegraph_search`, `puppetmaster_codegraph_context`, `puppetmaster_codegraph_affected`, `puppetmaster_codegraph_files`, `puppetmaster_codegraph_status`, `puppetmaster_codegraph_init`.
 
@@ -154,6 +154,8 @@ If any `puppetmaster_*` MCP tool returns `Tool execution error. Not connected`, 
 | --- | --- |
 | `puppetmaster_doctor` | `python -m puppetmaster doctor` |
 | `puppetmaster_start_cursor_swarm` | `python -m puppetmaster swarm "<goal>"` |
+| `puppetmaster_review` | `python -m puppetmaster review "<goal>" --wait` |
+| `puppetmaster_start_review` | `python -m puppetmaster review "<goal>"` |
 | `puppetmaster_start_swarm` | `python -m puppetmaster swarm "<goal>" --adapter <name>` |
 | `puppetmaster_status` | `python -m puppetmaster status <job_id>` |
 | `puppetmaster_logs` | `python -m puppetmaster logs <job_id>` |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Use Puppetmaster to run doctor in this repo and summarize what is missing.
 For a supervised change:
 
 ```text
-Use Puppetmaster to start a cursor swarm for this repo and return the job id immediately.
+Use Puppetmaster to start a review for this repo on my configured reviewer platform and return the job id immediately.
 Problem: users get logged out after refresh and token-refresh tests are flaky.
 Constraints: keep the patch focused, preserve public API behavior, run relevant tests.
 Do review/plan first. Poll status/logs by job id. Do not edit until you summarize findings and ask for approval.
@@ -65,6 +65,8 @@ From the shell:
 puppetmaster doctor
 puppetmaster route "Security audit every endpoint" --role audit
 puppetmaster cursor "Review this repo for release blockers" --review --dry-run
+puppetmaster platform reviewer codex
+puppetmaster review "Review this repo for release blockers"
 puppetmaster claude "Implement the approved change and run focused tests" --permission-mode acceptEdits
 puppetmaster show "$(puppetmaster last)"
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,33 @@
+## Unreleased
+
+**Feature: User-configurable default reviewer platform with fail-closed dispatch.**
+
+Generic review dispatch now resolves in strict precedence order: explicit
+adapter/platform selection, then the user's configured default reviewer,
+then fail closed with an actionable error listing enabled valid reviewer
+platforms and how to configure one. There is no built-in reviewer platform
+default. If the configured reviewer is disabled or unavailable, dispatch
+fails clearly and does not silently fall back. Explicit platform-specific
+review commands such as `puppetmaster_cursor_review` remain platform-specific
+and fail rather than reinterpreting the command. Reviewer-platform selection
+is kept separate from model auto-routing.
+
+- **CLI**: `puppetmaster platform reviewer [<platform>]` shows or sets the
+  default reviewer; `--clear` unsets it. `puppetmaster review "<goal>"` uses
+  that choice (or an explicit `--adapter`/`--platform`) and detaches by default.
+  `puppetmaster platform status` shows the current default reviewer alongside
+  enabled/disabled adapters.
+- **MCP**: New generic `puppetmaster_review` and `puppetmaster_start_review`
+  tools use the configured default or explicit adapter. Platform-specific
+  tools such as `puppetmaster_cursor_review` remain unchanged.
+- **Configuration**: `~/.puppetmaster/platform.json` gains `default_reviewer`
+  field. Persisted alongside the platform lock's `disabled` list.
+- **Fail-closed behavior**: Generic review dispatch with no configured default
+  and no explicit adapter fails with an actionable error message, never silently
+  falls back.
+- **Tests**: Comprehensive regression tests cover precedence, configured-default
+  use, unset fail-closed behavior, and disabled/unavailable configured defaults.
+
 ## v1.22.19
 
 Absorb of [@bsmi021](https://github.com/bsmi021) PR

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -49,6 +49,8 @@ python -m puppetmaster swarm "Audit the MCP surface"
 python -m puppetmaster swarm "Goal" --roles explore audit review --label "MCP peel"
 python -m puppetmaster swarm "Goal" --wait          # block until complete
 python -m puppetmaster swarm "Goal" --adapter agentic
+python -m puppetmaster review "Goal"                # configured default reviewer
+python -m puppetmaster review "Goal" --adapter codex # explicit one-off reviewer
 
 python -m puppetmaster run "Goal" --config examples/enterprise-workflow.json
 python -m puppetmaster daemon --roles explore architect implement redteam test
@@ -179,11 +181,23 @@ python -m puppetmaster platform only cursor                   # lock to Cursor o
 python -m puppetmaster platform enable claude-code codex      # turn platforms back on
 python -m puppetmaster platform disable openai                # turn a platform off
 python -m puppetmaster platform reset                         # clear the lock (all platforms on)
+python -m puppetmaster platform reviewer                     # show generic review default
+python -m puppetmaster platform reviewer cursor              # set generic review default
+python -m puppetmaster platform reviewer --clear              # unset; generic review fails closed
 # ephemeral / CI override (wins over saved config):
 PUPPETMASTER_ONLY_ADAPTERS=cursor python -m puppetmaster route "audit" --role audit
 ```
 
 A disabled platform is never routed to, auto-discovered, or used for fallback. Default is everything-on. Lock state persists in `~/.puppetmaster/platform.json`.
+
+Generic MCP review selection is separate from model auto-routing: explicit
+`adapter`/`platform` wins, then the persisted `default_reviewer`, otherwise
+dispatch fails closed with the enabled valid reviewer platforms and the command
+to configure one. A configured reviewer that is disabled or unavailable is an
+error; it is never silently replaced. Platform-specific commands such as
+`cursor --review` and `puppetmaster_cursor_review` remain Cursor-only.
+The CLI equivalent is `python -m puppetmaster review "<goal>"`; it detaches by
+default and accepts `--wait` for synchronous use.
 
 The lock is enforced at three layers (v1.12.0+): the router excludes disabled platforms; the platform-specific MCP verbs (`start_cursor_swarm`, `start_claude_implement`, ...) fail fast with remediation before spawning anything; and the orchestrator's task-creation gate raises `PlatformLockedError` for any spec that still carries a disabled adapter — so a hardcoded verb can never run work on a platform you turned off. Related honesty guarantee: a worker dispatched without a routed model records a FAILED task (`no_model`), and a job whose every task failed finishes FAILED with a `job.all_tasks_failed` event instead of stitching into a green COMPLETE.
 

--- a/docs/DAILY_DRIVER.md
+++ b/docs/DAILY_DRIVER.md
@@ -24,7 +24,8 @@ conversational questions yourself without a job.
 
 ```bash
 python -m puppetmaster doctor
-python -m puppetmaster cursor "Review the current repo and propose the next patch" --review --dry-run
+python -m puppetmaster platform reviewer codex
+python -m puppetmaster review "Review the current repo and propose the next patch" --wait
 python -m puppetmaster cursor "Plan the next implementation slice" --plan --dry-run
 python -m puppetmaster claude "Implement the approved change and run focused tests" --permission-mode acceptEdits
 python -m puppetmaster logs

--- a/docs/GROK_BOT.md
+++ b/docs/GROK_BOT.md
@@ -141,7 +141,7 @@ Default **`supervise`** — read-only / supervise-first:
 | Allowed | Examples |
 |---|---|
 | Health / routing | `puppetmaster_doctor`, `puppetmaster_route_task`, `puppetmaster_list_models` |
-| Start analysis | `puppetmaster_start_cursor_review`, `puppetmaster_start_cursor_plan`, `puppetmaster_start_cursor_swarm`, `puppetmaster_start_swarm` |
+| Start analysis | `puppetmaster_start_review`, `puppetmaster_start_cursor_review`, `puppetmaster_start_cursor_plan`, `puppetmaster_start_cursor_swarm`, `puppetmaster_start_swarm` |
 | Observe | `puppetmaster_status`, `puppetmaster_logs`, `puppetmaster_live_artifacts`, `puppetmaster_live_artifacts_follow`, `puppetmaster_partial_summary`, `puppetmaster_artifacts`, `puppetmaster_show`, `puppetmaster_await_job`, `puppetmaster_job_graph`, … |
 | CodeGraph reads | `puppetmaster_codegraph_search`, `_context`, `_affected`, `_files`, `_status` |
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -70,7 +70,7 @@ When you run `mcp serve-remote` you deliberately open a network endpoint that ca
 
 ## Hardening recommendations
 
-1. **Untrusted or high-stakes repo?** Use read-only modes (`cursor --review/--plan`, `codex payload.sandbox="read-only"`) until you've read the plan, then approve edits explicitly.
+1. **Untrusted or high-stakes repo?** Use the generic read-only `review` command (or explicit platform modes such as `cursor --review/--plan` and `codex payload.sandbox="read-only"`) until you've read the findings, then approve edits explicitly.
 2. **Run implement work in a dedicated git worktree** so diffs are isolated and a bad run is `git worktree remove` away.
 3. **Scope your provider tokens** to least privilege; prefer the platform's own login over inlining keys in MCP config.
 4. **Only use `--dangerously-bypass...` inside a container/VM** you already trust to be sandboxed.

--- a/puppetmaster/cli/_dispatch.py
+++ b/puppetmaster/cli/_dispatch.py
@@ -1227,7 +1227,7 @@ def _main(argv: Optional[list[str]] = None) -> int:
         )
         return cli.finalize_cli_run(result)
 
-    if args.command == "swarm":
+    if args.command in ("swarm", "review"):
         from dataclasses import replace
 
         from puppetmaster import platform_lock
@@ -1237,16 +1237,51 @@ def _main(argv: Optional[list[str]] = None) -> int:
             detach_analysis_swarm,
         )
 
-        adapter = str(getattr(args, "adapter", None) or "cursor")
+        if args.command == "review":
+            from puppetmaster.workers import NoReviewAdapterError, pick_review_adapter
+
+            explicit_adapter = getattr(args, "adapter", None)
+            explicit_platform = getattr(args, "platform", None)
+            if (
+                explicit_adapter
+                and explicit_platform
+                and explicit_adapter != explicit_platform
+            ):
+                print(
+                    "review: pass only one of --adapter or --platform.",
+                    file=sys.stderr,
+                )
+                return 2
+            try:
+                adapter = pick_review_adapter(
+                    platform_lock.enabled_adapters(),
+                    explicit_adapter or explicit_platform,
+                    platform_lock.get_default_reviewer(),
+                )
+            except NoReviewAdapterError as exc:
+                print(f"review: {exc}", file=sys.stderr)
+                print(
+                    "  configure: puppetmaster platform reviewer <platform>",
+                    file=sys.stderr,
+                )
+                return 2
+            roles = ["review"]
+        else:
+            adapter = str(getattr(args, "adapter", None) or "cursor")
+            roles = (
+                list(args.roles)
+                if getattr(args, "roles", None)
+                else list(DEFAULT_SWARM_ROLES)
+            )
+
         if adapter != "local" and not platform_lock.is_adapter_enabled(adapter):
             print(
-                f"swarm: adapter {adapter!r} is disabled by the platform lock.",
+                f"{args.command}: adapter {adapter!r} is disabled by the platform lock.",
                 file=sys.stderr,
             )
             print(f"  enable it: puppetmaster platform enable {adapter}", file=sys.stderr)
             return 2
 
-        roles = list(args.roles) if getattr(args, "roles", None) else list(DEFAULT_SWARM_ROLES)
         disable_memory = not bool(getattr(args, "enable_memory", False))
         auto_route = None
         if getattr(args, "no_auto_route", False):
@@ -1301,7 +1336,7 @@ def _main(argv: Optional[list[str]] = None) -> int:
                 launch_key=getattr(args, "launch_key", None),
             )
         except Exception as exc:
-            print(f"swarm: failed to start: {exc}", file=sys.stderr)
+            print(f"{args.command}: failed to start: {exc}", file=sys.stderr)
             return 1
         if getattr(args, "json", False):
             print(json.dumps(body, indent=2))

--- a/puppetmaster/cli/_parser.py
+++ b/puppetmaster/cli/_parser.py
@@ -1815,6 +1815,72 @@ def build_parser() -> argparse.ArgumentParser:
     swarm.add_argument("--json", action="store_true", help="Emit the start receipt as JSON.")
     _add_label_argument(swarm)
 
+    review = subcommands.add_parser(
+        "review",
+        help=(
+            "Run one read-only review assignment. Uses --adapter/--platform when "
+            "provided, otherwise the configured default reviewer; fails closed "
+            "when neither is set. Detaches by default and prints job_id."
+        ),
+    )
+    review.add_argument("goal", help="Review goal / audit prompt.")
+    review.add_argument(
+        "--cwd",
+        default=str(Path.cwd()),
+        help="Workspace for worker cwd + CodeGraph context.",
+    )
+    review.add_argument(
+        "--adapter",
+        choices=list(_platform_lock.KNOWN_ADAPTERS),
+        help="Explicit reviewer platform; overrides the configured default.",
+    )
+    review.add_argument(
+        "--platform",
+        choices=list(_platform_lock.KNOWN_ADAPTERS),
+        help="Alias for --adapter; pass only one.",
+    )
+    review.add_argument(
+        "--launch-key", help="Optional idempotency key for detached launch recovery."
+    )
+    review.add_argument(
+        "--model", help="Optional model pin (disables auto-route unless --auto-route)."
+    )
+    review.add_argument("--timeout-seconds", type=_positive_seconds, default=900)
+    review.add_argument("--max-timeout-seconds", type=_positive_seconds, default=None)
+    review.add_argument(
+        "--worker-mode",
+        choices=["subprocess", "inline", "daemon"],
+        default="subprocess",
+    )
+    review.add_argument("--auto-route", action="store_true", default=None)
+    review.add_argument(
+        "--no-auto-route",
+        action="store_true",
+        help="Disable auto-route (use adapter default / pinned model).",
+    )
+    review.add_argument(
+        "--routing-policy",
+        choices=["balanced", "cheap", "absolute-cheapest", "quality", "escalating"],
+    )
+    review.add_argument(
+        "--wait",
+        action="store_true",
+        help="Block until review finishes (default: detach and print job_id).",
+    )
+    review.add_argument(
+        "--disable-memory",
+        action="store_true",
+        default=True,
+        help="Skip promoted memory injection (default: on).",
+    )
+    review.add_argument(
+        "--enable-memory",
+        action="store_true",
+        help="Force promoted memory injection.",
+    )
+    review.add_argument("--json", action="store_true", help="Emit the start receipt as JSON.")
+    _add_label_argument(review)
+
     browser = subcommands.add_parser(
         "browser",
         help=(
@@ -2602,6 +2668,28 @@ def build_parser() -> argparse.ArgumentParser:
         "reset", help="Clear the lock; enable every platform again."
     )
     platform_reset.add_argument("--registry-path", help="Override the registry path.")
+    platform_reviewer = platform_sub.add_parser(
+        "reviewer",
+        aliases=["default-reviewer", "set-reviewer", "set-default-reviewer"],
+        help=(
+            "Show or set the default platform for generic reviews. There is no "
+            "built-in reviewer platform; unset fails closed."
+        ),
+    )
+    platform_reviewer.add_argument(
+        "reviewer_adapter",
+        nargs="?",
+        choices=list(_platform_lock.KNOWN_ADAPTERS),
+        help="Reviewer platform to persist. Omit to show the current setting.",
+    )
+    platform_reviewer.add_argument(
+        "--clear",
+        dest="clear_reviewer",
+        action="store_true",
+        help="Unset the default reviewer so generic review fails closed.",
+    )
+    platform_reviewer.add_argument("--registry-path", help="Override the registry path.")
+    platform_reviewer.add_argument("--json", action="store_true", help="Emit JSON.")
 
     skills_cmd = subcommands.add_parser(
         "skills",

--- a/puppetmaster/cli/commands_platform.py
+++ b/puppetmaster/cli/commands_platform.py
@@ -135,7 +135,47 @@ def _run_platform_subcommand(args) -> int:
         unknown = sorted(a for a in wanted if a not in pl.KNOWN_ADAPTERS)
         return {a for a in wanted if a in pl.KNOWN_ADAPTERS}, unknown
 
-    if sub in ("only", "enable", "disable"):
+    reviewer_commands = {
+        "reviewer",
+        "default-reviewer",
+        "set-reviewer",
+        "set-default-reviewer",
+    }
+    if sub in reviewer_commands:
+        from puppetmaster.workers import REVIEW_ADAPTERS
+
+        reviewer = getattr(args, "reviewer_adapter", None)
+        clear_reviewer = getattr(args, "clear_reviewer", False)
+        if clear_reviewer and reviewer:
+            print(
+                "error: pass a reviewer platform or --clear, not both.",
+                file=sys.stderr,
+            )
+            return 1
+        if clear_reviewer:
+            pl.set_default_reviewer(None, path)
+        elif reviewer:
+            reviewer = pl.canonicalize_adapter(reviewer)
+            if reviewer not in REVIEW_ADAPTERS:
+                print(
+                    f"error: {reviewer!r} is not a valid reviewer platform. "
+                    f"Known: {', '.join(REVIEW_ADAPTERS)}.",
+                    file=sys.stderr,
+                )
+                return 1
+            pl.set_default_reviewer(reviewer, path)
+        elif not getattr(args, "json", False):
+            current = pl.get_default_reviewer(path)
+            if current:
+                print(f"Default reviewer platform: {current}")
+            else:
+                print(
+                    "No default reviewer platform is configured. Set one with "
+                    "`puppetmaster platform reviewer <platform>`."
+                )
+            return 0
+        # Fall through to the common status rendering below.
+    elif sub in ("only", "enable", "disable"):
         valid, unknown = _normalize(args.adapters)
         if unknown:
             print(
@@ -167,6 +207,7 @@ def _run_platform_subcommand(args) -> int:
                 {
                     "enabled": sorted(enabled),
                     "disabled": sorted(set(pl.KNOWN_ADAPTERS) - enabled),
+                    "default_reviewer": pl.get_default_reviewer(path),
                     "restricted": restricted,
                     "env_override": env_override,
                     "config_path": str(pl.platform_config_path(path)),
@@ -183,6 +224,7 @@ def _run_platform_subcommand(args) -> int:
     for adapter in pl.KNOWN_ADAPTERS:
         mark = "on " if adapter in enabled else "off"
         print(f"  [{mark}] {adapter}")
+    print(f"  default reviewer: {pl.get_default_reviewer(path) or '(unset)'}")
     if env_override:
         print(
             f"note: ${pl.ONLY_ENV} is set and overrides the saved config "

--- a/puppetmaster/hook_runner.py
+++ b/puppetmaster/hook_runner.py
@@ -71,7 +71,7 @@ _ASSUME_TOOLS_ENV = "PUPPETMASTER_HOOK_ASSUME_TOOLS"
 # route to whatever platform the lock enables, so they are safe everywhere.
 _HOST_PORTABLE_VERBS = {
     "puppetmaster_start_cursor_swarm": "puppetmaster_start_swarm",
-    "puppetmaster_start_cursor_review": "puppetmaster_start_swarm",
+    "puppetmaster_start_cursor_review": "puppetmaster_start_review",
     "puppetmaster_start_cursor_plan": "puppetmaster_start_swarm",
     "puppetmaster_start_cursor_implement": "puppetmaster_start_implement",
 }

--- a/puppetmaster/invocation_gate.py
+++ b/puppetmaster/invocation_gate.py
@@ -133,8 +133,8 @@ _TRIVIAL_PATTERNS = [
 # Role inference → (canonical role for the classifier, suggested Puppetmaster
 # verb the host should reach for). Order matters: first match wins.
 _ROLE_INFERENCE = [
-    (re.compile(r"\b(security|vuln|exploit|cve)\b"), "security-review", "puppetmaster_start_cursor_review"),
-    (re.compile(r"\b(audit|review|risk|find issues|what could break)\b"), "review", "puppetmaster_start_cursor_review"),
+    (re.compile(r"\b(security|vuln|exploit|cve)\b"), "security-review", "puppetmaster_start_review"),
+    (re.compile(r"\b(audit|review|risk|find issues|what could break)\b"), "review", "puppetmaster_start_review"),
     (re.compile(r"\b(architect|design|approach|trade[-\s]?off|plan|scope)\b"), "plan", "puppetmaster_start_cursor_plan"),
     # Implementation intent → a SINGLE implement worker, never a fan-out swarm.
     # Broadened beyond the old narrow verb list because plain feature work
@@ -174,6 +174,11 @@ _IMPLEMENT_VERBS = frozenset(
 # intent (no broad-scope signal) here instead of the heavier implement job.
 _EDIT_VERB = "puppetmaster_edit"
 _EDIT_VERBS = frozenset({_EDIT_VERB})
+
+# Generic review is intentionally one read-only assignment on the user's
+# selected reviewer platform. It is not a cursor-specific command and it is not
+# inherently a fan-out swarm.
+_REVIEW_VERBS = frozenset({"puppetmaster_review", "puppetmaster_start_review"})
 
 # Verbs that resolve a "where/what/how is X" question structurally instead of
 # crawling the tree. Framed as look-up, not fan-out.
@@ -259,6 +264,16 @@ class DelegationDecision:
                 f"the code instead of grepping, then read only what it points to. "
                 f"If the MCP tool isn't reachable, run `python -m puppetmaster "
                 f"codegraph search '<query>'`. {tail}"
+            )
+        if verb in _REVIEW_VERBS:
+            return (
+                f"[Puppetmaster] This warrants a read-only review pass (capability "
+                f"{self.capability_score}, {self.reason}). Call `{verb}` to run one "
+                f"review assignment on the explicitly selected or configured default "
+                f"reviewer platform. Puppetmaster has no built-in reviewer default; "
+                f"configure one with `puppetmaster platform reviewer <platform>`. "
+                f"For implementation, follow up with `puppetmaster_start_implement`. "
+                f"{tail}"
             )
         return (
             f"[Puppetmaster] This warrants a read-only analysis pass (capability "

--- a/puppetmaster/mcp_remote.py
+++ b/puppetmaster/mcp_remote.py
@@ -132,6 +132,8 @@ SUPERVISE_TOOL_NAMES = frozenset(
         "puppetmaster_job_receipt",
         "puppetmaster_cursor_review",
         "puppetmaster_start_cursor_review",
+        "puppetmaster_review",
+        "puppetmaster_start_review",
         "puppetmaster_cursor_plan",
         "puppetmaster_start_cursor_plan",
         "puppetmaster_start_swarm",

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -1229,6 +1229,8 @@ _TRACKABLE_SWARM_BLOCKED_TOOLS = frozenset(
         "puppetmaster_start_codex",
         "puppetmaster_start_agentic",
         "puppetmaster_start_browser_swarm",
+        "puppetmaster_review",
+        "puppetmaster_start_review",
         "puppetmaster_start_openai",
         "puppetmaster_start_prewalk",
         # Sync wait verbs also write jobs outside Marionette swarm_pending.
@@ -1384,6 +1386,32 @@ def _build_tools() -> list[McpTool]:
                 "Review this repo and identify risks, findings, and verification gaps."
             ),
             handler=lambda args: start_cursor(args, review=True),
+        ),
+        McpTool(
+            name="puppetmaster_review",
+            description=(
+                "Platform-agnostic review: run one read-only review worker on the explicitly "
+                "selected platform or the user's configured default reviewer. Generic review "
+                "dispatch resolves: explicit adapter selection, then configured default "
+                "reviewer, then fails closed with actionable guidance. Returns structured "
+                "FINDING artifacts. WAIT for completion (synchronous). Use start_review for "
+                "async. Requires a configured default reviewer or explicit adapter selection."
+            ),
+            input_schema=review_schema(),
+            handler=run_review,
+        ),
+        McpTool(
+            name="puppetmaster_start_review",
+            description=(
+                "Platform-agnostic review: start one read-only review worker asynchronously on "
+                "the explicitly selected platform or the user's configured default reviewer. "
+                "Generic review dispatch resolves: explicit adapter selection, then configured "
+                "default reviewer, then fails closed with actionable guidance. Returns job_id "
+                "immediately. Requires a configured default reviewer or explicit adapter selection. "
+                "Configure with: puppetmaster platform reviewer <platform>."
+            ),
+            input_schema=review_schema(),
+            handler=start_review,
         ),
         McpTool(
             name="puppetmaster_cursor_plan",
@@ -2385,6 +2413,99 @@ def start_implement(args: JsonObject) -> JsonObject:
     if isinstance(result, dict):
         result.setdefault("implement_adapter", adapter)
     return result
+
+
+def _review_command(args: JsonObject, adapter: str) -> list[str]:
+    """Build one read-only review assignment through the analysis runtime.
+
+    Platform CLIs do not share Cursor's ``--review``/``--dry-run`` flags. The
+    analysis-swarm builder already knows how to express read-only work for every
+    supported adapter, so generic review uses that common contract with exactly
+    one structured ``review`` role.
+    """
+    goal = require_string(args, "goal")
+    roles: list[object] = [{"role": "review", "instruction": goal}]
+    config_path = write_generated_swarm_config(args, roles, adapter)
+    command = ["run", goal, "--config", str(config_path)]
+    worker_mode = args.get("worker_mode")
+    if worker_mode:
+        command.extend(["--worker-mode", str(worker_mode)])
+    _append_swarm_timeout_flags(command, args)
+    _append_swarm_memory_flags(command, args)
+    _append_label_flag(command, args)
+    return command
+
+
+def _resolve_review_adapter(args: JsonObject) -> tuple[Optional[str], Optional[JsonObject]]:
+    """Resolve explicit/configured review policy once for sync and async verbs."""
+    from puppetmaster import platform_lock
+    from puppetmaster.workers import NoReviewAdapterError, REVIEW_ADAPTERS, pick_review_adapter
+
+    explicit_adapter = args.get("adapter")
+    explicit_platform = args.get("platform")
+    if (
+        explicit_adapter
+        and explicit_platform
+        and str(explicit_adapter) != str(explicit_platform)
+    ):
+        return None, tool_error(
+            "pass only one of adapter or platform for generic review dispatch."
+        )
+
+    enabled = platform_lock.enabled_adapters()
+    configured_default = platform_lock.get_default_reviewer()
+    requested = explicit_adapter or explicit_platform
+    try:
+        adapter = pick_review_adapter(enabled, requested, configured_default)
+    except NoReviewAdapterError as exc:
+        valid_enabled = [name for name in REVIEW_ADAPTERS if name in exc.enabled]
+        details: JsonObject = {
+            "enabled_review_platforms": valid_enabled,
+            "configure": "puppetmaster platform reviewer <platform>",
+        }
+        if exc.requested is not None:
+            details["requested"] = exc.requested
+        if exc.configured_default is not None:
+            details["configured_default"] = exc.configured_default
+        return None, tool_error(str(exc), details)
+    return adapter, None
+
+
+def start_review(args: JsonObject) -> JsonObject:
+    """Platform-agnostic review: resolve the reviewer adapter from explicit request,
+    configured default, or fail closed with actionable guidance. Generic review
+    dispatch works no matter which platform is enabled and configured."""
+    adapter, blocked = _resolve_review_adapter(args)
+    if blocked is not None:
+        return blocked
+    assert adapter is not None
+    try:
+        command = _review_command(args, adapter)
+    except Exception as exc:
+        ambiguous = _ambiguous_model_pin_tool_error(exc, args.get("model"))
+        if ambiguous is not None:
+            return ambiguous
+        raise
+    result = start_cli(command, args)
+    if isinstance(result, dict):
+        result.setdefault("review_adapter", adapter)
+    return result
+
+
+def run_review(args: JsonObject) -> JsonObject:
+    """Synchronous platform-agnostic review: resolve the adapter and wait for completion."""
+    adapter, blocked = _resolve_review_adapter(args)
+    if blocked is not None:
+        return blocked
+    assert adapter is not None
+    try:
+        command = _review_command(args, adapter)
+    except Exception as exc:
+        ambiguous = _ambiguous_model_pin_tool_error(exc, args.get("model"))
+        if ambiguous is not None:
+            return ambiguous
+        raise
+    return run_worker_cli(command, args)
 
 
 def edit_command(args: JsonObject) -> list[str]:
@@ -4583,6 +4704,35 @@ def swarm_schema() -> JsonObject:
                 ),
             },
         }
+    )
+    return schema
+
+
+def review_schema() -> JsonObject:
+    """Schema for generic review dispatch.
+
+    Keep this separate from platform-specific review schemas so the absence of
+    ``adapter`` is visible to MCP clients as an intentional fail-closed choice,
+    not a hidden Cursor default.
+    """
+    schema = swarm_schema()
+    for name in ("roles", "config", "allow_local_demo"):
+        schema["properties"].pop(name, None)
+    schema["properties"]["adapter"] = {
+        "type": "string",
+        "enum": [name for name in SWARM_ANALYSIS_ADAPTERS if name != "local"],
+        "description": (
+            "Explicit reviewer platform. Overrides the persisted default reviewer."
+        ),
+    }
+    schema["properties"]["platform"] = {
+        "type": "string",
+        "enum": [name for name in SWARM_ANALYSIS_ADAPTERS if name != "local"],
+        "description": "Alias for adapter; pass only one of adapter or platform.",
+    }
+    schema["description"] = (
+        "Generic review: explicit adapter/platform, then configured default "
+        "reviewer; no built-in default."
     )
     return schema
 

--- a/puppetmaster/platform_lock.py
+++ b/puppetmaster/platform_lock.py
@@ -50,6 +50,7 @@ ADAPTER_ALIASES = {
 }
 
 ONLY_ENV = "PUPPETMASTER_ONLY_ADAPTERS"
+DEFAULT_REVIEWER_KEY = "default_reviewer"
 
 
 def canonicalize_adapter(name: str) -> str:
@@ -217,3 +218,59 @@ def disable(adapters: set[str], registry_path: Optional[Path] = None) -> Path:
 def reset(registry_path: Optional[Path] = None) -> Path:
     """Clear the lock — every known adapter enabled again."""
     return _write_disabled(set(), registry_path)
+
+
+def get_default_reviewer(registry_path: Optional[Path] = None) -> Optional[str]:
+    """Return the configured default reviewer adapter, if any.
+
+    Returns ``None`` when no default is configured. The returned adapter name is
+    already canonicalized (aliases like ``agy`` → ``antigravity``).
+    """
+    path = platform_config_path(registry_path)
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    reviewer = data.get(DEFAULT_REVIEWER_KEY)
+    if reviewer is None or not str(reviewer).strip():
+        return None
+    return canonicalize_adapter(str(reviewer).strip())
+
+
+def set_default_reviewer(
+    adapter: Optional[str], registry_path: Optional[Path] = None
+) -> Path:
+    """Set the default reviewer adapter (or clear it with ``None``).
+
+    The adapter is canonicalized before being persisted. Setting ``None`` clears
+    the default (generic review dispatch will fail closed until a default is set).
+    """
+    canonical: Optional[str] = None
+    if adapter is not None:
+        canonical = canonicalize_adapter(str(adapter).strip())
+        if canonical not in KNOWN_ADAPTERS:
+            raise ValueError(
+                f"unknown reviewer platform {adapter!r}. Known: "
+                f"{', '.join(KNOWN_ADAPTERS)}"
+            )
+
+    path = platform_config_path(registry_path)
+    with InterProcessFileLock.for_target(path):
+        payload: dict = {}
+        if path.is_file():
+            try:
+                existing = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(existing, dict):
+                    payload = existing
+            except (json.JSONDecodeError, OSError):
+                payload = {}
+        if canonical is None:
+            payload.pop(DEFAULT_REVIEWER_KEY, None)
+        else:
+            payload[DEFAULT_REVIEWER_KEY] = canonical
+        write_private_text(path, json.dumps(payload, indent=2) + "\n", lock=False)
+    return path

--- a/puppetmaster/skills/puppetmaster/SKILL.md
+++ b/puppetmaster/skills/puppetmaster/SKILL.md
@@ -36,7 +36,8 @@ broad investigation, multi-file audits, and cross-cutting changes.
 |---|---|---|
 | **One focused edit** ("fix this fn", "add a flag", "wire up retries") | `edit` | Cheapest sufficient model + CodeGraph + in-place edit + synchronous diff. The snappy path between editing inline and a full implement job. |
 | **One coupled multi-file feature** | `start_implement` | Isolated clean worktree, one coherent PATCH artifact. |
-| **Broad read-only analysis** (audit, review, "find all X") | `start_swarm` / `start_cursor_swarm` | Parallel roles over read-only analysis. |
+| **One focused read-only review** | `start_review` | Resolves explicit adapter/platform → configured default reviewer → actionable fail-closed error. Cursor tools remain Cursor-only. |
+| **Broad read-only analysis** (audit, "find all X") | `start_swarm` / `start_cursor_swarm` | Parallel roles over read-only analysis; use the Cursor-specific verb only when Cursor is an explicit choice. |
 | **Live-site browser QA** (drive a real browser, capture real network payloads) | `start_browser_swarm` | N parallel browser workers with React-input/network-truth/strong-model guardrails. Hermes preferred; `adapter=agentic` uses stdlib CDP / OpenRouter. ACTING AGENT (side effects). |
 | **"Where is X / what calls Y"** | `codegraph_search` | Structural lookup before reading files. |
 | **"What model / how much?"** | `route_task` | Pure decision, no spend. |
@@ -93,6 +94,13 @@ CodeGraph first, then read only the files it points to. Verbs: `codegraph_search
 - **Platform lock** (`~/.puppetmaster/platform.json`, a denylist) restricts which
   adapters the router may pick. Lock rejections mid-migration are expected, not
   failures.
+- **Generic reviewer selection is separate from model routing.** Set the user
+  choice with `puppetmaster platform reviewer <adapter>` (or inspect it with
+  `puppetmaster platform reviewer`). There is no built-in reviewer platform:
+  `start_review` fails closed when unset, and a configured
+  reviewer that is disabled or unavailable never falls back to another enabled
+  platform. Pass `adapter` or `platform` explicitly when a one-off choice is
+  intended.
 
 ## Output style (optional "Signal-maximizer")
 

--- a/puppetmaster/workers.py
+++ b/puppetmaster/workers.py
@@ -454,6 +454,20 @@ IMPLEMENT_ADAPTER_PRIORITY = (
     "agentic",
 )
 
+# Platforms that can run a read-only analysis worker. This is deliberately a
+# capability set, not a priority list: generic review never chooses the first
+# enabled platform. It requires an explicit request or the user's configured
+# default reviewer.
+REVIEW_ADAPTERS = (
+    "agentic",
+    "cursor",
+    "claude-code",
+    "codex",
+    "openai",
+    "hermes",
+    "antigravity",
+)
+
 
 class NoImplementAdapterError(RuntimeError):
     """Raised when no implement-capable adapter is available/enabled.
@@ -466,6 +480,28 @@ class NoImplementAdapterError(RuntimeError):
         super().__init__(message)
         self.enabled = enabled
         self.requested = requested
+
+
+class NoReviewAdapterError(RuntimeError):
+    """Raised when no review-capable adapter is available/enabled.
+
+    Carries the resolved ``enabled`` set, the (optional) ``requested`` adapter,
+    and the (optional) ``configured_default`` so callers can render a precise,
+    actionable error without re-deriving state.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        enabled: AbstractSet[str],
+        requested: Optional[str] = None,
+        configured_default: Optional[str] = None,
+    ):
+        super().__init__(message)
+        self.enabled = enabled
+        self.requested = requested
+        self.configured_default = configured_default
 
 
 # Actionable, per-adapter "how to make me runnable" hints, surfaced when the
@@ -589,6 +625,105 @@ def pick_implement_adapter(
         f"enabled but their CLI/credentials are missing: {', '.join(candidates)}. "
         f"Install/configure one of: {hints}.",
         enabled=enabled,
+    )
+
+
+def pick_review_adapter(
+    enabled: AbstractSet[str],
+    requested: Optional[str] = None,
+    configured_default: Optional[str] = None,
+    *,
+    is_available: Optional[Callable[[str], bool]] = None,
+) -> str:
+    """Resolve the review adapter to use, honoring the platform lock.
+
+    Resolution order:
+    1. ``requested`` (explicit adapter/platform selection) → validate it's
+       review-capable AND enabled, else raise.
+    2. ``configured_default`` (user's configured default reviewer) → validate
+       it's review-capable, enabled, AND available, else raise with clear
+       guidance (no silent fallback).
+    3. Fail closed with an actionable error listing enabled valid reviewer
+       platforms and how to configure a default.
+
+    Review-capable means any adapter in ``REVIEW_ADAPTERS``. An explicit
+    ``requested`` adapter is allowed to reach its platform-specific preflight;
+    a configured default is checked here so an unavailable default fails with
+    precise guidance instead of silently falling back.
+
+    Raising (vs. returning ``None``) keeps the single decision point honest:
+    every caller gets the same precise failure with the same context.
+    """
+    # Explicit request wins and is never second-guessed.
+    if requested:
+        adapter = str(requested)
+        if adapter not in REVIEW_ADAPTERS:
+            raise NoReviewAdapterError(
+                f"adapter {adapter!r} cannot review. Review-capable: "
+                f"{', '.join(REVIEW_ADAPTERS)}.",
+                enabled=enabled,
+                requested=adapter,
+                configured_default=configured_default,
+            )
+        if adapter not in enabled:
+            raise NoReviewAdapterError(
+                f"adapter {adapter!r} is disabled by the platform lock.",
+                enabled=enabled,
+                requested=adapter,
+                configured_default=configured_default,
+            )
+        return adapter
+
+    # Configured default is authoritative when present — fail clearly if it's
+    # disabled or unavailable instead of silently falling back.
+    if configured_default:
+        adapter = str(configured_default)
+        if adapter not in REVIEW_ADAPTERS:
+            raise NoReviewAdapterError(
+                f"configured default reviewer {adapter!r} is not review-capable. "
+                f"Review-capable: {', '.join(REVIEW_ADAPTERS)}. "
+                f"Fix: run `puppetmaster platform reviewer <platform>`.",
+                enabled=enabled,
+                configured_default=adapter,
+            )
+        if adapter not in enabled:
+            raise NoReviewAdapterError(
+                f"configured default reviewer {adapter!r} is disabled by the platform lock. "
+                f"Fix: run `puppetmaster platform enable {adapter}` or choose a different "
+                f"default reviewer with `puppetmaster platform reviewer <platform>`.",
+                enabled=enabled,
+                configured_default=adapter,
+            )
+        available = is_available or adapter_is_available
+        if not available(adapter):
+            hint = _ADAPTER_AVAILABILITY_HINT.get(adapter, adapter)
+            raise NoReviewAdapterError(
+                f"configured default reviewer {adapter!r} is enabled but not available "
+                f"on this machine (CLI/credentials missing). Install/configure: {hint}.",
+                enabled=enabled,
+                configured_default=adapter,
+            )
+        return adapter
+
+    # No explicit request and no configured default → fail closed with actionable guidance.
+    candidates = [a for a in REVIEW_ADAPTERS if a in enabled]
+    if not candidates:
+        raise NoReviewAdapterError(
+            "No review-capable platform is enabled and no default reviewer is configured. "
+            f"Enable one of {', '.join(REVIEW_ADAPTERS)} and configure it as your "
+            f"default reviewer: `puppetmaster platform enable <adapter> && "
+            f"puppetmaster platform reviewer <adapter>`.",
+            enabled=enabled,
+            configured_default=configured_default,
+        )
+
+    # Enabled platforms exist but no default is configured — fail closed.
+    raise NoReviewAdapterError(
+        f"No default reviewer configured. Enabled review-capable platforms: "
+        f"{', '.join(candidates)}. Configure one as your default: "
+        f"`puppetmaster platform reviewer <adapter>`.",
+        enabled=enabled,
+        configured_default=configured_default,
     )
 
 

--- a/tests/test_default_reviewer_platform.py
+++ b/tests/test_default_reviewer_platform.py
@@ -1,0 +1,499 @@
+"""Focused tests for user-configurable default reviewer platform.
+
+Tests cover:
+- Resolution precedence: explicit > configured default > fail-closed
+- Configured default use when no explicit adapter
+- Unset fail-closed behavior with actionable error
+- Disabled/unavailable configured defaults fail clearly
+- Platform-specific review commands remain platform-specific
+"""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import patch
+
+from puppetmaster import mcp_server, platform_lock
+from puppetmaster.cli._parser import build_parser
+from puppetmaster.cli._dispatch import _main as run_cli_main
+from puppetmaster.cli.commands_platform import _run_platform_subcommand
+from puppetmaster.workers import (
+    NoReviewAdapterError,
+    REVIEW_ADAPTERS,
+    pick_review_adapter,
+)
+
+
+class DefaultReviewerPlatformTests(TestCase):
+    def test_explicit_adapter_wins_over_configured_default(self) -> None:
+        """Explicit adapter selection takes precedence over configured default."""
+        enabled = {"cursor", "claude-code", "codex"}
+        # Configured default is cursor, but explicit request is claude-code
+        adapter = pick_review_adapter(
+            enabled, requested="claude-code", configured_default="cursor"
+        )
+        self.assertEqual(adapter, "claude-code")
+
+    def test_configured_default_used_when_no_explicit_request(self) -> None:
+        """Configured default reviewer is used when no explicit adapter requested."""
+        enabled = {"cursor", "claude-code", "codex"}
+        adapter = pick_review_adapter(
+            enabled,
+            requested=None,
+            configured_default="cursor",
+            is_available=lambda _adapter: True,
+        )
+        self.assertEqual(adapter, "cursor")
+
+    def test_fail_closed_when_no_configured_default_and_no_request(self) -> None:
+        """Fail closed with actionable error when no default configured and no explicit request."""
+        enabled = {"cursor", "claude-code"}
+        with self.assertRaises(NoReviewAdapterError) as ctx:
+            pick_review_adapter(enabled, requested=None, configured_default=None)
+        exc = ctx.exception
+        self.assertEqual(exc.enabled, enabled)
+        self.assertIsNone(exc.requested)
+        self.assertIsNone(exc.configured_default)
+        self.assertIn("No default reviewer configured", str(exc))
+        self.assertIn("platform reviewer", str(exc))
+
+    def test_fail_closed_lists_enabled_platforms(self) -> None:
+        """Fail-closed error lists enabled valid reviewer platforms."""
+        enabled = {"cursor", "codex", "hermes"}
+        with self.assertRaises(NoReviewAdapterError) as ctx:
+            pick_review_adapter(enabled, requested=None, configured_default=None)
+        exc = ctx.exception
+        error_msg = str(exc)
+        self.assertIn("cursor", error_msg)
+        self.assertIn("codex", error_msg)
+        self.assertIn("hermes", error_msg)
+
+    def test_explicit_disabled_adapter_fails_clearly(self) -> None:
+        """Explicit request for disabled adapter fails with clear error."""
+        enabled = {"cursor"}  # codex is disabled
+        with self.assertRaises(NoReviewAdapterError) as ctx:
+            pick_review_adapter(enabled, requested="codex", configured_default=None)
+        exc = ctx.exception
+        self.assertEqual(exc.requested, "codex")
+        self.assertIn("disabled by the platform lock", str(exc))
+
+    def test_configured_default_disabled_fails_clearly(self) -> None:
+        """Configured default that is disabled fails with clear error and remediation."""
+        enabled = {"cursor"}  # codex is disabled
+        with self.assertRaises(NoReviewAdapterError) as ctx:
+            pick_review_adapter(enabled, requested=None, configured_default="codex")
+        exc = ctx.exception
+        self.assertEqual(exc.configured_default, "codex")
+        self.assertIn("disabled by the platform lock", str(exc))
+        self.assertIn("platform enable codex", str(exc))
+        self.assertIn("platform reviewer", str(exc))
+
+    def test_configured_default_unavailable_fails_clearly(self) -> None:
+        """Configured default that is enabled but unavailable fails with clear error."""
+        enabled = {"cursor", "codex"}
+
+        def always_unavailable(adapter: str) -> bool:
+            return False
+
+        with self.assertRaises(NoReviewAdapterError) as ctx:
+            pick_review_adapter(
+                enabled,
+                requested=None,
+                configured_default="cursor",
+                is_available=always_unavailable,
+            )
+        exc = ctx.exception
+        self.assertEqual(exc.configured_default, "cursor")
+        self.assertIn("not available", str(exc))
+        self.assertIn("CLI/credentials missing", str(exc))
+
+    def test_explicit_request_not_review_capable_fails(self) -> None:
+        """Explicit request for non-review-capable adapter fails."""
+        enabled = {"cursor", "local"}  # local is not a billable review platform
+        with self.assertRaises(NoReviewAdapterError) as ctx:
+            pick_review_adapter(enabled, requested="local", configured_default=None)
+        exc = ctx.exception
+        self.assertEqual(exc.requested, "local")
+        self.assertIn("cannot review", str(exc))
+
+    def test_configured_default_not_review_capable_fails(self) -> None:
+        """Configured default that is not review-capable fails."""
+        enabled = {"cursor", "shell"}
+        with self.assertRaises(NoReviewAdapterError) as ctx:
+            pick_review_adapter(enabled, requested=None, configured_default="shell")
+        exc = ctx.exception
+        self.assertEqual(exc.configured_default, "shell")
+        self.assertIn("not review-capable", str(exc))
+        self.assertIn("platform reviewer", str(exc))
+
+    def test_no_enabled_review_platforms_fails(self) -> None:
+        """No enabled review-capable platforms fails with clear guidance."""
+        enabled = set()  # no platforms enabled
+        with self.assertRaises(NoReviewAdapterError) as ctx:
+            pick_review_adapter(enabled, requested=None, configured_default=None)
+        exc = ctx.exception
+        self.assertIn("No review-capable platform is enabled", str(exc))
+        self.assertIn("platform enable", str(exc))
+
+    def test_all_billable_analysis_platforms_can_be_reviewers(self) -> None:
+        self.assertEqual(set(REVIEW_ADAPTERS), set(platform_lock.KNOWN_ADAPTERS))
+
+
+class GenericReviewDispatchTests(TestCase):
+    def _start_result(self) -> dict:
+        return {"content": [{"type": "text", "text": "{}"}], "isError": False}
+
+    @patch.object(mcp_server, "start_cli")
+    @patch.object(mcp_server, "write_generated_swarm_config")
+    @patch("puppetmaster.platform_lock.get_default_reviewer", return_value="cursor")
+    @patch("puppetmaster.platform_lock.enabled_adapters", return_value={"cursor", "codex"})
+    def test_explicit_platform_overrides_configured_default(
+        self, _enabled, _default, write_config, start_cli
+    ) -> None:
+        write_config.return_value = Path("review.json")
+        start_cli.return_value = self._start_result()
+
+        result = mcp_server.start_review(
+            {"goal": "Review the parser", "cwd": ".", "adapter": "codex"}
+        )
+
+        self.assertFalse(result["isError"])
+        roles = [{"role": "review", "instruction": "Review the parser"}]
+        write_config.assert_called_once()
+        self.assertEqual(write_config.call_args.args[1:], (roles, "codex"))
+        command = start_cli.call_args.args[0]
+        self.assertEqual(command[:2], ["run", "Review the parser"])
+        self.assertNotIn("--review", command)
+        self.assertNotIn("--dry-run", command)
+
+    @patch.object(mcp_server, "start_cli")
+    @patch.object(mcp_server, "write_generated_swarm_config")
+    @patch("puppetmaster.workers.adapter_is_available", return_value=True)
+    @patch("puppetmaster.platform_lock.get_default_reviewer", return_value="openai")
+    @patch("puppetmaster.platform_lock.enabled_adapters", return_value={"openai", "cursor"})
+    def test_configured_default_uses_platform_neutral_analysis_runtime(
+        self, _enabled, _default, _available, write_config, start_cli
+    ) -> None:
+        write_config.return_value = Path("review.json")
+        start_cli.return_value = self._start_result()
+
+        result = mcp_server.start_review({"goal": "Review routing", "cwd": "."})
+
+        self.assertFalse(result["isError"])
+        self.assertEqual(write_config.call_args.args[2], "openai")
+        self.assertEqual(start_cli.call_args.args[0][0], "run")
+
+    @patch.object(mcp_server, "start_cli")
+    @patch("puppetmaster.platform_lock.get_default_reviewer", return_value=None)
+    @patch("puppetmaster.platform_lock.enabled_adapters", return_value={"cursor", "codex"})
+    def test_unset_default_fails_without_starting_job(
+        self, _enabled, _default, start_cli
+    ) -> None:
+        result = mcp_server.start_review({"goal": "Review routing", "cwd": "."})
+
+        self.assertTrue(result["isError"])
+        self.assertIn("No default reviewer configured", result["content"][0]["text"])
+        self.assertIn("platform reviewer <platform>", result["content"][0]["text"])
+        start_cli.assert_not_called()
+
+    @patch.object(mcp_server, "start_cli")
+    @patch("puppetmaster.platform_lock.get_default_reviewer", return_value="codex")
+    @patch("puppetmaster.platform_lock.enabled_adapters", return_value={"cursor"})
+    def test_disabled_configured_default_fails_without_fallback(
+        self, _enabled, _default, start_cli
+    ) -> None:
+        result = mcp_server.start_review({"goal": "Review routing", "cwd": "."})
+
+        self.assertTrue(result["isError"])
+        self.assertIn("disabled by the platform lock", result["content"][0]["text"])
+        self.assertIn('"configured_default": "codex"', result["content"][0]["text"])
+        start_cli.assert_not_called()
+
+    @patch.object(mcp_server, "start_cli")
+    @patch("puppetmaster.workers.adapter_is_available", return_value=False)
+    @patch("puppetmaster.platform_lock.get_default_reviewer", return_value="codex")
+    @patch("puppetmaster.platform_lock.enabled_adapters", return_value={"cursor", "codex"})
+    def test_unavailable_configured_default_fails_without_fallback(
+        self, _enabled, _default, _available, start_cli
+    ) -> None:
+        result = mcp_server.start_review({"goal": "Review routing", "cwd": "."})
+
+        self.assertTrue(result["isError"])
+        self.assertIn("enabled but not available", result["content"][0]["text"])
+        start_cli.assert_not_called()
+
+    @patch.object(mcp_server, "start_cli")
+    @patch("puppetmaster.platform_lock.get_default_reviewer", return_value="cursor")
+    @patch("puppetmaster.platform_lock.enabled_adapters", return_value={"cursor", "codex"})
+    def test_conflicting_adapter_and_platform_fails_closed(
+        self, _enabled, _default, start_cli
+    ) -> None:
+        result = mcp_server.start_review(
+            {
+                "goal": "Review routing",
+                "cwd": ".",
+                "adapter": "cursor",
+                "platform": "codex",
+            }
+        )
+
+        self.assertTrue(result["isError"])
+        self.assertIn("pass only one", result["content"][0]["text"])
+        start_cli.assert_not_called()
+
+
+class PlatformLockDefaultReviewerTests(TestCase):
+    def test_get_default_reviewer_when_unset(self) -> None:
+        """get_default_reviewer returns None when no default is configured."""
+        with TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "models.json"
+            registry_path.touch()
+            result = platform_lock.get_default_reviewer(registry_path)
+            self.assertIsNone(result)
+
+    def test_set_and_get_default_reviewer(self) -> None:
+        """set_default_reviewer persists and get_default_reviewer retrieves it."""
+        with TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "models.json"
+            registry_path.touch()
+            platform_lock.set_default_reviewer("cursor", registry_path)
+            result = platform_lock.get_default_reviewer(registry_path)
+            self.assertEqual(result, "cursor")
+
+    def test_set_default_reviewer_canonicalizes_alias(self) -> None:
+        """set_default_reviewer canonicalizes adapter aliases."""
+        with TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "models.json"
+            registry_path.touch()
+            # agy is an alias for antigravity
+            platform_lock.set_default_reviewer("agy", registry_path)
+            result = platform_lock.get_default_reviewer(registry_path)
+            self.assertEqual(result, "antigravity")
+
+    def test_set_default_reviewer_none_clears_default(self) -> None:
+        """set_default_reviewer with None clears the configured default."""
+        with TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "models.json"
+            registry_path.touch()
+            platform_lock.set_default_reviewer("cursor", registry_path)
+            self.assertEqual(platform_lock.get_default_reviewer(registry_path), "cursor")
+            platform_lock.set_default_reviewer(None, registry_path)
+            self.assertIsNone(platform_lock.get_default_reviewer(registry_path))
+
+    def test_set_default_reviewer_preserves_other_platform_json_fields(self) -> None:
+        """set_default_reviewer preserves other fields in platform.json."""
+        with TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "models.json"
+            registry_path.touch()
+            # Disable some adapters first
+            platform_lock.disable({"codex"}, registry_path)
+            disabled_before = platform_lock._read_disabled(registry_path)
+            # Set default reviewer
+            platform_lock.set_default_reviewer("cursor", registry_path)
+            # Verify disabled list is preserved
+            disabled_after = platform_lock._read_disabled(registry_path)
+            self.assertEqual(disabled_before, disabled_after)
+            self.assertIn("codex", disabled_after)
+
+    def test_get_default_reviewer_returns_none_on_malformed_json(self) -> None:
+        """get_default_reviewer returns None if platform.json is malformed."""
+        with TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "models.json"
+            registry_path.touch()
+            config_path = platform_lock.platform_config_path(registry_path)
+            config_path.write_text("not valid json", encoding="utf-8")
+            result = platform_lock.get_default_reviewer(registry_path)
+            self.assertIsNone(result)
+
+    def test_set_default_reviewer_rejects_unknown_platform(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "models.json"
+            with self.assertRaisesRegex(ValueError, "unknown reviewer platform"):
+                platform_lock.set_default_reviewer("not-a-platform", registry_path)
+
+
+class DefaultReviewerCliTests(TestCase):
+    def test_cli_sets_reports_and_clears_default_reviewer(self) -> None:
+        parser = build_parser()
+        with TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "models.json"
+
+            set_args = parser.parse_args(
+                [
+                    "platform",
+                    "reviewer",
+                    "codex",
+                    "--registry-path",
+                    str(registry_path),
+                ]
+            )
+            with redirect_stdout(io.StringIO()):
+                self.assertEqual(_run_platform_subcommand(set_args), 0)
+            self.assertEqual(platform_lock.get_default_reviewer(registry_path), "codex")
+
+            show_args = parser.parse_args(
+                [
+                    "platform",
+                    "reviewer",
+                    "--registry-path",
+                    str(registry_path),
+                ]
+            )
+            output = io.StringIO()
+            with redirect_stdout(output):
+                self.assertEqual(_run_platform_subcommand(show_args), 0)
+            self.assertIn("Default reviewer platform: codex", output.getvalue())
+
+            status_args = parser.parse_args(
+                [
+                    "platform",
+                    "status",
+                    "--json",
+                    "--registry-path",
+                    str(registry_path),
+                ]
+            )
+            status_output = io.StringIO()
+            with redirect_stdout(status_output):
+                self.assertEqual(_run_platform_subcommand(status_args), 0)
+            self.assertIn('"default_reviewer": "codex"', status_output.getvalue())
+
+            clear_args = parser.parse_args(
+                [
+                    "platform",
+                    "reviewer",
+                    "--clear",
+                    "--registry-path",
+                    str(registry_path),
+                ]
+            )
+            with redirect_stdout(io.StringIO()):
+                self.assertEqual(_run_platform_subcommand(clear_args), 0)
+            self.assertIsNone(platform_lock.get_default_reviewer(registry_path))
+
+    def test_cli_rejects_platform_and_clear_together(self) -> None:
+        parser = build_parser()
+        with TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "models.json"
+            args = parser.parse_args(
+                [
+                    "platform",
+                    "reviewer",
+                    "cursor",
+                    "--clear",
+                    "--registry-path",
+                    str(registry_path),
+                ]
+            )
+            error = io.StringIO()
+            with redirect_stderr(error):
+                self.assertEqual(_run_platform_subcommand(args), 1)
+            self.assertIn("not both", error.getvalue())
+            self.assertIsNone(platform_lock.get_default_reviewer(registry_path))
+
+    @patch("puppetmaster.swarm_launch.detach_analysis_swarm")
+    @patch("puppetmaster.workers.adapter_is_available", return_value=True)
+    @patch("puppetmaster.platform_lock.get_default_reviewer", return_value="codex")
+    @patch("puppetmaster.platform_lock.enabled_adapters", return_value={"cursor", "codex"})
+    def test_generic_review_cli_uses_configured_default(
+        self, _enabled, _default, _available, detach
+    ) -> None:
+        detach.return_value = {"job_id": "job_review"}
+        with TemporaryDirectory() as tmpdir:
+            output = io.StringIO()
+            with redirect_stdout(output):
+                result = run_cli_main(
+                    [
+                        "--state-dir",
+                        str(Path(tmpdir) / "state"),
+                        "review",
+                        "Review routing",
+                        "--cwd",
+                        tmpdir,
+                        "--json",
+                    ]
+                )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(detach.call_args.kwargs["adapter"], "codex")
+        self.assertEqual(detach.call_args.kwargs["roles"], ["review"])
+        self.assertIn("job_review", output.getvalue())
+
+    @patch("puppetmaster.swarm_launch.detach_analysis_swarm")
+    @patch("puppetmaster.platform_lock.get_default_reviewer", return_value=None)
+    @patch("puppetmaster.platform_lock.enabled_adapters", return_value={"cursor", "codex"})
+    def test_generic_review_cli_fails_closed_when_unset(
+        self, _enabled, _default, detach
+    ) -> None:
+        with TemporaryDirectory() as tmpdir:
+            error = io.StringIO()
+            with redirect_stderr(error):
+                result = run_cli_main(
+                    [
+                        "--state-dir",
+                        str(Path(tmpdir) / "state"),
+                        "review",
+                        "Review routing",
+                        "--cwd",
+                        tmpdir,
+                    ]
+                )
+
+        self.assertEqual(result, 2)
+        self.assertIn("No default reviewer configured", error.getvalue())
+        detach.assert_not_called()
+
+
+class ReviewAdapterAvailabilityTests(TestCase):
+    def test_available_adapter_is_selected(self) -> None:
+        """When configured default is available, it is selected."""
+        enabled = {"cursor", "codex"}
+
+        def cursor_available(adapter: str) -> bool:
+            return adapter == "cursor"
+
+        adapter = pick_review_adapter(
+            enabled,
+            requested=None,
+            configured_default="cursor",
+            is_available=cursor_available,
+        )
+        self.assertEqual(adapter, "cursor")
+
+    def test_unavailable_configured_default_fails(self) -> None:
+        """When configured default is unavailable, fail with clear error."""
+        enabled = {"cursor", "codex"}
+
+        def none_available(adapter: str) -> bool:
+            return False
+
+        with self.assertRaises(NoReviewAdapterError) as ctx:
+            pick_review_adapter(
+                enabled,
+                requested=None,
+                configured_default="cursor",
+                is_available=none_available,
+            )
+        exc = ctx.exception
+        self.assertIn("not available", str(exc))
+        self.assertIn("CLI/credentials missing", str(exc))
+
+    def test_explicit_request_skips_availability_check(self) -> None:
+        """Explicit adapter request is honored even if unavailable (fails later with precise error)."""
+        enabled = {"cursor", "codex"}
+
+        def none_available(adapter: str) -> bool:
+            return False
+
+        # Explicit request is honored regardless of availability
+        adapter = pick_review_adapter(
+            enabled,
+            requested="cursor",
+            configured_default=None,
+            is_available=none_available,
+        )
+        self.assertEqual(adapter, "cursor")

--- a/tests/test_harness_regression_guards.py
+++ b/tests/test_harness_regression_guards.py
@@ -27,6 +27,7 @@ REQUIRED_STDIO_TOOLS = frozenset(
     {
         "puppetmaster_doctor",
         "puppetmaster_start_cursor_review",
+        "puppetmaster_start_review",
         "puppetmaster_start_cursor_plan",
         "puppetmaster_start_cursor_swarm",
         "puppetmaster_start_swarm",

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -280,6 +280,8 @@ class PuppetmasterTests(unittest.TestCase):
         self.assertIn("puppetmaster_doctor", tool_names)
         self.assertIn("puppetmaster_cursor_review", tool_names)
         self.assertIn("puppetmaster_start_cursor_review", tool_names)
+        self.assertIn("puppetmaster_review", tool_names)
+        self.assertIn("puppetmaster_start_review", tool_names)
         self.assertIn("puppetmaster_claude_implement", tool_names)
         self.assertIn("puppetmaster_start_claude_implement", tool_names)
         self.assertIn("puppetmaster_codex", tool_names)
@@ -24891,7 +24893,7 @@ class InvocationGateTests(unittest.TestCase):
 
         d = should_delegate("audit the auth module for security issues across the repo")
         self.assertTrue(d.should_delegate)
-        self.assertEqual(d.suggested_verb, "puppetmaster_start_cursor_review")
+        self.assertEqual(d.suggested_verb, "puppetmaster_start_review")
         self.assertGreaterEqual(d.capability_score, 60)
 
     def test_should_not_delegate_trivial_typo(self):
@@ -25040,13 +25042,14 @@ class InvocationGateTests(unittest.TestCase):
         self.assertIn("single", directive.lower())
         self.assertNotIn("fan it out to a swarm", directive)
 
-    def test_review_directive_still_uses_swarm_framing(self):
-        """Read-only analysis keeps the swarm framing — swarms are correct there."""
+    def test_review_directive_uses_configured_reviewer_framing(self):
+        """Review routing names the user-selected platform and does not assume Cursor."""
         from puppetmaster.invocation_gate import should_delegate
 
         d = should_delegate("audit the auth module for security issues across the repo")
-        self.assertEqual(d.suggested_verb, "puppetmaster_start_cursor_review")
-        self.assertIn("fan it out to a swarm", d.directive())
+        self.assertEqual(d.suggested_verb, "puppetmaster_start_review")
+        self.assertIn("configured default reviewer platform", d.directive())
+        self.assertNotIn("fan it out to a swarm", d.directive())
 
     def test_trivial_add_comment_stays_inline_despite_broadened_implement(self):
         """Broadening implement detection to include 'add' must not start
@@ -25197,7 +25200,7 @@ class HookRunnerTests(unittest.TestCase):
         cursor = handle_hook(
             prompt, host="cursor", event="beforeSubmitPrompt", env=self._TOOLS_ON
         )
-        self.assertEqual(cursor.decision.suggested_verb, "puppetmaster_start_cursor_review")
+        self.assertEqual(cursor.decision.suggested_verb, "puppetmaster_start_review")
 
     def test_verb_for_host_translation_table(self):
         from puppetmaster.hook_runner import verb_for_host


### PR DESCRIPTION
## Summary

- Persist an explicit default reviewer platform in the existing platform policy file, with CLI set/show/clear and status support.
- Add platform-neutral review entry points for CLI and MCP with strict precedence: explicit selection, configured default, then actionable fail-closed error.
- Run reviews through the existing read-only analysis runtime so Codex, Claude Code, OpenAI, Hermes, Antigravity, Agentic, and Cursor receive their correct adapter contracts.
- Route invocation hooks and repository skill guidance through the generic reviewer path while preserving Cursor-specific review as an explicit opt-in.

## Validation

- python -m pytest tests/test_default_reviewer_platform.py tests/test_puppetmaster.py::PuppetmasterTests::test_mcp_lists_puppetmaster_agent_tools tests/test_puppetmaster.py::InvocationGateTests tests/test_puppetmaster.py::HookRunnerTests tests/test_harness_regression_guards.py -q — 78 passed
- python -m pytest tests/test_puppetmaster.py -q — 1275 passed, 14 skipped
- Mutation check: reintroduced the forbidden implicit fallback; the fail-closed regression test failed as expected, then passed after restoration.
- git diff --check — passed

The unfiltered unittest-discover suite was not run; the repository-defined pre-publication gate is tests/test_puppetmaster.py.