### PR TITLE
Merge dev: Windows Pi doctor visibility (1.22.23, no bump)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ as a subprocess worker; Pi stays the TUI.
   path in settings.json. Documented: pi install PATH_TO_PI_PACKAGE.
 - Doctor: pi-pilot is healthy when the Pi CLI is visible, the package is listed,
   and Puppetmaster MCP is reachable. Missing pieces print the exact fix.
+  Windows treats ``pi`` and ``pi.exe`` as the CLI (PATHEXT / PATH scan); a
+  no-extension stub is visible, and package listings compare via resolve/samefile.
 - Tests: hermetic unittest (no pytest). Live E2E is skipped unless PI_LIVE_E2E=1
   and a provider key plus pi are available; never faked.
 - Docs: [PI.md](PI.md), ADAPTERS.md, CLI_REFERENCE.md. Does not reopen 1.22.22.

--- a/puppetmaster/diagnostics.py
+++ b/puppetmaster/diagnostics.py
@@ -994,15 +994,105 @@ def _pi_cli_command(env: Optional[Mapping[str, str]] = None) -> str:
     return (probe.get("PI_COMMAND") or "pi").strip() or "pi"
 
 
+# Windows PATHEXT suffixes we treat as the same CLI as a bare name.
+# shutil.which already honors PATHEXT, but a stub named ``pi`` (no extension)
+# is invisible on Windows, and a real ``pi.exe`` fails a naive
+# ``name == "pi" or name.startswith("pi-")`` check.
+_PI_PATHEXT = (".exe", ".cmd", ".bat", ".com")
+
+
+def _pi_cli_name_ok(name: str) -> bool:
+    """Accept resolved basenames ``pi``, ``pi.exe``, and ``pi-*`` (plus PATHEXT)."""
+    n = (name or "").lower()
+    stem = n
+    for ext in _PI_PATHEXT:
+        if stem.endswith(ext):
+            stem = stem[: -len(ext)]
+            break
+    return stem == "pi" or stem.startswith("pi-") or n == "pi" or n.startswith("pi-")
+
+
+def _pi_which_on_path(command: str, path_value: Optional[str], pathext: Optional[str]) -> Optional[str]:
+    """Locate the Pi CLI without assuming POSIX ``which`` semantics.
+
+    Order: ``shutil.which`` on the given command, then ``pi.exe`` when the
+    command is the bare CLI, then a PATH-directory scan for either filename
+    (and PATHEXT variants). A file literally named ``pi`` with no extension
+    is a valid stub on Windows CI.
+    """
+    names: list[str] = []
+    # Honor an explicit PI_COMMAND path first (absolute or with a separator).
+    direct = Path(command).expanduser()
+    if os.path.isabs(str(direct)) or os.sep in command or (os.altsep and os.altsep in command):
+        try:
+            if direct.is_file():
+                return str(direct)
+        except OSError:
+            pass
+    found = shutil.which(command, path=path_value)
+    if found:
+        return found
+
+    cmd_name = Path(command).name
+    if cmd_name:
+        names.append(cmd_name)
+    if cmd_name.lower() in ("", "pi", "pi.exe"):
+        for extra in ("pi", "pi.exe"):
+            if extra.lower() not in {n.lower() for n in names} and extra.lower() != command.lower():
+                names.append(extra)
+
+    search_path = path_value
+    for name in names:
+        found = shutil.which(name, path=search_path)
+        if found:
+            return found
+
+    exts: list[str] = []
+    raw_ext = pathext if pathext is not None else os.environ.get("PATHEXT", "")
+    if raw_ext:
+        exts = [e for e in raw_ext.split(os.pathsep) if e]
+
+    for directory in (search_path or "").split(os.pathsep):
+        if not directory:
+            continue
+        folder = Path(directory)
+        try:
+            if not folder.is_dir():
+                continue
+        except OSError:
+            continue
+        for name in names:
+            candidate = folder / name
+            try:
+                if candidate.is_file():
+                    return str(candidate)
+            except OSError:
+                pass
+            for ext in exts:
+                if name.lower().endswith(ext.lower()):
+                    continue
+                extra = folder / f"{name}{ext}"
+                try:
+                    if extra.is_file():
+                        return str(extra)
+                except OSError:
+                    continue
+    return None
+
+
 def _pi_cli_visible(env: Optional[Mapping[str, str]] = None) -> bool:
     probe = env if env is not None else os.environ
     command = _pi_cli_command(probe)
-    resolved = shutil.which(command, path=probe.get("PATH"))
+    resolved = _pi_which_on_path(command, probe.get("PATH"), probe.get("PATHEXT"))
     if resolved is None:
         candidate = Path(command).expanduser()
-        return candidate.is_file()
-    name = Path(resolved).name.lower()
-    return name == "pi" or name.startswith("pi-") or Path(command).name.lower() == "pi"
+        try:
+            if candidate.is_file():
+                return _pi_cli_name_ok(candidate.name)
+        except OSError:
+            return False
+        return False
+    return _pi_cli_name_ok(Path(resolved).name)
 
 
 def _pi_package_files_ok(pkg: Optional[Path]) -> bool:

--- a/puppetmaster/installers.py
+++ b/puppetmaster/installers.py
@@ -2510,14 +2510,38 @@ def _normalize_package_source(value: object) -> str:
         return str(Path(raw).expanduser())
 
 
+def _package_paths_equivalent(left: object, right: object) -> bool:
+    """True when two package listings name the same directory.
+
+    Windows CI can write 8.3 short names or mix ``/`` and ``\\``; a raw
+    ``Path == Path`` (or even ``str(resolve())``) then misses a listed package.
+    Prefer resolve + samefile when both sides exist.
+    """
+    a = _normalize_package_source(left)
+    b = _normalize_package_source(right)
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    if os.path.normcase(os.path.normpath(a)) == os.path.normcase(os.path.normpath(b)):
+        return True
+    if os.path.normcase(a.replace("\\", "/")) == os.path.normcase(b.replace("\\", "/")):
+        return True
+    try:
+        if os.path.exists(a) and os.path.exists(b) and os.path.samefile(a, b):
+            return True
+    except OSError:
+        pass
+    return False
+
+
 def _settings_has_package(settings: Mapping, package_dir: Path) -> bool:
     packages = settings.get("packages")
     if not isinstance(packages, list):
         return False
-    wanted = _normalize_package_source(package_dir)
     for item in packages:
         source = item if isinstance(item, str) else (item or {}).get("source") if isinstance(item, dict) else ""
-        if _normalize_package_source(source) == wanted:
+        if _package_paths_equivalent(source, package_dir):
             return True
     return False
 
@@ -2729,7 +2753,7 @@ def uninstall_pi_mcp(
             removed = 0
             for item in packages:
                 source = item if isinstance(item, str) else str((item or {}).get("source") or "")
-                if str(Path(source).expanduser()) == wanted:
+                if _package_paths_equivalent(source, pkg):
                     removed += 1
                     continue
                 kept.append(item)

--- a/tests/test_pi_pilot_package.py
+++ b/tests/test_pi_pilot_package.py
@@ -14,9 +14,16 @@ if _HERMETIC_DIR not in sys.path:
     sys.path.insert(0, _HERMETIC_DIR)
 import hermetic_env  # noqa: F401
 
-from puppetmaster.diagnostics import pi_pilot_check, run_doctor
+from puppetmaster.diagnostics import (
+    _pi_cli_name_ok,
+    _pi_cli_visible,
+    pi_pilot_check,
+    run_doctor,
+)
 from puppetmaster.installers import (
     HandshakeResult,
+    _package_paths_equivalent,
+    _settings_has_package,
     build_pi_mcp_entry,
     bundled_pi_package_dir,
     install_pi_mcp,
@@ -83,9 +90,9 @@ class PiInstallerTests(unittest.TestCase):
 
 
 class PiDoctorTests(unittest.TestCase):
-    def _stub_pi(self, bindir: Path) -> Path:
+    def _stub_pi(self, bindir: Path, name: str = "pi") -> Path:
         bindir.mkdir(parents=True, exist_ok=True)
-        pi = bindir / "pi"
+        pi = bindir / name
         pi.write_bytes(b"exit 0\n")
         pi.chmod(0o755)
         return pi
@@ -124,6 +131,41 @@ class PiDoctorTests(unittest.TestCase):
             check = pi_pilot_check(env=env)
             self.assertEqual(check.status, "error")
             self.assertIn("install-pi-mcp", check.detail)
+
+    def test_pi_exe_stub_is_visible(self) -> None:
+        """Windows installs the real CLI as pi.exe; which('pi') can miss a stub.
+
+        The file is named pi.exe even on Linux so the same which/PATH-scan
+        logic is covered without a Windows runner.
+        """
+        with tempfile.TemporaryDirectory() as raw:
+            bindir = Path(raw) / "bin"
+            self._stub_pi(bindir, "pi.exe")
+            env = {"PATH": str(bindir), "PI_COMMAND": "pi"}
+            self.assertTrue(_pi_cli_visible(env))
+            env_exe = {"PATH": str(bindir), "PI_COMMAND": "pi.exe"}
+            self.assertTrue(_pi_cli_visible(env_exe))
+            self.assertTrue(_pi_cli_name_ok("pi.exe"))
+            self.assertTrue(_pi_cli_name_ok("pi"))
+            self.assertTrue(_pi_cli_name_ok("pi-coding-agent"))
+            self.assertFalse(_pi_cli_name_ok("pip"))
+            # Incomplete (cli only) is still error, not warn-as-uninstalled.
+            env_err = {
+                "PI_CODING_AGENT_DIR": str(Path(raw) / "agent"),
+                "PATH": str(bindir),
+                "PI_COMMAND": "pi",
+            }
+            (Path(raw) / "agent").mkdir()
+            check = pi_pilot_check(env=env_err)
+            self.assertEqual(check.status, "error", check.detail)
+
+    def test_package_listing_matches_slash_and_samefile(self) -> None:
+        pkg = bundled_pi_package_dir()
+        self.assertIsNotNone(pkg)
+        assert pkg is not None
+        posix = str(pkg.resolve()).replace("\\", "/")
+        self.assertTrue(_package_paths_equivalent(posix, pkg))
+        self.assertTrue(_settings_has_package({"packages": [posix]}, pkg))
 
     def test_run_doctor_includes_pi_pilot(self) -> None:
         with tempfile.TemporaryDirectory() as raw:


### PR DESCRIPTION
## Summary
- Land the 1.22.23 Windows Pi doctor fix from dev (PR #81) onto main without a version bump or PyPI publish.
- `pi` / `pi.exe` visibility + resolve/samefile package listing. Target: `test (windows-latest, 3.12)`.

## Test plan
- [ ] Windows 3.12 unittest job green on the equated SHA