### PR TITLE
Warn when the dashboard is serving the wrong project state dir

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,51 @@
+## Unreleased
+
+**Fix: a dashboard could confidently serve the wrong project's state dir, and
+nothing said so.**
+
+`default_state_dir` hashes the git root of the caller's cwd *or* the cwd itself,
+so a session opened at a non-git wrapper folder above the checkout took the
+fallback and forked one logical project into two state dirs — a near-empty one
+the dashboard showed and the busy one every job actually wrote to. The two boards
+were pixel-identical and neither the CLI, the MCP tool, nor doctor contradicted
+the empty one. The dashboard header now carries a project tag —
+`<slug> · <first 8 hex of the state dir digest>`, rendered from `/api/meta` by a
+pure `projectLabel()` — and the same label goes in the browser tab title, so
+adjacent boards are distinguishable from the tab strip and the taskbar. The 8 hex
+digits are load-bearing: the two forked dirs differed only by letter case once
+the digest was stripped. **No existing state directory path changes** —
+repointing a hash would orphan live job history.
+
+- **Warn-only detection.** New `puppetmaster/state_health.py`
+  (`diagnose_state_dir`, `short_warning`) returns a verdict from a closed set
+  over directory stats only — no SQLite, and no `git` subprocess when the caller
+  supplies the state dir. It resolves nothing and moves nothing. `doctor` reports
+  it as a **state-identity** row (`warn` when forked, `optional` for a new or
+  explicitly pinned dir, `ok` otherwise), replacing an `sqlite-state` row that
+  called the wrong near-empty dir a benign "no local sqlite state yet".
+- **Three warning surfaces.** A `WARNING:` line on stderr when `serve()` starts,
+  directly after the `Reading durable state from:` line it contradicts (stderr
+  because that is what `--background` and the MCP launch redirect into
+  `dashboard.err.log`); a `state_dir_may_be_wrong` warning plus an appended
+  remedy in `run_dashboard`'s note, advisory and never `isError` since the server
+  did start; and an escaped in-page banner. Every message is basenames and counts
+  only — an absolute state dir carries the username and gets quoted verbatim into
+  agent transcripts.
+- **`/api/diagnostics`, deliberately not `/api/meta`.** The identity route is
+  what every reuse check depends on: `dashboard_identity` reads a bounded body
+  under a one-second timeout, so a slow or oversized response there degrades to
+  "not my dashboard" and the CLI and MCP spawn duplicate dashboards. The
+  filesystem walk lives behind its own TTL-cached route instead. Both routes gate
+  the human-readable basename to loopback, so a `--mobile` peer of an
+  unauthenticated board sees only a short state id.
+- **Never second-guessed.** An `--all-projects` board never warns (it serves
+  every project), and an explicit `--state-dir` or `PUPPETMASTER_STATE_DIR` is a
+  deliberate choice — only the hashed `projects/` layout can fork.
+- **Non-silent aggregation.** `list_all_projects_snapshot` reports a project it
+  cannot read instead of dropping it, so an `--all-projects` board showing less
+  than everything says so rather than erasing a project's job list with no log
+  line and no wire field.
+
 ## v1.22.23 — 2026-08-23
 
 **Feature: Pi as a TUI/pilot package (not a worker adapter).**

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -51,6 +51,70 @@ is never mistaken for a match — no coordinated upgrade needed, and `--status`
 still reports it as yours (noting it predates `/api/meta`) as long as the pid
 your own runfile tracked is still alive.
 
+That same identity also has a human half. The header carries a **project tag**,
+rendered from `/api/meta` by a pure `projectLabel()` as
+`<slug> · <first 8 hex of the state dir digest>` — for example
+`puppetmaster · c3177e60` — and the identical label goes into the **browser tab
+title** (`Puppetmaster — puppetmaster · c3177e60`). Two boards on adjacent ports are
+therefore distinguishable at a glance, and from the taskbar or tab strip without
+focusing either one. The 8 hex digits are kept on purpose rather than trimmed for
+looks: the two dirs one real project forked into were
+`puppetmaster-c3177e6032c4` and `Puppetmaster-b92145e840c8`, which differ **only
+by letter case** once the digest is stripped — dropping it would re-merge on
+screen exactly what the tag exists to tell apart. An `--all-projects` board is
+labelled `all projects` instead of one incidental member of the set, and a state
+dir whose name isn't `<slug>-<12 hex>` is passed through unmangled.
+
+Under `--mobile` — or for any non-loopback peer — `/api/meta` withholds the
+human-readable basename, so the header degrades to a short state id
+(`state c3177e60`). That is deliberate, not a gap: the endpoint is
+**unauthenticated**, and a project basename is a folder name off the local
+filesystem, while the hash is safe to hand to anyone who can already reach the
+board.
+
+**When the board may be serving the wrong project.** Because the default state
+dir is derived from the git root of the launching shell's cwd, a session opened
+at a non-git wrapper folder *above* the checkout gets its own separate store —
+one logical project forks into two state dirs, and the emptier one renders as a
+perfectly healthy, perfectly empty board. A wrong-state-dir warning now appears
+in three places:
+
+- a `WARNING:` line on **stderr** when `serve()` starts, right after the
+  `Reading durable state from:` line it would otherwise contradict (the
+  `--background` and MCP launch paths redirect stderr into `dashboard.err.log`,
+  the only channel from a detached board that reaches a human);
+- a `state_dir_may_be_wrong` entry in `warnings` on the **MCP dashboard tool**
+  response, plus the same sentence appended to that response's `note` alongside
+  how to get out of it (pass the repo root as `cwd`, an explicit `state_dir`, or
+  `all_projects=true`). It is advisory: the dashboard did start, so nothing is
+  flagged as an error;
+- a **banner** in the page itself, fed by a separate `GET /api/diagnostics`
+  route and HTML-escaped like every other artifact-derived string on the board.
+
+`puppetmaster doctor` reports the same finding as a **state-identity** row —
+`warn` when the active dir looks forked, `optional` for a brand-new project or an
+explicitly pinned dir, `ok` otherwise.
+
+A few properties of this check are worth stating plainly:
+
+- The diagnosis is **not** served on `/api/meta`. The identity check that makes
+  reuse work reads a bounded body under a short socket timeout, so a slow or
+  oversized response there is silently read as "not my dashboard" — which is
+  precisely how you end up with duplicate dashboards. The filesystem walk stays
+  behind its own route.
+- Detection is **warn-only**. It changes no existing state directory path, so no
+  job history is moved, re-homed, or orphaned by it; the warning tells you where
+  the other history is and leaves it exactly where it is.
+- An `--all-projects` board **never warns** — it serves every project, so "you
+  may be pointed at the wrong one" cannot be true of it.
+- An explicit `--state-dir` (or `PUPPETMASTER_STATE_DIR`) is treated as a
+  deliberate choice and is **never second-guessed**; only the hashed
+  `projects/<slug>-<digest>` layout can fork.
+- `--all-projects` also stopped hiding failures: a project it cannot read is now
+  **reported** rather than silently omitted, so an aggregate board that is
+  showing less than everything says so instead of erasing a whole project's job
+  list without a trace.
+
 ## Easiest setup: let the pilot run it (no second terminal)
 
 The lowest-lift path is to have the agent start it for you. The MCP

--- a/puppetmaster/dashboard.py
+++ b/puppetmaster/dashboard.py
@@ -25,6 +25,9 @@ import hashlib
 import json
 import os
 import re
+import sqlite3
+import sys
+import time
 from pathlib import Path
 from typing import Any, Callable, Optional, Union
 
@@ -628,16 +631,78 @@ def list_jobs_snapshot(store: SwarmStore, *, limit: int = 50) -> list[dict[str, 
     return rows[:limit]
 
 
-def list_all_projects_snapshot(*, backend: str = "sqlite", limit: int = 200) -> list[dict[str, Any]]:
-    """Aggregate jobs from every project state dir on this machine."""
+# `default_state_dir` mints project dirs as ``<slug>-<12 hex of sha256>``; the
+# board wants the human half back. Named (rather than inlined at the one call
+# site) so a test can pin the exact strip against the digest convention.
+_PROJECT_DIGEST_RE = re.compile(r"-[0-9a-f]{12}$")
+
+
+def project_slug(name: str) -> str:
+    """Strip the hashed workspace suffix off a project state-dir name.
+
+    ``project_slug("alpha-0123456789ab") == "alpha"``, and a name without the
+    12-hex digest (or one that is *only* a digest) is returned unchanged.
+    """
+    return _PROJECT_DIGEST_RE.sub("", name) or name
+
+
+# Reading somebody else's project state dir is a best-effort operation, and
+# these are the ways it legitimately fails: the directory or DB file is
+# unreadable/locked (OSError), the sqlite file is corrupt or held by another
+# writer (sqlite3.Error), or a row was written by a schema this build cannot
+# decode (ValueError from json/enum, KeyError/TypeError from the job decoder).
+# Everything else — AttributeError, ImportError, RecursionError — is a bug in
+# *this* process and must propagate instead of being laundered into "that
+# project has no jobs".
+_PROJECT_READ_ERRORS = (OSError, sqlite3.Error, ValueError, KeyError, TypeError)
+
+
+class ProjectsSnapshot(list):
+    """The all-projects job list, plus the projects that could not be read.
+
+    A plain ``list`` subclass on purpose: ``/api/jobs`` is a bare JSON array on
+    the wire and the page's ``for (const j of jobs)`` iterates the top level, so
+    reshaping this into ``{"jobs": ..., "errors": ...}`` would break every
+    existing consumer. ``json.dumps`` dispatches on ``isinstance(obj, list)``,
+    so the failures ride along as an *attribute* and never reach the wire.
+
+    Base class is bare ``list`` (not ``list[dict]``) — subscripting a builtin in
+    a runtime base-class position needs 3.9+/PEP 585 semantics we don't rely on
+    here, and ``pyproject.toml`` declares ``requires-python >= 3.9``.
+    """
+
+    def __init__(self, rows: Any = (), errors: Any = None) -> None:
+        super().__init__(rows)
+        self.errors: list[dict[str, str]] = list(errors or ())
+
+    @property
+    def partial(self) -> bool:
+        """True when at least one project was skipped — i.e. the board is
+        showing less than everything and should say so."""
+        return bool(self.errors)
+
+
+def list_all_projects_snapshot(*, backend: str = "sqlite", limit: int = 200) -> "ProjectsSnapshot":
+    """Aggregate jobs from every project state dir on this machine.
+
+    A project that cannot be read is *reported*, not dropped: its slug and the
+    exception land in the returned snapshot's ``errors`` attribute so a caller
+    (see :func:`make_handler`) can put it in front of a human. Silently
+    continuing used to erase a whole project's job list from the board with no
+    trace anywhere — no log line, no wire field, nothing.
+    """
     from puppetmaster.state import list_project_state_dirs
     from puppetmaster.store_factory import create_store
 
     rows: list[dict[str, Any]] = []
+    errors: list[dict[str, str]] = []
     for project_dir in list_project_state_dirs():
+        short = project_slug(project_dir.name)
         try:
+            # create_store stays inside the try: SwarmStore.__init__ runs
+            # ensure_state_dir, which can legitimately raise a per-project
+            # OSError (unwritable or vanished directory).
             store = create_store(backend, project_dir)
-            short = re.sub(r"-[0-9a-f]{12}$", "", project_dir.name) or project_dir.name
             for job in store.list_jobs():
                 rows.append(
                     {
@@ -650,10 +715,14 @@ def list_all_projects_snapshot(*, backend: str = "sqlite", limit: int = 200) -> 
                         **_job_snapshot_meta(job),
                     }
                 )
-        except Exception:
+        except _PROJECT_READ_ERRORS as exc:
+            message = str(exc).strip() or type(exc).__name__
+            errors.append(
+                {"project": short, "error": f"{type(exc).__name__}: {message}"}
+            )
             continue
     rows.sort(key=lambda r: r.get("created_at") or "", reverse=True)
-    return rows[:limit]
+    return ProjectsSnapshot(rows[:limit], errors)
 
 
 # --- HTTP layer ------------------------------------------------------------
@@ -743,6 +812,58 @@ function phaseStrip(phase) {
 
 function jobHeadline(j) {
   return j.label || j.title || j.id;
+}
+
+// Header label answering "which project is this board serving?" from an
+// /api/meta payload. Pure by contract: no fetch/document/window/location, no
+// globals at all -- this constant is executed verbatim under node by the test
+// suite, and free identifiers in JS resolve at CALL time, so any browser API
+// touched here would blow up there rather than in a browser.
+function projectLabel(meta) {
+  if (!meta) return "";
+  // Checked BEFORE meta.project on purpose: serve() always passes a state_dir,
+  // so an --all-projects board carries a project basename too and would
+  // otherwise be labelled with one incidental project out of the set.
+  if (meta.all_projects) return "all projects";
+  const project = meta.project;
+  if (project) {
+    // default_state_dir() names dirs "<slug>-<12 hex digest>". Keeping 8 hex
+    // digits is load-bearing: "puppetmaster-c3177e6032c4" and
+    // "Puppetmaster-b92145e840c8" -- the two dirs one project forked into --
+    // differ ONLY by case once the digest is stripped, so dropping or
+    // over-truncating it would re-merge exactly what this tag exists to tell
+    // apart. A name of any other shape is passed through unmangled.
+    const parts = /^(.+)-([0-9a-f]{12})$/.exec(project);
+    if (parts) return parts[1] + " · " + parts[2].slice(0, 8);
+    return project;
+  }
+  // The --mobile / non-loopback path: /api/meta gates the human-readable
+  // basename to loopback callers, so a remote peer only ever gets the hash.
+  // String() before slice() so a non-string never renders as "null"/"NaN".
+  if (meta.state_dir_id) return "state " + String(meta.state_dir_id).slice(0, 8);
+  return "";
+}
+
+// Banner for "this board may be serving the wrong project's state dir", built
+// from an /api/diagnostics payload. Pure for the same reason as projectLabel()
+// -- and load-bearing here: with an explicit --state-dir the project basename
+// is filesystem-derived and never sanitised on its way out of the endpoint, so
+// its trip through esc() is exercised verbatim under node by the test suite.
+function stateDirHint(hint, jobsShown) {
+  if (!hint || !hint.suspect) return "";
+  // Client-side staleness guard. The server caches the diagnosis for ~15s, and
+  // it counts job *directories* -- so by the time the banner would render, the
+  // board may already show more jobs than the "nearly empty" dir the detector
+  // complained about. A board visibly busier than what was reported is not
+  // this incident; drop the banner rather than contradict the rows below it.
+  const counted = Number(hint.jobs);
+  if (Number.isFinite(counted) && Number(jobsShown) > counted) return "";
+  const message = hint.message
+    || "This state dir may not be where this workspace's jobs go.";
+  return '<div class="state-dir-hint" role="status">'
+    + "<strong>Possibly the wrong project.</strong> " + esc(message)
+    + " Run <code>puppetmaster projects</code>, or start the dashboard from the"
+    + " git root or with <code>--all-projects</code>.</div>";
 }
 """
 
@@ -994,6 +1115,19 @@ _PAGE_HEAD = r"""<!doctype html>
     color: #d3f9d8;
     font-size: 13px;
   }
+  /* "This board may be serving the wrong project's state dir." Amber, not the
+     red .alert: nothing failed, the jobs are simply somewhere else. */
+  .state-dir-hint {
+    background: #2b2410;
+    border: 1px solid #9e6a03;
+    border-radius: 8px;
+    padding: 10px 14px;
+    margin: 8px 0 12px;
+    color: #f2cc60;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  .state-dir-hint strong { color: #ffdf5d; }
   .ev {
     color: #6e7681;
     font-size: 12px;
@@ -1379,6 +1513,25 @@ _PAGE_HEAD = r"""<!doctype html>
   }
   .home-link:hover { color: #c9d1d9; border-color: #30363d; background: #161b22; }
   .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; }
+  /* Which project is this board serving? Two dashboards on adjacent ports used
+     to be pixel-identical: default_state_dir() hashes the caller's git root, so
+     one logical project can fork into two state dirs whose basenames differ
+     only by case. Styled like the per-row .job-project pill so the header tag
+     and the row tags read as the same kind of thing. Declared AFTER .mono so
+     the 11px pill size wins over .mono's 12px at equal specificity. */
+  .project-tag {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 11px;
+    color: #8b949e;
+    background: #21262d;
+    border-radius: 4px;
+    padding: 1px 6px;
+    white-space: nowrap;
+  }
+  /* The slot ships empty and is filled in from /api/meta. Without this, an
+     unreachable or pre-upgrade /api/meta would leave the pill's padding and
+     background showing as a permanent grey nub next to the brand. */
+  .project-tag:empty { display: none; }
   .swarm-hero { margin-bottom: 14px; }
   .swarm-hero-top {
     display: flex;
@@ -1584,6 +1737,11 @@ _PAGE_HEAD = r"""<!doctype html>
     header { flex-wrap: wrap; gap: 8px; padding: 8px 12px; box-shadow: none; }
     header h1 { font-size: 15px; }
     #updated, #jobid { display: none; }
+    /* #project deliberately NOT joined to the display:none rule above: on a
+       phone (dashboard --mobile, one tab per project over Tailscale) knowing
+       which project the board serves is the single most useful thing in the
+       header. Shrink it instead of hiding it. */
+    .project-tag { font-size: 10px; padding: 1px 5px; }
     .home-link { padding: 4px 8px; font-size: 12px; }
     /* Full-bleed content: cards run edge-to-edge like a native mobile list
        instead of floating in a centered, padded desktop column. */
@@ -1643,6 +1801,11 @@ _PAGE_HEAD = r"""<!doctype html>
 <header>
   <a href="/" class="home-link" id="home" title="All jobs">← Jobs</a>
   <h1>Puppetmaster</h1>
+  <!-- Filled in by loadMeta() from /api/meta; ships empty so a pre-upgrade or
+       unreachable /api/meta simply leaves no tag rather than a wrong one. A
+       SIBLING of #status on purpose -- loadIndex()/loadJob() replace #status
+       wholesale via outerHTML every 1.5s, which would wipe a nested tag. -->
+  <span class="project-tag mono" id="project" title=""></span>
   <span id="status" class="pill s-queued">…</span>
   <span class="muted mono" id="jobid"></span>
   <span class="muted" id="updated" style="margin-left:auto"></span>
@@ -1678,6 +1841,13 @@ let expandedSections = new Set();
 let expandedAlts = new Set();
 let taskFilter = "all";
 let lastContent = "";
+// The /api/meta payload (project identity), fetched once by loadMeta() at
+// bootstrap. Stays null if that fetch fails, which projectLabel() renders as "".
+let meta = null;
+// The /api/diagnostics `diagnosis` object (or null), fetched once by
+// loadDiagnostics() at bootstrap. Null covers every quiet path: healthy dir,
+// --all-projects board, non-loopback peer, pre-upgrade server, failed fetch.
+let stateDirDiagnosis = null;
 
 function pill(s) {
   return `<span class="pill s-${esc(s)}">${esc(s)}</span>`;
@@ -1724,6 +1894,12 @@ async function loadIndex() {
   const shown = jobFilter === "all" ? jobs : jobs.filter(j => j.status === jobFilter);
 
   let html = '<div class="card"><h2>Jobs</h2>';
+  // Right under the heading, NOT in the !shown.length branch below: the
+  // reported bad state dir held exactly ONE job, so the empty state never
+  // rendered and a hint placed there would have missed the actual incident.
+  // `jobs.length` (unfiltered) is the staleness comparison the server's count
+  // is comparable to -- a status filter shrinking the list is not new history.
+  html += stateDirHint(stateDirDiagnosis, jobs.length);
   html += '<div class="filter-bar">';
   html += `<button class="filter-btn ${jobFilter === "all" ? "active" : ""}" onclick="setJobFilter('all')">All (${jobs.length})</button>`;
   for (const status of Object.keys(counts).sort()) {
@@ -2206,6 +2382,55 @@ async function tick() {
   } catch (e) { /* keep polling; transient during writes */ }
 }
 
+// One-shot, deliberately NOT folded into tick(): which project a board serves
+// cannot change while the page is open, so polling it every 1.5s forever would
+// be pure noise. tick()'s bare catch is not an umbrella for anything called
+// outside it, so this owns its own rejection: a failed fetch, a non-2xx (a
+// pre-upgrade server 404s /api/meta) or malformed JSON all return without
+// touching the DOM, leaving the page exactly as the server shipped it.
+async function loadMeta() {
+  try {
+    const r = await fetch("/api/meta");
+    if (!r.ok) return;
+    meta = await r.json();
+  } catch (e) { return; }
+  applyMeta();
+}
+
+function applyMeta() {
+  const label = projectLabel(meta);
+  if (!label) return;
+  const el = document.getElementById("project");
+  if (el) {
+    // textContent, not innerHTML: with an explicit --state-dir the basename is
+    // filesystem-derived and never sanitised on the way out of /api/meta.
+    el.textContent = label;
+    el.title = label;
+  }
+  // Also the tab/window title, so two boards are distinguishable from the
+  // taskbar and from a browser's tab strip, not just from the header.
+  document.title = "Puppetmaster — " + label;
+}
+
+// Same one-shot bootstrap as loadMeta(), and for the same reason: which state
+// dir this board serves is a filesystem property that cannot change while the
+// page is open, and there is a directory walk behind the endpoint (TTL-cached
+// server-side, but still). Folding it into tick() would hit it every 1.5s
+// forever. It also owns its own rejection -- tick()'s bare catch is not an
+// umbrella for a sibling called from the bootstrap. No re-render here: the
+// running tick picks the banner up on its next pass, which keeps this off
+// loadIndex()'s promise chain entirely.
+async function loadDiagnostics() {
+  try {
+    const r = await fetch("/api/diagnostics");
+    if (!r.ok) return;
+    const data = await r.json();
+    stateDirDiagnosis = data && data.diagnosis ? data.diagnosis : null;
+  } catch (e) { return; }
+}
+
+loadMeta();
+loadDiagnostics();
 tick();
 setInterval(tick, 1500);
 </script>
@@ -2214,6 +2439,97 @@ setInterval(tick, 1500);
 """
 
 INDEX_HTML = _PAGE_HEAD + RENDERER_JS + _PAGE_APP_JS
+
+
+# How long a wrong-state-dir diagnosis is reused before the filesystem is
+# consulted again. The answer is a property of the on-disk layout, not of live
+# job state, so a stale-by-15s reading costs nothing — while a *fresh* reading
+# per request would put a directory walk behind an endpoint the page can hit on
+# every reload.
+_DIAGNOSTICS_TTL_SECONDS = 15.0
+
+
+def _state_dir_diagnosis(
+    state_dir: Optional[Union[Path, str]], *, all_projects: bool = False
+):
+    """The ``state_health`` diagnosis for ``state_dir`` when suspect, else None.
+
+    Returns None on **any** failure. Two callers, one guard, because in both
+    of them a raising diagnostic is worse than no diagnostic at all:
+
+    * In :func:`serve`, every statement after the bind runs inside an
+      ``except BaseException: httpd.server_close(); raise``, so an exception
+      escaping here would convert an already-listening dashboard into a
+      failed start.
+    * In :func:`make_handler`, the blanket ``except`` around ``do_GET`` turns
+      any error into a 500.
+
+    ``all_projects`` boards serve every project's store, so "you may be
+    pointed at the wrong one" cannot be true of them. ``state_dir=None`` is
+    what ``make_handler`` receives from several existing tests. Both short-
+    circuit without touching the filesystem.
+    """
+    if all_projects or state_dir is None:
+        return None
+    try:
+        # Imported lazily: this is an advisory path, and an ImportError on a
+        # partial install must not be able to reach the dashboard's bind.
+        from puppetmaster.state_health import diagnose_state_dir
+
+        diagnosis = diagnose_state_dir(state_dir=state_dir)
+        return diagnosis if diagnosis.suspect else None
+    except Exception:
+        return None
+
+
+def state_dir_warning(
+    state_dir: Optional[Union[Path, str]], *, all_projects: bool = False
+) -> Optional[str]:
+    """One stderr line for "this board may be serving the wrong project", or None.
+
+    Basenames only — ``short_warning`` guarantees that, and this string lands
+    in ``dashboard.err.log``, which users paste into issues verbatim.
+    """
+    diagnosis = _state_dir_diagnosis(state_dir, all_projects=all_projects)
+    if diagnosis is None:
+        return None
+    try:
+        from puppetmaster.state_health import short_warning
+
+        return short_warning(diagnosis)
+    except Exception:
+        return None
+
+
+def state_dir_diagnosis_payload(
+    state_dir: Optional[Union[Path, str]], *, all_projects: bool = False
+) -> dict:
+    """The ``/api/diagnostics`` body: ``{"diagnosis": {...}}`` or ``{"diagnosis": None}``.
+
+    Never raises, so the handler can serve a 200 with an absent diagnosis
+    instead of letting its blanket ``except`` turn a diagnostic hiccup into a
+    500 on a page that is otherwise fine.
+    """
+    diagnosis = _state_dir_diagnosis(state_dir, all_projects=all_projects)
+    if diagnosis is None:
+        return {"diagnosis": None}
+    try:
+        from puppetmaster.state_health import short_warning
+
+        candidate = diagnosis.candidates[0] if diagnosis.candidates else None
+        return {
+            "diagnosis": {
+                "suspect": True,
+                "verdict": diagnosis.verdict,
+                "project": Path(diagnosis.state_dir).name,
+                "jobs": diagnosis.active.job_count,
+                "candidate": None if candidate is None else candidate.state_dir.name,
+                "candidate_jobs": 0 if candidate is None else candidate.job_count,
+                "message": short_warning(diagnosis) or "",
+            }
+        }
+    except Exception:
+        return {"diagnosis": None}
 
 
 def make_handler(
@@ -2226,7 +2542,64 @@ def make_handler(
     from http.server import BaseHTTPRequestHandler
     from urllib.parse import parse_qs, urlparse
 
+    # Unreadable projects, kept in the handler's enclosing scope: {slug: error}
+    # is the *latest* state (so a project that recovers drops out), and
+    # `announced` is the once-per-process dedup for the stderr line. Dedup is
+    # not optional — /api/jobs is polled every 1.5s, so an un-deduped warning
+    # would emit ~40 identical lines a minute into dashboard.err.log forever.
+    # A dashboard process builds exactly one handler class, so "enclosing
+    # scope" and "per process" are the same lifetime here.
+    project_errors: dict[str, str] = {}
+    announced: set = set()
+
+    # Same enclosing-scope-is-per-process lifetime as `project_errors` above.
+    # `at` is monotonic seconds; `payload` is None only until the first probe,
+    # so a *negative* result caches too — an unremarkable state dir must not
+    # re-walk the projects dir on every reload either.
+    diagnostics_cache: dict = {"at": 0.0, "payload": None}
+
+    def _diagnostics_payload() -> dict:
+        """TTL-cached ``/api/diagnostics`` body. Never raises."""
+        now = time.monotonic()
+        cached = diagnostics_cache["payload"]
+        if cached is not None and (now - diagnostics_cache["at"]) < _DIAGNOSTICS_TTL_SECONDS:
+            return cached
+        payload = state_dir_diagnosis_payload(state_dir, all_projects=all_projects)
+        diagnostics_cache["at"] = now
+        diagnostics_cache["payload"] = payload
+        return payload
+
+    def _record_project_errors(snapshot: Any) -> None:
+        """Refresh `project_errors` and warn about newly seen failures.
+
+        stderr, specifically: `log_message` is silenced below, and stderr is
+        what the `--background` and MCP launch paths redirect into
+        dashboard.err.log — it is the only channel from this handler that
+        actually reaches a human.
+        """
+        errors = getattr(snapshot, "errors", None) or []
+        project_errors.clear()
+        for entry in errors:
+            project = entry.get("project", "?")
+            error = entry.get("error", "unknown error")
+            project_errors[project] = error
+            key = (project, error)
+            if key in announced:
+                continue
+            announced.add(key)
+            print(
+                f"dashboard: skipping project {project}: {error}",
+                file=sys.stderr,
+                flush=True,
+            )
+
     class _Handler(BaseHTTPRequestHandler):
+        # Exposed for callers/tests that want the current skip list without
+        # re-reading every project's store. Aliased under a different name
+        # because a class body cannot read a closure cell it also assigns
+        # (`x = x` there resolves to globals, not the enclosing scope).
+        skipped_projects = project_errors
+
         def log_message(self, *args: Any) -> None:  # silence default logging
             pass
 
@@ -2249,7 +2622,11 @@ def make_handler(
                     return
                 if path == "/api/jobs":
                     if all_projects:
-                        self._json(200, list_all_projects_snapshot(backend=backend))
+                        snapshot = list_all_projects_snapshot(backend=backend)
+                        _record_project_errors(snapshot)
+                        # Serializes as a bare JSON array — ProjectsSnapshot is
+                        # a list subclass, so the failures never hit the wire.
+                        self._json(200, snapshot)
                     else:
                         self._json(200, list_jobs_snapshot(store_factory()))
                     return
@@ -2295,6 +2672,30 @@ def make_handler(
                         "all_projects": all_projects,
                         "backend": backend,
                     })
+                    return
+                if path == "/api/diagnostics":
+                    # Deliberately NOT folded into /api/meta. That endpoint is
+                    # the identity contract every reuse check depends on:
+                    # `dashboard_identity` reads at most 65536 bytes under a
+                    # one-second socket timeout and json.loads the result, so
+                    # an oversized or slow body silently becomes None, which
+                    # reads as "not my dashboard" and makes the CLI and MCP
+                    # spawn duplicate servers. Putting a filesystem walk behind
+                    # /api/meta would risk exactly the duplicate-dashboard bug
+                    # that endpoint exists to prevent.
+                    payload = _diagnostics_payload()
+                    # Same loopback gate as /api/meta: a remote (--mobile) peer
+                    # learns only *that* something looks off — never a project
+                    # basename and never a job count, both of which disclose
+                    # the local filesystem and history.
+                    is_loopback = self.client_address[0] in ("127.0.0.1", "::1")
+                    if not is_loopback:
+                        self._json(
+                            200,
+                            {"diagnosis": None, "suspect": bool(payload.get("diagnosis"))},
+                        )
+                        return
+                    self._json(200, payload)
                     return
                 self._json(404, {"error": "not found"})
             except Exception:
@@ -2928,6 +3329,18 @@ def serve(
             print("Serving all projects (--all-projects mode)")
         else:
             print("Reading durable state from:", resolved)
+            # The surface the reporting user would have hit first — they ran
+            # the dashboard from a shell and got a confident "Reading durable
+            # state from: <the wrong dir>" with nothing to contradict it.
+            # stderr specifically, because the --background and MCP launch
+            # paths redirect stderr into dashboard.err.log, the only channel
+            # from a detached board that reaches a human. `state_dir_warning`
+            # swallows everything: an exception here would be caught by the
+            # `except BaseException` below and turn an already-listening
+            # dashboard into a failed start.
+            _warning = state_dir_warning(resolved, all_projects=all_projects)
+            if _warning:
+                print(f"WARNING: {_warning}", file=sys.stderr, flush=True)
         print("Press Ctrl-C to stop.")
         if open_browser:
             try:

--- a/puppetmaster/diagnostics.py
+++ b/puppetmaster/diagnostics.py
@@ -69,6 +69,7 @@ def run_doctor(root: Path, state_dir: Optional[Path] = None) -> list[Check]:
         _guard("CURSOR_API_KEY", lambda: _env_check("CURSOR_API_KEY")),
         _guard("OPENAI_API_KEY", lambda: _env_check("OPENAI_API_KEY")),
         _guard("sqlite-state", lambda: _sqlite_state_check(state_path / "state.sqlite3")),
+        _guard("state-identity", lambda: _state_identity_check(root, state_path)),
         _guard("git-status", lambda: _git_clean_check(root)),
         _guard("agent-rules", lambda: _agent_rules_check(root)),
     ]
@@ -971,6 +972,74 @@ def _sqlite_state_check(path: Path) -> Check:
             f"synchronous={expected_synchronous})"
         )
     return Check("sqlite-state", status, detail)
+
+
+def _state_identity_check(root: Path, state_dir: Path) -> Check:
+    """Warn when the active state dir looks like a fork of a nested repo's.
+
+    ``default_state_dir`` hashes ``git root or cwd``. Opening a session one
+    level above the real checkout makes the ``or`` fallback fire, splitting a
+    single logical project into two state dirs — the sqlite-state row above
+    then reports the near-empty wrong one as a benign "no local sqlite state
+    yet" optional. This row names the busy dir instead.
+
+    Detect-only: nothing here changes what any path resolves to. ``state_dir``
+    is passed explicitly by ``run_doctor``, which keeps the probe git-free —
+    doctor adds no git subprocess for this check.
+    """
+    from puppetmaster.state_health import (
+        GUARD_VERDICTS,
+        VERDICT_NEW,
+        VERDICT_NOT_PROJECT_SCOPED,
+        VERDICT_UNAVAILABLE,
+        diagnose_state_dir,
+    )
+
+    diagnosis = diagnose_state_dir(cwd=root, state_dir=state_dir)
+    evidence = list(diagnosis.evidence)
+
+    if diagnosis.verdict == VERDICT_UNAVAILABLE:
+        return Check(
+            "state-identity",
+            "warn",
+            f"state dir identity probe unavailable; {'; '.join(evidence)}",
+            evidence,
+        )
+
+    if diagnosis.suspect and diagnosis.candidates:
+        best = diagnosis.candidates[0]
+        return Check(
+            "state-identity",
+            "warn",
+            (
+                f"{state_dir.name} holds {diagnosis.active.job_count} job(s) but "
+                f"{best.state_dir.name} holds {best.job_count}; this folder is not a "
+                f"git repository, so state forked to a second project dir. "
+                f"Re-run from the git root ({best.workspace.name}), pass an explicit "
+                f"--state-dir, or use `puppetmaster projects` and "
+                f"`puppetmaster dashboard --all-projects` to reach the other history."
+            ),
+            evidence,
+        )
+
+    # A brand-new project has nothing to compare against yet, and an
+    # explicitly pinned state dir is out of scope by construction.
+    if diagnosis.verdict in {VERDICT_NEW, VERDICT_NOT_PROJECT_SCOPED}:
+        return Check(
+            "state-identity",
+            "optional",
+            f"{diagnosis.verdict}; {state_dir.name}",
+            evidence,
+        )
+
+    guarded = "guarded" if diagnosis.verdict in GUARD_VERDICTS else "healthy"
+    return Check(
+        "state-identity",
+        "ok",
+        f"{guarded}: {diagnosis.verdict}; {state_dir.name} "
+        f"({diagnosis.active.job_count} job(s))",
+        evidence,
+    )
 
 
 def _git_clean_check(root: Path) -> Check:

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -45,6 +45,7 @@ from puppetmaster.mcp_registry import (
 )
 from puppetmaster.run_id import reserve_run_logs
 from puppetmaster.state import resolve_state_dir, state_identity
+from puppetmaster.state_health import diagnose_state_dir, short_warning
 from puppetmaster.store_factory import create_store
 from puppetmaster.swarm_launch import (
     EARLY_JOB_ID_TIMEOUT_SECONDS,
@@ -3639,6 +3640,63 @@ def _spawn_dashboard_server(
             err_handle.close()
 
 
+# How to get *out* of a wrong-state-dir situation, appended to the dashboard
+# note whenever the diagnosis is suspect. Basenames only by construction —
+# there is no path in here at all, so this can never leak the caller's home
+# directory into an agent transcript.
+_STATE_DIR_REMEDY = (
+    "The state dir is derived from the git root of whatever cwd you sent, so a "
+    "cwd above the checkout gets its own separate store: pass the repo root as "
+    "cwd, or an explicit state_dir, or all_projects=true to serve every "
+    "project at once. `python -m puppetmaster projects` lists every project."
+)
+
+
+def _attach_state_dir_warning(body: JsonObject, args: JsonObject, state_dir: str) -> None:
+    """Fold a wrong-state-dir advisory into an *already successful* dashboard body.
+
+    The reported defect was silence: ``dashboard_serves`` only proves "the
+    server on this port serves the state dir I computed", never "that state dir
+    is where this workspace's jobs go", so ``run_dashboard`` reported
+    ``started=true`` with a cheerful note while serving an empty store.
+
+    Advisory, never fatal — the dashboard *did* start, so this sets no
+    ``isError`` and the whole probe sits inside one swallow-all guard: a
+    diagnostic that can fail a dashboard start is worse than no diagnostic.
+    The note is appended to rather than replaced (same shape as
+    ``_attach_codegraph_freshness`` folding a warning into an existing hint),
+    so the caller still learns whether the server was reused or freshly
+    started.
+    """
+    try:
+        diagnosis = diagnose_state_dir(cwd=cwd(args), state_dir=state_dir)
+        if not diagnosis.suspect:
+            return
+        message = short_warning(diagnosis)
+        candidate = diagnosis.candidates[0] if diagnosis.candidates else None
+    except Exception:
+        return
+    body.setdefault("warnings", []).append(
+        {
+            "kind": "state_dir_may_be_wrong",
+            "verdict": diagnosis.verdict,
+            # Basenames and counts only — `short_warning` guarantees the same
+            # for `message`. An absolute state dir path carries the username
+            # and the on-disk layout, and this body is quoted verbatim into
+            # agent transcripts.
+            "state_dir_name": Path(diagnosis.state_dir).name,
+            "active_jobs": diagnosis.active.job_count,
+            "candidate": None if candidate is None else candidate.state_dir.name,
+            "candidate_jobs": 0 if candidate is None else candidate.job_count,
+            "message": message
+            or "This state dir may not be where this workspace's jobs go.",
+        }
+    )
+    existing = body.get("note") or ""
+    warning_note = " ".join(part for part in (message, _STATE_DIR_REMEDY) if part)
+    body["note"] = (existing + " " + warning_note).strip() if existing else warning_note
+
+
 def run_dashboard(args: JsonObject) -> JsonObject:
     """Ensure a dashboard server is running and return its URL (and QR for phones).
 
@@ -3895,6 +3953,15 @@ def run_dashboard(args: JsonObject) -> JsonObject:
                 )
             )
         )
+
+    # Last, so the advisory lands on a body that is otherwise complete and
+    # already carries its note. Skipped for all_projects=true: that board
+    # serves every project's store, so "you may be pointed at the wrong one"
+    # is not a thing that can be true of it. The three early returns above
+    # (stop=true, no phone-reachable address, failed to start) never reach
+    # here on purpose — none of them is this problem.
+    if not all_projects:
+        _attach_state_dir_warning(body, args, state_dir)
     return {"content": [{"type": "text", "text": json.dumps(body, indent=2)}]}
 
 

--- a/puppetmaster/state.py
+++ b/puppetmaster/state.py
@@ -39,11 +39,31 @@ def resolve_state_dir(value: Optional[Union[Path, str]] = None, cwd: Optional[Pa
 
 
 def default_state_dir(cwd: Optional[Path] = None) -> Path:
-    workspace = _git_root(cwd or Path.cwd()) or (cwd or Path.cwd())
-    resolved = workspace.resolve()
+    base = cwd or Path.cwd()
+    workspace = _git_root(base) or base
+    return project_state_dir_for(workspace)
+
+
+def projects_root() -> Path:
+    """Return the parent directory holding every project-scoped state dir."""
+    return app_state_root() / "projects"
+
+
+def project_state_dir_for(workspace: Union[Path, str]) -> Path:
+    """Return the state dir ``workspace`` hashes to, without probing git.
+
+    Split out of ``default_state_dir`` so a caller can ask "what state dir
+    would *that* directory get?" for an arbitrary path — the identity check
+    in ``state_health`` needs to map a sibling repo to its state dir without
+    shelling out to git and without re-deriving the slug/digest formula.
+
+    ``workspace`` is used verbatim (already the git root, or the cwd when the
+    caller has no repo): this helper never resolves a repository for you.
+    """
+    resolved = Path(workspace).resolve()
     slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", resolved.name).strip("-") or "workspace"
     digest = hashlib.sha256(str(resolved).encode("utf-8")).hexdigest()[:12]
-    return app_state_root() / "projects" / f"{slug}-{digest}"
+    return projects_root() / f"{slug}-{digest}"
 
 
 def app_state_root() -> Path:
@@ -68,10 +88,10 @@ def list_project_state_dirs() -> list[Path]:
     helper lets callers iterate every known project to support cross-
     workspace job lookup without forcing users to memorize the hash.
     """
-    projects_root = app_state_root() / "projects"
-    if not projects_root.is_dir():
+    root = projects_root()
+    if not root.is_dir():
         return []
-    return sorted(p for p in projects_root.iterdir() if p.is_dir())
+    return sorted(p for p in root.iterdir() if p.is_dir())
 
 
 def find_state_dir_for_job(job_id: str) -> Optional[Path]:

--- a/puppetmaster/state_health.py
+++ b/puppetmaster/state_health.py
@@ -1,0 +1,395 @@
+"""Warn-only detection of a forked / wrong-project state directory.
+
+``state.default_state_dir`` hashes ``_git_root(cwd) or cwd``. When a session
+is opened one level *above* the real repository — say ``C:\\Projects\\foo``
+holding the actual checkout at ``C:\\Projects\\foo\\Foo`` — the ``or``
+fallback fires and hashes the wrapper folder instead. One logical project
+then silently forks into two state dirs: a near-empty one the dashboard
+shows, and the busy one every job actually wrote to.
+
+This module *detects* that split and nothing else. It never changes which
+directory anything resolves to (repointing a hash would orphan live job
+history); it only reports a verdict a caller can turn into a warning.
+
+Everything here is deliberately cheap: directory stats only, no SQLite, and
+no ``git`` subprocess when the caller supplies ``state_dir``.
+"""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Union
+
+from puppetmaster import state
+
+
+# Verdict vocabulary. Closed set: callers may switch on these and nothing
+# else ever comes out of ``diagnose_state_dir``.
+VERDICT_OK = "ok"
+VERDICT_NEW = "new"
+VERDICT_NOT_PROJECT_SCOPED = "not-project-scoped"
+VERDICT_WORKSPACE_IS_GIT_ROOT = "workspace-is-git-root"
+VERDICT_NOT_CWD_DERIVED = "not-cwd-derived"
+VERDICT_FORKED_PROJECT = "forked-project"
+VERDICT_NAME_TWIN = "name-twin"
+VERDICT_AMBIGUOUS = "ambiguous"
+VERDICT_UNAVAILABLE = "unavailable"
+
+VERDICTS = frozenset(
+    {
+        VERDICT_OK,
+        VERDICT_NEW,
+        VERDICT_NOT_PROJECT_SCOPED,
+        VERDICT_WORKSPACE_IS_GIT_ROOT,
+        VERDICT_NOT_CWD_DERIVED,
+        VERDICT_FORKED_PROJECT,
+        VERDICT_NAME_TWIN,
+        VERDICT_AMBIGUOUS,
+        VERDICT_UNAVAILABLE,
+    }
+)
+
+# Verdicts that mean "the user is probably looking at the wrong dir".
+SUSPECT_VERDICTS = frozenset(
+    {VERDICT_FORKED_PROJECT, VERDICT_NAME_TWIN, VERDICT_AMBIGUOUS}
+)
+
+# Verdicts reached by an early exit: a deliberate choice or a legitimately
+# separate project, never a fork.
+GUARD_VERDICTS = frozenset(
+    {
+        VERDICT_NOT_PROJECT_SCOPED,
+        VERDICT_WORKSPACE_IS_GIT_ROOT,
+        VERDICT_NOT_CWD_DERIVED,
+    }
+)
+
+# Child directories that are never a sibling checkout worth probing.
+_SKIP_CHILDREN = frozenset(
+    {"node_modules", "__pycache__", "venv", ".venv", "dist", "build", "target"}
+)
+
+# ``dashboard.py`` strips this same suffix to show a short project label; the
+# name-twin check compares the surviving slug.
+_DIGEST_SUFFIX_RE = re.compile(r"-[0-9a-f]{12}$")
+
+# "Materially busier" gates a candidate into the report at all.
+_MATERIAL_MULTIPLE = 2
+_MATERIAL_MARGIN = 2
+# "Far busier" is the stricter bar a same-name twin must clear before we
+# contradict an active dir that already has real history in it.
+_FAR_MULTIPLE = 5
+_FAR_MARGIN = 5
+
+_MAX_WARNING_CHARS = 140
+_MAX_EVIDENCE_CANDIDATES = 3
+
+
+@dataclass(frozen=True)
+class StateDirSummary:
+    """Cheap, SQLite-free activity snapshot of one project state dir."""
+
+    path: Path
+    job_count: int
+    last_activity: Optional[float]
+    truncated: bool = False
+
+
+@dataclass(frozen=True)
+class CandidateStateDir:
+    """A sibling checkout whose state dir looks like the real project."""
+
+    workspace: Path
+    state_dir: Path
+    job_count: int
+    last_activity: Optional[float]
+    name_twin: bool
+
+
+@dataclass(frozen=True)
+class StateDirDiagnosis:
+    """Verdict plus the evidence that produced it. Never raised, never acted on."""
+
+    verdict: str
+    state_dir: Path
+    active: StateDirSummary
+    candidates: tuple[CandidateStateDir, ...]
+    evidence: tuple[str, ...]
+
+    @property
+    def suspect(self) -> bool:
+        return self.verdict in SUSPECT_VERDICTS
+
+
+def summarize_project_state_dir(
+    path: Union[Path, str], *, max_jobs: int = 4096
+) -> StateDirSummary:
+    """Summarize ``path`` by counting ``jobs/*`` directories and their mtimes.
+
+    Deliberately does **not** open the store. The SQLite store keeps each
+    job on disk under ``<state_dir>/jobs/<job_id>/``, so a directory listing
+    is enough to tell how busy a project is — and it avoids spinning up the
+    WAL writer just to answer a diagnostic question (same rationale as
+    ``state.find_state_dir_for_job``).
+
+    Never raises: an unreadable or missing directory yields zero jobs and no
+    last-activity timestamp.
+    """
+    root = Path(path)
+    jobs_dir = root / "jobs"
+    count = 0
+    latest: Optional[float] = None
+    truncated = False
+    try:
+        with os.scandir(jobs_dir) as entries:
+            for entry in entries:
+                if count >= max_jobs:
+                    truncated = True
+                    break
+                try:
+                    if not entry.is_dir():
+                        continue
+                    mtime = entry.stat().st_mtime
+                except OSError:
+                    continue
+                count += 1
+                if latest is None or mtime > latest:
+                    latest = mtime
+    except OSError:
+        return StateDirSummary(path=root, job_count=0, last_activity=None)
+    return StateDirSummary(
+        path=root, job_count=count, last_activity=latest, truncated=truncated
+    )
+
+
+def diagnose_state_dir(
+    cwd: Optional[Union[Path, str]] = None,
+    state_dir: Optional[Union[Path, str]] = None,
+    *,
+    near_empty_max: int = 1,
+    max_children: int = 512,
+) -> StateDirDiagnosis:
+    """Decide whether the active state dir is a fork of a nested repo's dir.
+
+    Passing ``state_dir`` keeps the whole probe git-free: only filesystem
+    stats are consulted. Omitting it resolves the default, which does shell
+    out to ``git`` exactly as ``state.default_state_dir`` always has.
+    """
+    base = Path(cwd) if cwd is not None else Path.cwd()
+    try:
+        return _diagnose(base, state_dir, near_empty_max, max_children)
+    except OSError as exc:
+        active = Path(state_dir) if state_dir is not None else base
+        return StateDirDiagnosis(
+            verdict=VERDICT_UNAVAILABLE,
+            state_dir=active,
+            active=StateDirSummary(path=active, job_count=0, last_activity=None),
+            candidates=(),
+            evidence=(
+                f"verdict:{VERDICT_UNAVAILABLE}",
+                f"error:{type(exc).__name__}: {exc}",
+            ),
+        )
+
+
+def short_warning(diagnosis: StateDirDiagnosis) -> Optional[str]:
+    """One sentence, basenames only, for a status line. None when not suspect.
+
+    Never emits an absolute path: the caller decides how much of the
+    filesystem to reveal, and this string is safe to print anywhere.
+    """
+    if not diagnosis.suspect or not diagnosis.candidates:
+        return None
+    best = diagnosis.candidates[0]
+    sentence = (
+        f"{diagnosis.state_dir.name} has {diagnosis.active.job_count} job(s) "
+        f"but nested repo {best.workspace.name} has {best.job_count} — "
+        f"not a git repo here; see puppetmaster projects."
+    )
+    if len(sentence) > _MAX_WARNING_CHARS:
+        sentence = sentence[: _MAX_WARNING_CHARS - 1].rstrip() + "\u2026"
+    return sentence
+
+
+def _diagnose(
+    base: Path,
+    state_dir: Optional[Union[Path, str]],
+    near_empty_max: int,
+    max_children: int,
+) -> StateDirDiagnosis:
+    pinned = state_dir is not None
+    active_path = Path(state_dir) if pinned else state.default_state_dir(base)
+    active = summarize_project_state_dir(active_path)
+
+    # Guard 1 -- NOT-PROJECT-SCOPED. An explicit --state-dir or a
+    # PUPPETMASTER_STATE_DIR env var is a deliberate choice; only the hashed
+    # projects/ layout can fork.
+    if not _same_path(active_path.parent, state.projects_root()):
+        return StateDirDiagnosis(
+            verdict=VERDICT_NOT_PROJECT_SCOPED,
+            state_dir=active_path,
+            active=active,
+            candidates=(),
+            evidence=(
+                f"verdict:{VERDICT_NOT_PROJECT_SCOPED}",
+                f"active:{active_path.name}",
+                f"active_jobs:{active.job_count}",
+                f"pinned:{str(pinned).lower()}",
+            ),
+        )
+
+    # Guard 2 -- WORKSPACE-IS-GIT-ROOT. When cwd *is* the repo root its state
+    # dir is correct by definition, and a nested repo (submodule, vendored
+    # checkout, worktree) is legitimately its own project.
+    if (base / ".git").exists():
+        return StateDirDiagnosis(
+            verdict=VERDICT_WORKSPACE_IS_GIT_ROOT,
+            state_dir=active_path,
+            active=active,
+            candidates=(),
+            evidence=(
+                f"verdict:{VERDICT_WORKSPACE_IS_GIT_ROOT}",
+                f"active:{active_path.name}",
+                f"active_jobs:{active.job_count}",
+                "cwd_is_git_root:true",
+            ),
+        )
+
+    expected = state.project_state_dir_for(base)
+
+    # Guard 3 -- NOT-CWD-DERIVED. Exact, git-free proof that the or-fallback
+    # actually fired. Stays quiet when cwd is a subdirectory of a repo (the
+    # dir came from the git root, not from cwd) and when a job-ownership
+    # pivot picked the dir.
+    if active_path.name != expected.name:
+        return StateDirDiagnosis(
+            verdict=VERDICT_NOT_CWD_DERIVED,
+            state_dir=active_path,
+            active=active,
+            candidates=(),
+            evidence=(
+                f"verdict:{VERDICT_NOT_CWD_DERIVED}",
+                f"active:{active_path.name}",
+                f"active_jobs:{active.job_count}",
+                f"expected_for_cwd:{expected.name}",
+            ),
+        )
+
+    candidates, scanned, truncated = _scan_siblings(base, active, max_children)
+
+    # Guard 4 / 6 -- a populated active dir is fine unless a same-slug twin
+    # is *far* busier. near_empty_max defaults to 1 because the real incident
+    # had exactly one stale job in the wrong dir; a "zero jobs" rule would
+    # have missed it entirely.
+    populated = active.job_count > near_empty_max
+    twins = tuple(c for c in candidates if c.name_twin)
+    if twins:
+        verdict = VERDICT_NAME_TWIN
+    elif populated:
+        verdict = VERDICT_OK
+    elif not candidates:
+        verdict = VERDICT_NEW
+    elif len(candidates) == 1:
+        verdict = VERDICT_FORKED_PROJECT
+    else:
+        verdict = VERDICT_AMBIGUOUS
+
+    evidence = [
+        f"verdict:{verdict}",
+        f"active:{active_path.name}",
+        f"active_jobs:{active.job_count}",
+        f"cwd:{base.name}",
+        "cwd_is_git_root:false",
+        f"expected_for_cwd:{expected.name}",
+        f"scanned_children:{scanned}",
+        f"candidates:{len(candidates)}",
+    ]
+    for candidate in candidates[:_MAX_EVIDENCE_CANDIDATES]:
+        evidence.append(f"candidate:{candidate.state_dir.name}={candidate.job_count}")
+    if truncated:
+        evidence.append(f"truncated:{max_children}")
+    if twins:
+        evidence.append(f"name_twin:{twins[0].state_dir.name}")
+
+    return StateDirDiagnosis(
+        verdict=verdict,
+        state_dir=active_path,
+        active=active,
+        candidates=candidates,
+        evidence=tuple(evidence),
+    )
+
+
+def _scan_siblings(
+    base: Path, active: StateDirSummary, max_children: int
+) -> tuple[tuple[CandidateStateDir, ...], int, bool]:
+    """Depth-1 scan of ``base`` for nested checkouts with busier state dirs."""
+    found: list[CandidateStateDir] = []
+    scanned = 0
+    truncated = False
+    active_slug = _project_slug(active.path.name).lower()
+    try:
+        with os.scandir(base) as entries:
+            for entry in entries:
+                if scanned >= max_children:
+                    truncated = True
+                    break
+                scanned += 1
+                name = entry.name
+                if name.startswith(".") or name in _SKIP_CHILDREN:
+                    continue
+                try:
+                    if not entry.is_dir():
+                        continue
+                except OSError:
+                    continue
+                child = Path(entry.path)
+                # A .git *file* means a worktree or submodule; both count.
+                if not (child / ".git").exists():
+                    continue
+                candidate_dir = state.project_state_dir_for(child)
+                summary = summarize_project_state_dir(candidate_dir)
+                material = _busier(
+                    summary.job_count,
+                    active.job_count,
+                    _MATERIAL_MULTIPLE,
+                    _MATERIAL_MARGIN,
+                )
+                if not material:
+                    continue
+                far = _busier(
+                    summary.job_count, active.job_count, _FAR_MULTIPLE, _FAR_MARGIN
+                )
+                twin = far and _project_slug(candidate_dir.name).lower() == active_slug
+                found.append(
+                    CandidateStateDir(
+                        workspace=child,
+                        state_dir=candidate_dir,
+                        job_count=summary.job_count,
+                        last_activity=summary.last_activity,
+                        name_twin=twin,
+                    )
+                )
+    except OSError:
+        # A partially-read listing is still usable evidence; report what we got.
+        pass
+    found.sort(key=lambda c: (-c.job_count, c.state_dir.name))
+    return tuple(found), scanned, truncated
+
+
+def _busier(candidate_jobs: int, active_jobs: int, multiple: int, margin: int) -> bool:
+    if candidate_jobs <= 0:
+        return False
+    return candidate_jobs >= max(active_jobs * multiple, active_jobs + margin)
+
+
+def _project_slug(dir_name: str) -> str:
+    return _DIGEST_SUFFIX_RE.sub("", dir_name) or dir_name
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    return os.path.normcase(os.path.normpath(str(left))) == os.path.normcase(
+        os.path.normpath(str(right))
+    )

--- a/tests/test_dashboard_project_aggregate.py
+++ b/tests/test_dashboard_project_aggregate.py
@@ -1,0 +1,328 @@
+"""`--all-projects` aggregation must report unreadable projects, not erase them.
+
+`list_all_projects_snapshot` walks every project state dir on the machine. Its
+per-project body used to be wrapped in a bare ``except Exception: continue``, so
+a single locked/corrupt ``state.sqlite3`` — or one job row a newer schema wrote
+and this build cannot decode — removed that project's *entire* job list from the
+board with no trace anywhere: no stderr line, no wire field, no log. The board
+looked complete while showing less than everything. The defect is the silence.
+
+These tests pin the fix from three angles:
+
+* **reported, not dropped** — a healthy project's rows still come back while the
+  broken one shows up in ``snapshot.errors`` with its slug and exception type.
+  The corruption here is *real* (garbage bytes over the sqlite file, producing a
+  genuine ``sqlite3.DatabaseError``), never a patched-in fake, because a mocked
+  error proves the ``except`` clause is spelled right and nothing more.
+* **the wire contract is unchanged** — ``/api/jobs`` is a bare JSON array and the
+  page does ``for (const j of jobs)`` over the top level, so the failures ride on
+  a ``list`` *subclass* attribute and must never reach the wire.
+* **genuine bugs still crash** — ``AttributeError`` and friends are not "this
+  project is unreadable", they are "this code is wrong", and must propagate.
+
+A new file rather than an addition to tests/test_puppetmaster.py: that file is
+huge and concurrently edited by other workstreams around the same lines.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import unittest
+import urllib.request
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from puppetmaster.dashboard import (
+    ProjectsSnapshot,
+    list_all_projects_snapshot,
+    project_slug,
+    serve,
+)
+from puppetmaster.store_factory import create_store
+
+# Deliberately not a valid SQLite header ("SQLite format 3\000"), and long
+# enough that sqlite reads a full page before deciding: opening this raises
+# sqlite3.DatabaseError("file is not a database").
+_GARBAGE = b"this is not a database, it is a pile of bytes\n" * 128
+
+HEALTHY_DIR = "alpha-0123456789ab"
+CORRUPT_DIR = "beta-ba9876543210"
+
+
+class _Fixture:
+    """A temp `app_state_root()` holding one healthy and one corrupt project."""
+
+    def __init__(self, test: unittest.TestCase) -> None:
+        tmp = TemporaryDirectory()
+        test.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        self.projects = self.root / "projects"
+
+        self.healthy_dir = self.projects / HEALTHY_DIR
+        store = create_store("sqlite", self.healthy_dir)
+        store.init()
+        self.job_ids = [
+            store.create_job("alpha goal one").id,
+            store.create_job("alpha goal two").id,
+        ]
+
+        # Corrupt the second project for real. Built by hand rather than
+        # init()-then-clobber so no live handle or -wal sidecar is left over to
+        # change which error sqlite raises (Windows keeps a mandatory lock on
+        # an open DB file).
+        self.corrupt_dir = self.projects / CORRUPT_DIR
+        self.corrupt_dir.mkdir(parents=True)
+        (self.corrupt_dir / "state.sqlite3").write_bytes(_GARBAGE)
+
+    def patch_state_root(self):
+        """Point `list_project_state_dirs` at this fixture only.
+
+        `app_state_root` is patched (not `list_project_state_dirs`) so the real
+        directory walk runs — it is the code under test's actual input.
+        """
+        return patch("puppetmaster.state.app_state_root", return_value=self.root)
+
+
+class ProjectSlugTests(unittest.TestCase):
+    """`project_slug` replaced an inlined `re.sub(r"-[0-9a-f]{12}$", ...)`;
+    output must be byte-identical to that strip."""
+
+    def test_matches_the_previous_inline_strip(self) -> None:
+        import re
+
+        for name in (
+            "alpha-0123456789ab",
+            "no-digest",
+            "beta-ba9876543210",
+            # Boundary cases the 12-hex assumption must keep treating as
+            # "no digest here": 11 and 13 hex chars, and non-hex.
+            "gamma-0123456789a",
+            "gamma-0123456789abc",
+            "delta-0123456789zz",
+            "0123456789ab",
+        ):
+            with self.subTest(name=name):
+                previous = re.sub(r"-[0-9a-f]{12}$", "", name) or name
+                self.assertEqual(project_slug(name), previous)
+
+    def test_strips_digest_and_leaves_plain_names_alone(self) -> None:
+        self.assertEqual(project_slug("alpha-0123456789ab"), "alpha")
+        self.assertEqual(project_slug("no-digest"), "no-digest")
+
+
+class UnreadableProjectIsReportedTests(unittest.TestCase):
+    def test_corrupt_project_is_reported_not_dropped(self) -> None:
+        fixture = _Fixture(self)
+        with fixture.patch_state_root():
+            snapshot = list_all_projects_snapshot()
+
+        # The healthy project's jobs are still all there...
+        by_id = {row["id"]: row for row in snapshot}
+        for job_id in fixture.job_ids:
+            self.assertIn(job_id, by_id)
+            self.assertEqual(by_id[job_id]["project"], "alpha")
+
+        # ...and the broken one is named out loud instead of vanishing.
+        self.assertTrue(snapshot.partial)
+        self.assertEqual([e["project"] for e in snapshot.errors], ["beta"])
+        message = snapshot.errors[0]["error"]
+        self.assertRegex(message, r"^\w*Error: .+")
+
+        # Specifically the real sqlite failure, not some incidental OSError.
+        # Compared against the exception the same corrupt file raises when read
+        # directly, so this stays exact across sqlite/CPython wording changes.
+        with self.assertRaises(sqlite3.Error) as raised:
+            create_store("sqlite", fixture.corrupt_dir).list_jobs()
+        expected = f"{type(raised.exception).__name__}: {raised.exception}"
+        self.assertEqual(message, expected)
+
+    def test_the_corruption_is_real_not_mocked(self) -> None:
+        """Guards the fixture itself: if a future sqlite/store change stopped
+        raising here, the test above would pass vacuously (zero errors, zero
+        assertions about them) while proving nothing."""
+        fixture = _Fixture(self)
+        store = create_store("sqlite", fixture.corrupt_dir)
+        with self.assertRaises(sqlite3.DatabaseError):
+            store.list_jobs()
+
+    def test_all_healthy_projects_report_no_errors(self) -> None:
+        """The reporting path must stay quiet when nothing is broken."""
+        fixture = _Fixture(self)
+        (fixture.corrupt_dir / "state.sqlite3").unlink()
+        create_store("sqlite", fixture.corrupt_dir).init()
+        with fixture.patch_state_root():
+            snapshot = list_all_projects_snapshot()
+        self.assertEqual(snapshot.errors, [])
+        self.assertFalse(snapshot.partial)
+
+
+class WireContractTests(unittest.TestCase):
+    """`/api/jobs` is a bare JSON array; the page iterates the top level and an
+    existing test builds `{row["id"]: row for row in rows}`. Reshaping this into
+    a dict would break both, so the errors must ride on an attribute."""
+
+    def test_snapshot_is_a_list_that_serializes_as_a_bare_array(self) -> None:
+        fixture = _Fixture(self)
+        with fixture.patch_state_root():
+            snapshot = list_all_projects_snapshot()
+
+        self.assertIsInstance(snapshot, list)
+        self.assertIsInstance(snapshot, ProjectsSnapshot)
+        self.assertTrue(snapshot.errors, "fixture should have produced a failure")
+
+        wire = json.loads(json.dumps(snapshot))
+        self.assertIs(type(wire), list)
+        self.assertEqual(len(wire), len(snapshot))
+        for row in wire:
+            self.assertIsInstance(row, dict)
+            self.assertTrue(
+                {"id", "goal", "status", "created_at", "completed_at", "project"}
+                <= set(row)
+            )
+        # The failures are diagnostics, not payload: nothing leaks onto the wire.
+        self.assertNotIn("errors", json.dumps(snapshot))
+
+    def test_iterating_the_top_level_still_works(self) -> None:
+        """Exactly what the page's `for (const j of jobs)` and
+        tests/test_puppetmaster.py's `{row["id"]: row for row in rows}` do."""
+        fixture = _Fixture(self)
+        with fixture.patch_state_root():
+            snapshot = list_all_projects_snapshot()
+        self.assertEqual(
+            sorted({row["id"]: row for row in snapshot}), sorted(fixture.job_ids)
+        )
+
+
+class GenuineBugsPropagateTests(unittest.TestCase):
+    def test_attribute_error_is_not_swallowed(self) -> None:
+        """AttributeError is a bug in this process, not an unreadable project.
+        The old bare `except Exception` laundered it into "that project has no
+        jobs" -- so a typo'd attribute silently emptied the whole board."""
+        fixture = _Fixture(self)
+        with fixture.patch_state_root(), patch(
+            "puppetmaster.dashboard._job_snapshot_meta",
+            side_effect=AttributeError("boom"),
+        ):
+            with self.assertRaises(AttributeError) as ctx:
+                list_all_projects_snapshot()
+        self.assertIn("boom", str(ctx.exception))
+
+    def test_import_error_is_not_swallowed(self) -> None:
+        fixture = _Fixture(self)
+        with fixture.patch_state_root(), patch(
+            "puppetmaster.dashboard._job_snapshot_meta",
+            side_effect=ImportError("no such module"),
+        ):
+            with self.assertRaises(ImportError):
+                list_all_projects_snapshot()
+
+
+class SkipWarningReachesStderrTests(unittest.TestCase):
+    """`log_message` is silenced in this handler and stderr is what the
+    `--background` / MCP launch paths capture into dashboard.err.log, so stderr
+    is the only channel from here that reaches a human. It must also dedupe:
+    /api/jobs is polled every 1.5s."""
+
+    def _make_handler(self, fixture):
+        from puppetmaster.dashboard import make_handler
+
+        return make_handler(
+            lambda: create_store("sqlite", fixture.healthy_dir),
+            all_projects=True,
+            backend="sqlite",
+            state_dir=fixture.healthy_dir,
+        )
+
+    def _poll(self, handler) -> list:
+        """Run the handler's /api/jobs all-projects branch without a socket.
+
+        BaseHTTPRequestHandler.__init__ *is* the request loop, so it cannot be
+        instantiated without a live connection; drive do_GET on a bare instance
+        with the response plumbing captured instead. The captured status is
+        asserted so do_GET's own `except Exception -> 500` can never make a
+        broken poll look like a successful one.
+        """
+        sent: list = []
+        instance = handler.__new__(handler)
+        instance.path = "/api/jobs"
+        instance.client_address = ("127.0.0.1", 0)
+        instance._send = lambda code, body, content_type: sent.append((code, body))
+        instance.do_GET()
+        self.assertEqual([code for code, _ in sent], [200])
+        return json.loads(sent[0][1])
+
+    def test_new_failures_warn_once_and_are_deduped(self) -> None:
+        import io
+        import sys
+
+        fixture = _Fixture(self)
+        handler = self._make_handler(fixture)
+
+        buffer = io.StringIO()
+        with fixture.patch_state_root(), patch.object(sys, "stderr", buffer):
+            # Three polls -- what the page's 1.5s interval produces in ~5s.
+            for _ in range(3):
+                rows = self._poll(handler)
+                self.assertEqual(len(rows), len(fixture.job_ids))
+
+        lines = [ln for ln in buffer.getvalue().splitlines() if ln.strip()]
+        self.assertEqual(len(lines), 1, f"expected one deduped warning, got {lines}")
+        self.assertRegex(lines[0], r"^dashboard: skipping project beta: \w*Error: .+")
+
+    def test_skipped_projects_dict_tracks_latest_state(self) -> None:
+        import io
+        import sys
+
+        fixture = _Fixture(self)
+        handler = self._make_handler(fixture)
+
+        buffer = io.StringIO()
+        with fixture.patch_state_root(), patch.object(sys, "stderr", buffer):
+            self._poll(handler)
+            self.assertIn("beta", handler.skipped_projects)
+            self.assertRegex(handler.skipped_projects["beta"], r"^\w*Error: .+")
+
+            # Heal the project: the latest-state dict must drop it, so a
+            # recovered project stops being reported as skipped.
+            (fixture.corrupt_dir / "state.sqlite3").unlink()
+            create_store("sqlite", fixture.corrupt_dir).init()
+            self._poll(handler)
+            self.assertEqual(handler.skipped_projects, {})
+
+
+class ApiJobsStaysAJsonArrayTests(unittest.TestCase):
+    """End to end over a real socket: a corrupt project in the walk must not
+    change the shape (or the status code) of /api/jobs."""
+
+    def test_api_jobs_returns_a_json_array_with_a_broken_project_present(self) -> None:
+        fixture = _Fixture(self)
+        with fixture.patch_state_root():
+            httpd = serve(
+                fixture.healthy_dir,
+                backend="sqlite",
+                host="127.0.0.1",
+                port=0,
+                open_browser=False,
+                serve_forever=False,
+                all_projects=True,
+            )
+            self.addCleanup(httpd.server_close)
+            threading.Thread(target=httpd.serve_forever, daemon=True).start()
+            self.addCleanup(httpd.shutdown)
+            port = httpd.server_address[1]
+            url = f"http://127.0.0.1:{port}/api/jobs"
+            with urllib.request.urlopen(url) as resp:
+                self.assertEqual(resp.status, 200)
+                payload = json.loads(resp.read())
+
+        self.assertIs(type(payload), list)
+        self.assertEqual(
+            sorted(row["id"] for row in payload), sorted(fixture.job_ids)
+        )
+        self.assertEqual({row["project"] for row in payload}, {"alpha"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dashboard_project_identity.py
+++ b/tests/test_dashboard_project_identity.py
@@ -1,0 +1,295 @@
+"""The dashboard header must say which project the board is serving.
+
+The bug this closes: ``default_state_dir()`` hashes the git root of the
+caller's cwd, so a session opened at ``C:\\Projects\\puppetmaster`` (which is
+not itself a git repo -- the repo is one level down) took the fallback branch
+and forked ONE logical project into two state dirs,
+``projects\\puppetmaster-c3177e6032c4`` (1 stale job) and
+``projects\\Puppetmaster-b92145e840c8`` (24 jobs). Two dashboards then came up
+on :8787 and :8788, pixel-identical, with nothing on screen to say which was
+which -- so "where did my jobs go?" had no answer you could read off the page.
+
+/api/meta already carried the identity on the wire (see
+tests/test_dashboard_ports.py); this exercises the last mile -- rendering it in
+the header.
+
+A new file, deliberately: tests/test_puppetmaster.py is enormous and its
+existing node harness (``test_renderer_js_neutralizes_xss_and_preserves_digits``)
+is left untouched, so the purity harness below is additive rather than an edit
+to a hot, contended file.
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import threading
+import unittest
+import urllib.request
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from puppetmaster.dashboard import (
+    _PAGE_APP_JS,
+    _PAGE_HEAD,
+    RENDERER_JS,
+    serve,
+)
+from puppetmaster.store_factory import create_store
+
+MIDDLE_DOT = "\u00b7"
+
+
+def _store_dir(root) -> Path:
+    """An initialised sqlite state dir -- there are no shared fixtures in
+    tests/conftest.py, so each test builds its own."""
+    store_dir = Path(root) / ".puppetmaster"
+    create_store("sqlite", store_dir).init()
+    return store_dir
+
+
+def _mobile_block() -> str:
+    """The @media (max-width: 640px) body with /* comments */ stripped, so the
+    narrow-viewport rules can be asserted on without matching the desktop rules
+    of the same name -- or a prose mention of a selector inside a comment."""
+    start = _PAGE_HEAD.index("@media (max-width: 640px)")
+    block = _PAGE_HEAD[start : _PAGE_HEAD.index("</style>", start)]
+    return re.sub(r"/\*.*?\*/", "", block, flags=re.DOTALL)
+
+
+class HeaderSlotTests(unittest.TestCase):
+    def test_project_slot_sits_before_the_right_edge_spacer(self) -> None:
+        """#updated carries the inline ``margin-left:auto`` that pushes it to
+        the right edge, so anything after it lands on the far side of the gap.
+        The project tag belongs in the left cluster, next to the brand."""
+        self.assertIn('id="project"', _PAGE_HEAD)
+        self.assertLess(
+            _PAGE_HEAD.index('id="project"'),
+            _PAGE_HEAD.index('id="updated"'),
+        )
+        self.assertGreater(
+            _PAGE_HEAD.index('id="project"'),
+            _PAGE_HEAD.index("<h1>Puppetmaster</h1>"),
+        )
+
+    def test_project_slot_is_a_sibling_of_status_not_nested_in_it(self) -> None:
+        """loadIndex()/loadJob() replace #status wholesale via ``outerHTML``
+        every 1.5s. A tag nested inside it would be wiped on the first poll."""
+        header = _PAGE_HEAD[
+            _PAGE_HEAD.index("<header>") : _PAGE_HEAD.index("</header>")
+        ]
+        project_tag = re.search(r'<span[^>]*id="project"[^>]*>\s*</span>', header)
+        self.assertIsNotNone(project_tag, header)
+        self.assertNotIn('id="status"', project_tag.group(0))
+
+    def test_project_tag_has_its_own_pill_style(self) -> None:
+        self.assertIn(".project-tag", _PAGE_HEAD)
+        # Declared after .mono: equal specificity, so source order decides
+        # which font-size wins.
+        self.assertGreater(_PAGE_HEAD.index(".project-tag"), _PAGE_HEAD.index(".mono "))
+
+
+class MobileHeaderTests(unittest.TestCase):
+    def test_mobile_shrinks_the_project_tag_instead_of_hiding_it(self) -> None:
+        """On a phone the project tag is the most useful thing in the header
+        (one tab per project over Tailscale), so it must not join #updated and
+        #jobid in the display:none rule -- it gets a smaller font instead."""
+        block = _mobile_block()
+        hidden = [
+            line for line in block.splitlines() if re.search(r"display:\s*none", line)
+        ]
+        self.assertTrue(hidden, "mobile block no longer hides anything")
+        for line in hidden:
+            self.assertNotIn("#project", line)
+            self.assertNotIn(".project-tag", line)
+        self.assertIsNotNone(
+            re.search(r"\.project-tag\s*\{[^}]*font-size", block),
+            "mobile block must shrink .project-tag",
+        )
+
+    def test_the_only_intentional_hide_is_the_empty_slot_guard(self) -> None:
+        """One hide IS intended, in the desktop rules: the slot ships empty, so
+        without `:empty` the pill's padding/background would show as a grey nub
+        whenever /api/meta is unreachable. Pin it, so a future "hide #project on
+        mobile" edit can't hide behind it."""
+        desktop = _PAGE_HEAD[: _PAGE_HEAD.index("@media (max-width: 640px)")]
+        self.assertIn(".project-tag:empty { display: none; }", desktop)
+        # ...and that guard is the only place any project selector is hidden.
+        stripped = re.sub(r"/\*.*?\*/", "", _PAGE_HEAD, flags=re.DOTALL)
+        hides = [
+            line
+            for line in stripped.splitlines()
+            if re.search(r"display:\s*none", line)
+            and ("#project" in line or ".project-tag" in line)
+        ]
+        self.assertEqual([line.strip() for line in hides],
+                         [".project-tag:empty { display: none; }"])
+
+
+class ClientWiringTests(unittest.TestCase):
+    def test_meta_is_fetched_once_at_bootstrap_not_polled(self) -> None:
+        for needle in (
+            "/api/meta",
+            "function loadMeta",
+            "loadMeta();",
+            'getElementById("project")',
+            "document.title",
+        ):
+            self.assertIn(needle, _PAGE_APP_JS, needle)
+        # The one-shot call sits in the bootstrap seam after tick()'s
+        # definition -- if it had been folded INTO tick() it would re-fetch
+        # immutable identity every 1.5s forever.
+        self.assertGreater(
+            _PAGE_APP_JS.index("loadMeta();"),
+            _PAGE_APP_JS.index("async function tick()"),
+        )
+        self.assertEqual(_PAGE_APP_JS.count("loadMeta();"), 1)
+
+    def test_load_meta_owns_its_own_failure(self) -> None:
+        """tick()'s bare catch is not an umbrella for a sibling called from the
+        bootstrap, so loadMeta must guard itself: try/catch around the fetch
+        AND an r.ok check (a pre-upgrade server 404s /api/meta). Sliced to
+        loadMeta's own body so this can never accidentally see tick()'s catch
+        or applyMeta's guards."""
+        start = _PAGE_APP_JS.index("async function loadMeta")
+        end = _PAGE_APP_JS.index("function applyMeta", start)
+        body = _PAGE_APP_JS[start:end]
+        for needle in ("try {", "catch", "r.ok"):
+            self.assertIn(needle, body, f"{needle} missing from loadMeta body")
+
+    def test_project_tag_is_set_as_text_not_markup(self) -> None:
+        """With an explicit --state-dir the basename is filesystem-derived and
+        /api/meta never sanitises it, so the tag must go in as text."""
+        start = _PAGE_APP_JS.index("function applyMeta")
+        body = _PAGE_APP_JS[start:]
+        # // comments are stripped first: applyMeta deliberately NAMES innerHTML
+        # in prose, to record why it is avoided, so a raw substring scan would
+        # fire on the explanation. Strip the prose, then look for the thing that
+        # is actually dangerous -- an assignment -- rather than the mention.
+        code = re.sub(r"//.*", "", body)
+        self.assertIn("textContent", code)
+        self.assertIsNone(
+            re.search(r"innerHTML\s*=", code),
+            "applyMeta assigns to innerHTML",
+        )
+        self.assertIn("if (el)", code)
+
+
+class ServedHtmlTests(unittest.TestCase):
+    def _serve(self, state_dir: Path) -> int:
+        httpd = serve(
+            state_dir,
+            backend="sqlite",
+            host="127.0.0.1",
+            port=0,
+            open_browser=False,
+            serve_forever=False,
+        )
+        # addCleanup is LIFO, so server_close must be registered FIRST for
+        # shutdown to run before it -- closing the listening socket out from
+        # under a blocked serve_forever is the wrong order (same registration
+        # order as tests/test_dashboard_ports.py).
+        self.addCleanup(httpd.server_close)
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        self.addCleanup(httpd.shutdown)
+        return httpd.server_address[1]
+
+    def test_real_server_ships_the_project_slot_and_the_renderer(self) -> None:
+        with TemporaryDirectory() as tmp:
+            port = self._serve(_store_dir(tmp))
+            with urllib.request.urlopen(f"http://127.0.0.1:{port}/") as resp:
+                body = resp.read().decode("utf-8")
+        self.assertIn('id="project"', body)
+        self.assertIn("projectLabel(", body)
+        self.assertIn(".project-tag", body)
+
+
+class ProjectLabelSourceTests(unittest.TestCase):
+    def test_separator_is_a_real_middle_dot_not_mojibake(self) -> None:
+        """Checked in Python, with no subprocess in the way: a UTF-8 round-trip
+        accident would leave "Â·" (U+00C2 U+00B7) or an "&middot;" entity, and
+        the entity would render literally since the tag is set via
+        textContent."""
+        self.assertIn(f" {MIDDLE_DOT} ", RENDERER_JS)
+        self.assertNotIn("\u00c2\u00b7", RENDERER_JS)
+        self.assertNotIn("&middot;", RENDERER_JS)
+        self.assertNotIn("&#183;", RENDERER_JS)
+
+
+class ProjectLabelPurityTests(unittest.TestCase):
+    """RENDERER_JS is executed verbatim under node, so projectLabel may not
+    touch a single browser API. Merely EVALUATING the constant cannot prove
+    that -- JavaScript resolves free identifiers at call time -- so this
+    poisons the globals with throwing getters and then calls the function."""
+
+    def test_project_label_is_pure_and_preserves_the_digest(self) -> None:
+        node = shutil.which("node")
+        if not node:
+            self.skipTest("node not available")
+
+        harness = RENDERER_JS + r"""
+const assert = require("assert");
+
+// Throwing getters, not deletions: a free `document` inside projectLabel
+// resolves through globalThis at CALL time and trips the getter.
+const POISON = ["document", "window", "location", "fetch", "navigator", "localStorage"];
+for (const name of POISON) {
+  try {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      get() { throw new Error("projectLabel touched browser global: " + name); },
+    });
+  } catch (e) { /* non-configurable in this node build; the ones below suffice */ }
+}
+// Prove the poison actually took for the two names no node build owns
+// natively (so defineProperty cannot have been refused) -- otherwise this test
+// could silently degrade into "we called a function".
+for (const name of ["document", "window"]) {
+  assert.throws(() => globalThis[name], /touched browser global/, name + " not poisoned");
+}
+
+const forked_b = projectLabel({project: "Puppetmaster-b92145e840c8"});
+const forked_c = projectLabel({project: "puppetmaster-c3177e6032c4"});
+assert.strictEqual(forked_b, "Puppetmaster \u00b7 b92145e8");
+assert.strictEqual(forked_c, "puppetmaster \u00b7 c3177e60");
+// The whole point: these two are the SAME slug in different case, so the
+// digest is the only thing that can tell the boards apart.
+assert.notStrictEqual(forked_b.toLowerCase(), forked_c.toLowerCase());
+assert.ok(/[0-9a-f]{8}/.test(forked_b));
+assert.ok(/[0-9a-f]{8}/.test(forked_c));
+
+// all_projects wins over an incidental project name: serve() always passes a
+// state_dir, so an --all-projects board carries one too.
+assert.strictEqual(
+  projectLabel({project: "Puppetmaster-b92145e840c8", all_projects: true}),
+  "all projects"
+);
+assert.strictEqual(projectLabel({all_projects: true}), "all projects");
+
+// --mobile / non-loopback: /api/meta withholds the basename, hash only.
+const remote = projectLabel({project: null, state_dir_id: "abcdef123456"});
+assert.strictEqual(remote, "state abcdef12");
+for (const bad of ["null", "undefined", "NaN"]) {
+  assert.ok(!remote.includes(bad), "rendered " + bad);
+}
+
+assert.strictEqual(projectLabel(null), "");
+assert.strictEqual(projectLabel({}), "");
+// A name that isn't <slug>-<12 hex> is passed through, not mangled.
+assert.strictEqual(projectLabel({project: "plain-name"}), "plain-name");
+
+console.log("project-label-ok");
+"""
+        completed = subprocess.run(
+            [node, "-e", harness],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=30,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("project-label-ok", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dashboard_state_dir_warning.py
+++ b/tests/test_dashboard_state_dir_warning.py
@@ -1,0 +1,645 @@
+"""Surface the wrong-state-dir warning where a human or agent will see it.
+
+``default_state_dir()`` hashes the git root of the caller's cwd, so a session
+opened at a non-git *wrapper* directory forked one logical project into two
+state dirs: ``puppetmaster-c3177e6032c4`` (1 stale job, what the dashboard
+showed) and ``Puppetmaster-b92145e840c8`` (24 jobs, where the real work went).
+
+The detector for that split already exists (``puppetmaster.state_health``, see
+tests/test_state_dir_identity.py) and doctor already reports it. The deeper
+defect these tests close is that the *dashboard* stayed silent:
+``dashboard_serves()`` only proves "the server on this port serves the state
+dir I computed", never "that state dir is where this workspace's jobs go", so
+``run_dashboard`` reported ``started=true`` with a cheerful "Started a new
+dashboard for this project." while serving an empty store.
+
+Three surfaces, three groups below: the MCP tool body an agent reads, the
+stderr line a shell user reads, and the in-page banner a browser user reads.
+
+A new file for the same reason as tests/test_dashboard_project_identity.py:
+tests/test_puppetmaster.py is enormous and contended, so this workstream's
+node harness is additive rather than an edit to a hot file.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_HERMETIC_DIR = os.path.dirname(os.path.abspath(__file__))
+if _HERMETIC_DIR not in sys.path:
+    sys.path.insert(0, _HERMETIC_DIR)
+import hermetic_env  # noqa: F401
+
+import contextlib
+import io
+import json
+import shutil
+import subprocess
+import threading
+import unittest
+import urllib.request
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+
+import puppetmaster.dashboard as dash
+import puppetmaster.state_health as state_health
+from puppetmaster import state
+from puppetmaster.dashboard import _PAGE_APP_JS, RENDERER_JS, make_handler, serve
+
+# The exact note run_dashboard has always produced on the spawn path (the
+# other is "Reused this project's own dashboard, already running."). Pinned as
+# a constant so the "appended to, not replaced" contract is asserted against
+# the literal text an agent has learned to read, not a paraphrase.
+NOTE_STARTED = "Started a new dashboard for this project."
+
+_JOB_EPOCH = 1_700_000_000.0
+
+
+def _make_jobs(state_dir: Path, count: int, *, offset: float = 0.0) -> None:
+    """Fake job history: ``<state_dir>/jobs/<id>`` dirs with fixed mtimes.
+
+    The detector counts job *directories* rather than opening the store (it
+    has to stay SQLite-free), so directories are the whole fixture.
+    """
+    jobs = state_dir / "jobs"
+    jobs.mkdir(parents=True, exist_ok=True)
+    for index in range(count):
+        job = jobs / f"job_{state_dir.name[:8]}_{index:03d}"
+        job.mkdir(exist_ok=True)
+        stamp = _JOB_EPOCH + offset + index
+        os.utime(job, (stamp, stamp))
+
+
+@contextlib.contextmanager
+def _chdir(target: Path):
+    """Run the block with ``target`` as the process cwd.
+
+    Not incidental: ``serve()`` and ``make_handler()`` diagnose against
+    ``Path.cwd()``, because the dashboard process's cwd *is* the workspace
+    whose jobs the user expects to see. Reproducing the incident therefore
+    means actually standing in the wrapper directory — this repo's own root is
+    a git checkout, so without the chdir the detector's "cwd is a git root"
+    guard fires and every assertion below would pass vacuously.
+    """
+    previous = os.getcwd()
+    os.chdir(target)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+@contextlib.contextmanager
+def _fork_fixture(tmp: str, *, active_jobs: int, child_jobs: int):
+    """The reported incident, as a filesystem: wrapper folder above a checkout.
+
+    ``<tmp>/puppetmaster`` is not a git repo; ``<tmp>/puppetmaster/Puppetmaster``
+    is. Yields ``(wrapper, child, active_dir, child_dir)`` with the app state
+    root still patched, so callers can keep deriving paths inside the block —
+    ``projects_root``/``project_state_dir_for``/``default_state_dir`` all
+    resolve that root at *call* time, and a value derived after the block exits
+    is silently computed against the real AppData root instead.
+
+    ``_git_root`` is pinned to None rather than trusting the temp dir to sit
+    outside a checkout: "this folder is not in a git repo" is the precondition
+    of the whole incident, so it belongs in the fixture — and pinning it keeps
+    the suite off a ``git`` subprocess. The base is ``resolve()``d so the
+    detector's cwd-derivation check compares equal after ``_chdir``.
+    """
+    base = Path(tmp).resolve()
+    with patch.object(
+        state, "app_state_root", return_value=base / "app-state"
+    ), patch.object(state, "_git_root", return_value=None):
+        wrapper = base / "puppetmaster"
+        child = wrapper / "Puppetmaster"
+        child.mkdir(parents=True)
+        (child / ".git").mkdir()
+        active_dir = state.project_state_dir_for(wrapper)
+        child_dir = state.project_state_dir_for(child)
+        _make_jobs(active_dir, active_jobs)
+        _make_jobs(child_dir, child_jobs, offset=100.0)
+        yield wrapper, child, active_dir, child_dir
+
+
+@contextlib.contextmanager
+def _mocked_dashboard_lifecycle():
+    """Spawn path, fully mocked — no real server, no real process.
+
+    Mirrors tests/test_dashboard_background_identity.py's MCP cases: the
+    own-runfile pre-check finds nothing tracked, the literal-port probe says
+    "not ours" (``dashboard_serves`` False), the spawn is faked, and the
+    child's runfile appears on the poll loop's read. Result: ``started=true``
+    on port 8787 — the exact shape the reporting user saw.
+    """
+    spawned = MagicMock()
+    spawned.pid = 7070
+    spawned.poll.return_value = None
+    child_runfile = {
+        "pid": 7070,
+        "host": "127.0.0.1",
+        "port": 8787,
+        "url": "http://127.0.0.1:8787/",
+    }
+    import puppetmaster.mcp_server as mcp
+
+    with patch.object(
+        dash, "read_dashboard_runfile", side_effect=[None, child_runfile]
+    ), patch.object(
+        dash, "dashboard_serves", side_effect=[False, True]
+    ), patch.object(
+        dash, "dashboard_identity", return_value=None
+    ), patch(
+        "subprocess.Popen", return_value=spawned
+    ), patch.object(
+        mcp, "_spawn_dashboard_server", return_value=spawned
+    ):
+        yield
+
+
+def _run_dashboard(args: dict) -> dict:
+    """``run_dashboard``'s parsed body, plus the raw result for ``isError``.
+
+    Calls the handler directly rather than ``call_tool``: ``call_tool`` folds
+    version-staleness nudges into the payload, and these tests assert on the
+    exact contents of ``note``.
+    """
+    import puppetmaster.mcp_server as mcp
+
+    result = mcp.run_dashboard(args)
+    return {"result": result, "body": json.loads(result["content"][0]["text"])}
+
+
+class McpDashboardWarningTests(unittest.TestCase):
+    """The agent-facing surface: a structured warning plus an appended note."""
+
+    def test_suspect_state_dir_warns_without_failing_the_start(self) -> None:
+        with TemporaryDirectory() as tmp:
+            with _fork_fixture(tmp, active_jobs=1, child_jobs=5) as (
+                wrapper,
+                _child,
+                active_dir,
+                child_dir,
+            ):
+                active_name, child_name = active_dir.name, child_dir.name
+                with _mocked_dashboard_lifecycle():
+                    run = _run_dashboard({"cwd": str(wrapper)})
+
+        result, body = run["result"], run["body"]
+        # The dashboard *did* start. This is advisory, not a failure: flipping
+        # it to isError would make a working board look broken.
+        self.assertFalse(result.get("isError"))
+        self.assertTrue(body["started"])
+
+        warnings = body["warnings"]
+        self.assertEqual(warnings[0]["kind"], "state_dir_may_be_wrong")
+        self.assertEqual(warnings[0]["state_dir_name"], active_name)
+        self.assertEqual(warnings[0]["active_jobs"], 1)
+        self.assertEqual(warnings[0]["candidate"], child_name)
+        self.assertEqual(warnings[0]["candidate_jobs"], 5)
+
+        # Appended, not replaced: the caller must still be able to tell a
+        # fresh start from a reuse.
+        self.assertIn(NOTE_STARTED, body["note"])
+        # ...and the remedy has to name every escape hatch, because which one
+        # applies depends on what the caller was actually trying to do.
+        for needle in (
+            "git root",
+            "cwd",
+            "state_dir",
+            "all_projects=true",
+            "python -m puppetmaster projects",
+        ):
+            self.assertIn(needle, body["note"], needle)
+
+    def test_warning_and_note_carry_basenames_only(self) -> None:
+        """No absolute path anywhere in the advisory text.
+
+        ``body["state_dir"]`` legitimately carries the full path (it always
+        has), so this is scoped to the two fields that are new: an MCP body is
+        quoted verbatim into agent transcripts, where a home directory is
+        gratuitous disclosure.
+        """
+        with TemporaryDirectory() as tmp:
+            with _fork_fixture(tmp, active_jobs=1, child_jobs=5) as (
+                wrapper,
+                _child,
+                active_dir,
+                _child_dir,
+            ):
+                absolute, workspace = str(active_dir), str(wrapper)
+                with _mocked_dashboard_lifecycle():
+                    run = _run_dashboard({"cwd": str(wrapper)})
+
+        body = run["body"]
+        # ensure_ascii=False deliberately: the default would escape
+        # `short_warning`'s em-dash to "—", whose backslash IS os.sep on
+        # Windows and would make the separator assertion below fire on an
+        # artefact of this test's own serialisation.
+        advisory = body["note"] + json.dumps(body["warnings"], ensure_ascii=False)
+        self.assertNotIn(absolute, advisory)
+        self.assertNotIn(workspace, advisory)
+        # "No separator at all" is the strongest form of "basenames only", and
+        # it holds: the real advisory text contains no paths whatsoever.
+        self.assertNotIn(os.sep, advisory)
+        self.assertNotIn("/", advisory)
+
+    def test_healthy_state_dir_stays_silent(self) -> None:
+        """Anti-noise regression guard.
+
+        Identical fixture to the suspect case with the job counts flipped, so
+        the *only* difference is which dir holds the history. A busy active dir
+        next to a nested checkout is the normal shape of a vendored/submodule
+        tree and must produce no warnings key and a byte-identical note.
+        """
+        with TemporaryDirectory() as tmp:
+            with _fork_fixture(tmp, active_jobs=10, child_jobs=5) as (
+                wrapper,
+                _child,
+                _active_dir,
+                _child_dir,
+            ):
+                with _mocked_dashboard_lifecycle():
+                    run = _run_dashboard({"cwd": str(wrapper)})
+
+        body = run["body"]
+        self.assertNotIn("warnings", body)
+        self.assertEqual(body["note"], NOTE_STARTED)
+
+    def test_all_projects_board_never_warns(self) -> None:
+        """An --all-projects board serves every project's store, so "you may
+        be pointed at the wrong one" cannot be true of it — even on the exact
+        filesystem that makes the single-project case suspect."""
+        with TemporaryDirectory() as tmp:
+            with _fork_fixture(tmp, active_jobs=1, child_jobs=5) as (
+                wrapper,
+                _child,
+                _active_dir,
+                _child_dir,
+            ):
+                with _mocked_dashboard_lifecycle():
+                    run = _run_dashboard({"cwd": str(wrapper), "all_projects": True})
+
+        body = run["body"]
+        self.assertTrue(body["all_projects"])
+        self.assertNotIn("warnings", body)
+        self.assertEqual(body["note"], NOTE_STARTED)
+
+
+class ServeStderrWarningTests(unittest.TestCase):
+    """The shell surface: a line next to "Reading durable state from:".
+
+    This is what the reporting user would have hit first — they started the
+    board from a shell and got a confident "Reading durable state from: <the
+    wrong dir>" with nothing on screen to contradict it.
+    """
+
+    def test_serve_warns_on_stderr_beside_the_state_dir_line(self) -> None:
+        with TemporaryDirectory() as tmp:
+            with _fork_fixture(tmp, active_jobs=1, child_jobs=5) as (
+                wrapper,
+                child,
+                active_dir,
+                _child_dir,
+            ):
+                err, out = io.StringIO(), io.StringIO()
+                with _chdir(wrapper), patch.object(sys, "stderr", err):
+                    with contextlib.redirect_stdout(out):
+                        httpd = serve(
+                            active_dir,
+                            host="127.0.0.1",
+                            port=0,
+                            open_browser=False,
+                            serve_forever=False,
+                        )
+                    httpd.server_close()
+                names = (active_dir.name, child.name)
+                absolute = str(active_dir)
+
+        stderr_text = err.getvalue()
+        self.assertIn("WARNING", stderr_text)
+        for name in names:
+            self.assertIn(name, stderr_text, name)
+        # stdout still carries the line this one sits beside.
+        self.assertIn("Reading durable state from:", out.getvalue())
+        # Basenames only: this lands in dashboard.err.log, which users paste
+        # into issues verbatim.
+        self.assertNotIn(absolute, stderr_text)
+        self.assertNotIn(os.sep, stderr_text)
+
+    def test_state_dir_warning_returns_none_on_any_exception(self) -> None:
+        """Everything after the bind in ``serve()`` sits inside an
+        ``except BaseException: httpd.server_close(); raise``, so an unguarded
+        diagnosis would convert a working dashboard into a failed start."""
+        with TemporaryDirectory() as tmp:
+            with patch.object(
+                state_health, "diagnose_state_dir", side_effect=RuntimeError("boom")
+            ):
+                self.assertIsNone(dash.state_dir_warning(Path(tmp)))
+
+    def test_state_dir_warning_skips_all_projects_and_none(self) -> None:
+        with TemporaryDirectory() as tmp:
+            with patch.object(
+                state_health, "diagnose_state_dir", side_effect=AssertionError
+            ) as probe:
+                self.assertIsNone(dash.state_dir_warning(Path(tmp), all_projects=True))
+                self.assertIsNone(dash.state_dir_warning(None))
+            probe.assert_not_called()
+
+    def test_a_raising_detector_still_lets_serve_bind(self) -> None:
+        """End to end: the guard is only worth something if it is actually the
+        thing standing between a raising detector and a dead dashboard."""
+        with TemporaryDirectory() as tmp, patch.object(
+            state_health, "diagnose_state_dir", side_effect=RuntimeError("boom")
+        ):
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            with contextlib.redirect_stdout(io.StringIO()):
+                httpd = serve(
+                    state_dir,
+                    host="127.0.0.1",
+                    port=0,
+                    open_browser=False,
+                    serve_forever=False,
+                )
+            httpd.server_close()
+
+
+class DiagnosticsEndpointTests(unittest.TestCase):
+    """The browser surface, server side: a separate, cached, gated endpoint.
+
+    Deliberately NOT on /api/meta: ``dashboard_identity`` reads at most 65536
+    bytes under a one-second socket timeout and ``json.loads`` the result, so
+    an oversized or slow body silently becomes None — which reads as "not my
+    dashboard" and makes the CLI and MCP spawn duplicate servers. A filesystem
+    walk behind that endpoint would risk the very bug it exists to prevent.
+    """
+
+    def _serve(self, state_dir: Path) -> int:
+        with contextlib.redirect_stdout(io.StringIO()):
+            httpd = serve(
+                state_dir,
+                backend="sqlite",
+                host="127.0.0.1",
+                port=0,
+                open_browser=False,
+                serve_forever=False,
+            )
+        # addCleanup is LIFO, so server_close must be registered FIRST for
+        # shutdown to run before it (same order as tests/test_dashboard_ports.py).
+        self.addCleanup(httpd.server_close)
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        self.addCleanup(httpd.shutdown)
+        return httpd.server_address[1]
+
+    @staticmethod
+    def _get(port: int, path: str) -> dict:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}{path}") as resp:
+            return {"code": resp.status, "body": json.loads(resp.read().decode())}
+
+    def test_unmanaged_state_dir_gets_a_200_with_no_diagnosis(self) -> None:
+        """A temp dir outside the hashed ``projects/`` layout is a deliberate
+        choice (``--state-dir``), not a fork, so the endpoint answers 200 with
+        nothing to report rather than 404 or a guess."""
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            port = self._serve(state_dir)
+            got = self._get(port, "/api/diagnostics")
+        self.assertEqual(got["code"], 200)
+        self.assertIsNone(got["body"]["diagnosis"])
+
+    def test_a_raising_detector_cannot_break_the_reuse_contract(self) -> None:
+        """The handler's blanket ``except`` turns any error into a 500, so the
+        payload builder has to swallow — and the load-bearing half of this is
+        that /api/meta, which reuse detection reads, keeps answering."""
+        with TemporaryDirectory() as tmp, patch.object(
+            state_health, "diagnose_state_dir", side_effect=RuntimeError("boom")
+        ):
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            port = self._serve(state_dir)
+            diagnostics = self._get(port, "/api/diagnostics")
+            meta = self._get(port, "/api/meta")
+        self.assertEqual(diagnostics["code"], 200)
+        self.assertIsNone(diagnostics["body"]["diagnosis"])
+        self.assertEqual(meta["code"], 200)
+        self.assertEqual(meta["body"]["service"], "puppetmaster-dashboard")
+
+    def _call(self, handler, peer: str) -> str:
+        """Drive one request without a socket, so the peer address is ours to
+        choose (same shape as tests/test_dashboard_project_aggregate.py)."""
+        sent: list = []
+        instance = handler.__new__(handler)
+        instance.path = "/api/diagnostics"
+        instance.client_address = (peer, 0)
+        instance._send = lambda code, body, content_type: sent.append((code, body))
+        instance.do_GET()
+        self.assertEqual([code for code, _ in sent], [200])
+        return sent[0][1].decode("utf-8")
+
+    def test_non_loopback_peer_gets_a_boolean_and_nothing_else(self) -> None:
+        """--mobile makes this endpoint reachable off-loopback, so it is gated
+        exactly like /api/meta: a remote peer learns *that* something looks
+        wrong, never a project basename and never a job count."""
+        with TemporaryDirectory() as tmp:
+            with _fork_fixture(tmp, active_jobs=1, child_jobs=5) as (
+                wrapper,
+                _child,
+                active_dir,
+                child_dir,
+            ):
+                handler = make_handler(lambda: None, state_dir=active_dir)
+                with _chdir(wrapper):
+                    remote = self._call(handler, "100.64.0.7")
+                    local = self._call(handler, "127.0.0.1")
+                secrets = (
+                    active_dir.name,
+                    child_dir.name,
+                    str(active_dir),
+                    str(wrapper),
+                )
+                active_name = active_dir.name
+
+        payload = json.loads(remote)
+        # Not vacuous: there really was something to withhold.
+        self.assertTrue(payload["suspect"])
+        self.assertIsNone(payload["diagnosis"])
+        for secret in secrets:
+            self.assertNotIn(secret, remote, secret)
+        self.assertNotIn(os.sep, remote)
+        # ...and the loopback caller on the SAME handler does get the detail,
+        # which proves the gate withheld it rather than an inert diagnosis.
+        self.assertIn(active_name, local)
+
+    def test_the_diagnosis_is_ttl_cached_not_walked_per_request(self) -> None:
+        """The page can be reloaded freely and /api/jobs polls every 1.5s next
+        door; a directory walk per request is not an acceptable price for an
+        advisory. One probe must serve every request inside the TTL."""
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            handler = make_handler(lambda: None, state_dir=state_dir)
+            with patch.object(
+                state_health,
+                "diagnose_state_dir",
+                wraps=state_health.diagnose_state_dir,
+            ) as probe:
+                for _ in range(5):
+                    self._call(handler, "127.0.0.1")
+        self.assertEqual(probe.call_count, 1)
+
+    def test_all_projects_board_never_probes_the_filesystem(self) -> None:
+        with TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / ".puppetmaster"
+            state_dir.mkdir()
+            handler = make_handler(lambda: None, all_projects=True, state_dir=state_dir)
+            with patch.object(
+                state_health, "diagnose_state_dir", side_effect=AssertionError
+            ) as probe:
+                got = self._call(handler, "127.0.0.1")
+            probe.assert_not_called()
+        self.assertIsNone(json.loads(got)["diagnosis"])
+
+    def test_state_dir_none_never_probes_the_filesystem(self) -> None:
+        """``make_handler(lambda: None)`` with no state_dir is what several
+        existing tests build; it must not be made to walk anything."""
+        handler = make_handler(lambda: None)
+        with patch.object(
+            state_health, "diagnose_state_dir", side_effect=AssertionError
+        ) as probe:
+            got = self._call(handler, "127.0.0.1")
+        probe.assert_not_called()
+        self.assertIsNone(json.loads(got)["diagnosis"])
+
+
+class BannerCallSiteTests(unittest.TestCase):
+    """*Where* the banner is rendered from is the whole point of Part C."""
+
+    @staticmethod
+    def _load_index() -> str:
+        start = _PAGE_APP_JS.index("async function loadIndex")
+        return _PAGE_APP_JS[start : _PAGE_APP_JS.index("function rows(", start)]
+
+    def test_banner_sits_after_the_jobs_heading(self) -> None:
+        body = self._load_index()
+        self.assertGreater(body.index("stateDirHint("), body.index("<h2>Jobs</h2>"))
+
+    def test_banner_is_not_in_the_empty_state_branch(self) -> None:
+        """The reported bad dir held exactly ONE job, so the empty state never
+        rendered — a hint placed there would have missed the real incident."""
+        body = self._load_index()
+        self.assertEqual(body.count("stateDirHint("), 1)
+        self.assertLess(body.index("stateDirHint("), body.index("if (!shown.length)"))
+
+    def test_diagnostics_is_fetched_once_at_bootstrap_not_polled(self) -> None:
+        for needle in (
+            "/api/diagnostics",
+            "async function loadDiagnostics",
+            "loadDiagnostics();",
+        ):
+            self.assertIn(needle, _PAGE_APP_JS, needle)
+        self.assertEqual(_PAGE_APP_JS.count("loadDiagnostics();"), 1)
+        # Same seam as loadMeta(): after tick()'s definition, never inside it.
+        self.assertGreater(
+            _PAGE_APP_JS.index("loadDiagnostics();"),
+            _PAGE_APP_JS.index("async function tick()"),
+        )
+        tick_region = _PAGE_APP_JS[
+            _PAGE_APP_JS.index("async function tick()") : _PAGE_APP_JS.index(
+                "async function loadDiagnostics"
+            )
+        ]
+        self.assertNotIn("/api/diagnostics", tick_region)
+
+    def test_load_diagnostics_owns_its_own_failure(self) -> None:
+        start = _PAGE_APP_JS.index("async function loadDiagnostics")
+        body = _PAGE_APP_JS[start : _PAGE_APP_JS.index("loadMeta();", start)]
+        for needle in ("try {", "catch", "r.ok"):
+            self.assertIn(needle, body, needle)
+
+
+class StateDirHintPurityTests(unittest.TestCase):
+    """RENDERER_JS runs verbatim under node, so stateDirHint may not touch a
+    browser API — and the project basename it renders is filesystem-derived
+    and unsanitised when --state-dir is explicit, so its trip through esc()
+    needs real execution rather than a substring check on the source."""
+
+    def test_state_dir_hint_is_pure_escapes_and_defers_to_live_rows(self) -> None:
+        node = shutil.which("node")
+        if not node:
+            self.skipTest("node not available")
+
+        harness = RENDERER_JS + r"""
+const assert = require("assert");
+
+// Throwing getters, not deletions: a free `document` inside stateDirHint
+// resolves through globalThis at CALL time and trips the getter.
+const POISON = ["document", "window", "location", "fetch", "navigator", "localStorage"];
+for (const name of POISON) {
+  try {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      get() { throw new Error("stateDirHint touched browser global: " + name); },
+    });
+  } catch (e) { /* non-configurable in this node build; the ones below suffice */ }
+}
+for (const name of ["document", "window"]) {
+  assert.throws(() => globalThis[name], /touched browser global/, name + " not poisoned");
+}
+
+// Nothing to say -> nothing rendered. A healthy board, an --all-projects
+// board and a remote peer all land here and must render identically.
+assert.strictEqual(stateDirHint(null, 0), "");
+assert.strictEqual(stateDirHint(undefined, 0), "");
+assert.strictEqual(stateDirHint({}, 0), "");
+assert.strictEqual(stateDirHint({suspect: false, message: "x"}, 0), "");
+
+// The real incident: 1 job here, 24 over there.
+const real = stateDirHint({
+  suspect: true,
+  jobs: 1,
+  project: "puppetmaster-c3177e6032c4",
+  candidate: "Puppetmaster-b92145e840c8",
+  candidate_jobs: 24,
+  message: "puppetmaster-c3177e6032c4 has 1 job(s) but nested repo Puppetmaster has 24",
+}, 1);
+assert.ok(real.includes("state-dir-hint"), real);
+assert.ok(real.includes("puppetmaster projects"), real);
+assert.ok(real.includes("Puppetmaster"), real);
+
+// An unsanitised, filesystem-derived name reaches this string. It must be
+// escaped, and the raw tag must be nowhere in the output.
+const PAYLOAD = '<img src=x onerror="alert(1)">';
+const attacked = stateDirHint({suspect: true, jobs: 1, message: "dir " + PAYLOAD}, 1);
+assert.ok(!attacked.includes(PAYLOAD), "raw payload survived");
+assert.ok(!attacked.includes("<img"), "raw tag survived");
+assert.ok(!attacked.includes('onerror="'), "raw attribute survived");
+assert.ok(attacked.includes("&lt;img"), "payload was not escaped: " + attacked);
+
+// Staleness guard: the server caches the diagnosis for ~15s, so a board that
+// is visibly busier than the "nearly empty" dir the detector complained about
+// is not this incident. Drop the banner rather than contradict the rows.
+const stale = {suspect: true, jobs: 1, message: "m"};
+assert.strictEqual(stateDirHint(stale, 2), "");
+assert.strictEqual(stateDirHint(stale, 24), "");
+assert.notStrictEqual(stateDirHint(stale, 1), "");
+assert.notStrictEqual(stateDirHint(stale, 0), "");
+// A missing/garbage count must not silently suppress the banner.
+assert.notStrictEqual(stateDirHint({suspect: true, message: "m"}, 5), "");
+
+console.log("state-dir-hint-ok");
+"""
+        completed = subprocess.run(
+            [node, "-e", harness],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=30,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("state-dir-hint-ok", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_state_dir_identity.py
+++ b/tests/test_state_dir_identity.py
@@ -1,0 +1,424 @@
+"""Detect-only identity checks for a forked / wrong-project state dir.
+
+``default_state_dir`` hashes ``_git_root(cwd) or cwd``. A session opened one
+level *above* the real checkout makes the ``or`` fallback fire and silently
+splits one logical project into two state dirs. These tests pin the detector
+that notices, and pin that the detector stays cheap: no git subprocess when a
+state dir is supplied, and never a SQLite connection.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_HERMETIC_DIR = os.path.dirname(os.path.abspath(__file__))
+if _HERMETIC_DIR not in sys.path:
+    sys.path.insert(0, _HERMETIC_DIR)
+import hermetic_env  # noqa: F401
+
+import contextlib
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from puppetmaster import state
+from puppetmaster.diagnostics import run_doctor
+from puppetmaster.state_health import (
+    VERDICTS,
+    diagnose_state_dir,
+    short_warning,
+    summarize_project_state_dir,
+)
+
+
+_JOB_EPOCH = 1_700_000_000.0
+
+
+def _make_git(path: Path) -> None:
+    """Mark ``path`` as a checkout the way a real clone does."""
+    (path / ".git").mkdir(parents=True, exist_ok=True)
+
+
+def _make_jobs(state_dir: Path, count: int, *, offset: float = 0.0) -> Path:
+    """Fake job history: ``<state_dir>/jobs/<id>`` dirs with fixed mtimes."""
+    jobs = state_dir / "jobs"
+    jobs.mkdir(parents=True, exist_ok=True)
+    for index in range(count):
+        job = jobs / f"job_{state_dir.name[:8]}_{index:03d}"
+        job.mkdir(exist_ok=True)
+        stamp = _JOB_EPOCH + offset + index
+        os.utime(job, (stamp, stamp))
+    return jobs
+
+
+def _evidence_keys(diagnosis) -> set[str]:
+    return {item.split(":", 1)[0] for item in diagnosis.evidence}
+
+
+class StateDirIdentityTests(unittest.TestCase):
+    """The detector's guard chain, cheapest guard first."""
+
+    @contextlib.contextmanager
+    def _app_state(self, tmp: Path):
+        """Redirect the app state root at ``tmp/app-state`` for the block.
+
+        Scoping rule for every test below: ``project_state_dir_for``,
+        ``projects_root``, ``app_state_root``, ``list_project_state_dirs`` and
+        ``default_state_dir`` resolve the root *at call time*. Any expected
+        value derived from them must therefore be produced inside this block —
+        call it here and bind it to a local, then assert on the local. Calling
+        one of them after the block exits recomputes against the real AppData
+        root and silently makes the *expectation* wrong, not the actual value.
+        """
+        with patch(
+            "puppetmaster.state.app_state_root", return_value=tmp / "app-state"
+        ):
+            yield
+
+    def _diagnose(self, **kwargs):
+        """Every call also pins the closed verdict vocabulary."""
+        diagnosis = diagnose_state_dir(**kwargs)
+        self.assertIn(diagnosis.verdict, VERDICTS)
+        return diagnosis
+
+    def _fork_fixture(self, tmp: Path, *, active_jobs: int, child_jobs: int):
+        """The reported incident: wrapper folder above the real checkout.
+
+        ``tmp/puppetmaster`` is not a git repo, ``tmp/puppetmaster/Puppetmaster``
+        is. Returns ``(wrapper, child, active_dir, child_dir)``.
+        """
+        wrapper = tmp / "puppetmaster"
+        child = wrapper / "Puppetmaster"
+        child.mkdir(parents=True)
+        _make_git(child)
+        active_dir = state.project_state_dir_for(wrapper)
+        child_dir = state.project_state_dir_for(child)
+        _make_jobs(active_dir, active_jobs)
+        _make_jobs(child_dir, child_jobs, offset=100.0)
+        return wrapper, child, active_dir, child_dir
+
+    def test_reported_incident_is_suspect_with_one_candidate(self) -> None:
+        """One stale job in the wrapper dir, real history in the nested repo."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self._app_state(root):
+                wrapper, child, active_dir, child_dir = self._fork_fixture(
+                    root, active_jobs=1, child_jobs=5
+                )
+                diagnosis = self._diagnose(cwd=wrapper, state_dir=active_dir)
+                # Bound here, not below: project_state_dir_for resolves
+                # projects_root() at call time, so the expected path has to come
+                # from the same app_state_root patch that produced the actual
+                # one. Called after the block it would rebuild the same 12-hex
+                # digest under the real AppData root and never match.
+                expected_child_dir = state.project_state_dir_for(child)
+
+            self.assertTrue(diagnosis.suspect, diagnosis.evidence)
+            self.assertEqual(diagnosis.verdict, "forked-project")
+            self.assertEqual(diagnosis.active.job_count, 1)
+            self.assertEqual(len(diagnosis.candidates), 1)
+            candidate = diagnosis.candidates[0]
+            self.assertEqual(candidate.state_dir, child_dir)
+            self.assertEqual(candidate.state_dir, expected_child_dir)
+            self.assertEqual(candidate.workspace, child)
+            self.assertEqual(candidate.job_count, 5)
+            self.assertLessEqual(
+                {
+                    "verdict",
+                    "active",
+                    "active_jobs",
+                    "cwd",
+                    "cwd_is_git_root",
+                    "expected_for_cwd",
+                    "scanned_children",
+                    "candidates",
+                    "candidate",
+                },
+                _evidence_keys(diagnosis),
+            )
+            self.assertIn("cwd_is_git_root:false", diagnosis.evidence)
+            self.assertIn(f"candidate:{child_dir.name}=5", diagnosis.evidence)
+
+    def test_populated_active_dir_is_not_suspect(self) -> None:
+        """Anti-noise: a wrapper with real history of its own stays quiet."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self._app_state(root):
+                wrapper = root / "workspace"
+                child = wrapper / "app"
+                child.mkdir(parents=True)
+                _make_git(child)
+                active_dir = state.project_state_dir_for(wrapper)
+                _make_jobs(active_dir, 4)
+                _make_jobs(state.project_state_dir_for(child), 12, offset=100.0)
+                diagnosis = self._diagnose(cwd=wrapper, state_dir=active_dir)
+
+            self.assertFalse(diagnosis.suspect, diagnosis.evidence)
+            self.assertEqual(diagnosis.verdict, "ok")
+
+    def test_name_twin_beats_a_populated_active_dir(self) -> None:
+        """A same-slug twin that is *far* busier still wins (guard 6)."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self._app_state(root):
+                wrapper, _child, active_dir, child_dir = self._fork_fixture(
+                    root, active_jobs=4, child_jobs=24
+                )
+                diagnosis = self._diagnose(cwd=wrapper, state_dir=active_dir)
+
+            self.assertTrue(diagnosis.suspect, diagnosis.evidence)
+            self.assertEqual(diagnosis.verdict, "name-twin")
+            self.assertIn(f"name_twin:{child_dir.name}", diagnosis.evidence)
+
+    def test_child_repo_without_history_is_not_a_candidate(self) -> None:
+        """A fresh nested clone with no jobs proves nothing."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self._app_state(root):
+                wrapper, _child, active_dir, _child_dir = self._fork_fixture(
+                    root, active_jobs=1, child_jobs=0
+                )
+                diagnosis = self._diagnose(cwd=wrapper, state_dir=active_dir)
+
+            self.assertFalse(diagnosis.suspect, diagnosis.evidence)
+            self.assertEqual(diagnosis.candidates, ())
+            self.assertEqual(diagnosis.verdict, "new")
+
+    def test_cwd_that_is_a_git_root_is_never_suspect(self) -> None:
+        """Guard 2: a busy submodule / vendored checkout is legitimately separate."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self._app_state(root):
+                repo = root / "repo"
+                vendored = repo / "vendor-checkout"
+                vendored.mkdir(parents=True)
+                _make_git(repo)
+                _make_git(vendored)
+                active_dir = state.project_state_dir_for(repo)
+                _make_jobs(state.project_state_dir_for(vendored), 20)
+                diagnosis = self._diagnose(cwd=repo, state_dir=active_dir)
+
+            self.assertFalse(diagnosis.suspect, diagnosis.evidence)
+            self.assertEqual(diagnosis.verdict, "workspace-is-git-root")
+            self.assertEqual(diagnosis.candidates, ())
+
+    def test_explicit_state_dir_outside_projects_root_is_not_diagnosed(self) -> None:
+        """Guard 1: an explicit --state-dir / env pin is a deliberate choice."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self._app_state(root):
+                wrapper, _child, _active, child_dir = self._fork_fixture(
+                    root, active_jobs=1, child_jobs=24
+                )
+                explicit = root / "explicit-state"
+                _make_jobs(explicit, 1)
+                diagnosis = self._diagnose(cwd=wrapper, state_dir=explicit)
+
+            self.assertGreater(summarize_project_state_dir(child_dir).job_count, 1)
+            self.assertFalse(diagnosis.suspect, diagnosis.evidence)
+            self.assertEqual(diagnosis.verdict, "not-project-scoped")
+            self.assertEqual(diagnosis.candidates, ())
+
+    def test_state_dir_from_enclosing_git_root_is_not_diagnosed(self) -> None:
+        """Guard 3: running inside a subdirectory of a repo is normal."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self._app_state(root):
+                repo = root / "repo"
+                sub = repo / "packages"
+                nested = sub / "nested"
+                nested.mkdir(parents=True)
+                _make_git(repo)
+                _make_git(nested)
+                # What the enclosing git root hashes to -- not what ``sub`` does.
+                active_dir = state.project_state_dir_for(repo)
+                _make_jobs(active_dir, 1)
+                _make_jobs(state.project_state_dir_for(nested), 30, offset=100.0)
+                diagnosis = self._diagnose(cwd=sub, state_dir=active_dir)
+                # Same call-time resolution as everywhere else: bind what ``sub``
+                # hashes to under the patch. Outside the block this would be
+                # rebuilt against the real AppData root -- it happens to still
+                # compare unequal here, so the mistake would sit latent.
+                sub_dir = state.project_state_dir_for(sub)
+
+            self.assertNotEqual(active_dir.name, sub_dir.name)
+            self.assertFalse(diagnosis.suspect, diagnosis.evidence)
+            self.assertEqual(diagnosis.verdict, "not-cwd-derived")
+
+    def test_two_populated_child_repos_are_ambiguous_best_first(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self._app_state(root):
+                wrapper = root / "workspaces"
+                alpha = wrapper / "alpha"
+                beta = wrapper / "beta"
+                alpha.mkdir(parents=True)
+                beta.mkdir(parents=True)
+                _make_git(alpha)
+                _make_git(beta)
+                active_dir = state.project_state_dir_for(wrapper)
+                active_dir.mkdir(parents=True, exist_ok=True)
+                _make_jobs(state.project_state_dir_for(alpha), 4)
+                _make_jobs(state.project_state_dir_for(beta), 9, offset=100.0)
+                diagnosis = self._diagnose(cwd=wrapper, state_dir=active_dir)
+
+            self.assertTrue(diagnosis.suspect, diagnosis.evidence)
+            self.assertEqual(diagnosis.verdict, "ambiguous")
+            self.assertEqual([c.job_count for c in diagnosis.candidates], [9, 4])
+            self.assertEqual(
+                [c.workspace.name for c in diagnosis.candidates], ["beta", "alpha"]
+            )
+
+    def test_probe_with_explicit_state_dir_never_shells_out_to_git(self) -> None:
+        """A supplied state dir means filesystem stats only."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self._app_state(root):
+                wrapper, _child, active_dir, _child_dir = self._fork_fixture(
+                    root, active_jobs=1, child_jobs=5
+                )
+                with patch(
+                    "puppetmaster.state.subprocess.run",
+                    side_effect=AssertionError("unexpected git"),
+                ):
+                    diagnosis = self._diagnose(cwd=wrapper, state_dir=active_dir)
+
+            self.assertTrue(diagnosis.suspect, diagnosis.evidence)
+
+    def test_probe_never_opens_the_sqlite_store(self) -> None:
+        """Counting job dirs must not spin up the WAL writer."""
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self._app_state(root):
+                wrapper, _child, active_dir, _child_dir = self._fork_fixture(
+                    root, active_jobs=1, child_jobs=5
+                )
+                (active_dir / "state.sqlite3").write_bytes(b"")
+                with patch(
+                    "sqlite3.connect",
+                    side_effect=AssertionError("opened the sqlite store"),
+                ):
+                    diagnosis = self._diagnose(cwd=wrapper, state_dir=active_dir)
+                    summary = summarize_project_state_dir(active_dir)
+
+            self.assertTrue(diagnosis.suspect, diagnosis.evidence)
+            self.assertEqual(summary.job_count, 1)
+
+    def test_summarize_missing_dir_yields_zeros(self) -> None:
+        with TemporaryDirectory() as tmp:
+            summary = summarize_project_state_dir(Path(tmp) / "nope")
+            self.assertEqual(summary.job_count, 0)
+            self.assertIsNone(summary.last_activity)
+
+    def test_short_warning_has_no_absolute_path(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self._app_state(root):
+                wrapper, _child, active_dir, _child_dir = self._fork_fixture(
+                    root, active_jobs=1, child_jobs=5
+                )
+                diagnosis = self._diagnose(cwd=wrapper, state_dir=active_dir)
+                healthy = self._diagnose(cwd=wrapper, state_dir=root / "pinned")
+
+            warning = short_warning(diagnosis)
+            self.assertIsNotNone(warning)
+            self.assertLessEqual(len(warning), 140)
+            self.assertNotIn(str(root), warning)
+            self.assertNotIn(os.sep, warning)
+            self.assertIsNone(short_warning(healthy))
+
+    @unittest.skipUnless(shutil.which("git"), "git is required for this test")
+    def test_real_git_root_pivot_and_formula_agree(self) -> None:
+        """Real ``git rev-parse`` output must agree with ``project_state_dir_for``.
+
+        Load-bearing: the detector maps a sibling checkout to its state dir
+        via the formula, never via git. If ``--show-toplevel`` and
+        ``Path.resolve()`` disagreed, guard 3 would fire on a real repo.
+        """
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            outer = root / "puppetmaster"
+            repo = outer / "Puppetmaster"
+            sub = repo / "puppetmaster"
+            sub.mkdir(parents=True)
+            subprocess.run(
+                ["git", "init", "-q"], cwd=repo, check=True, capture_output=True
+            )
+            with self._app_state(root):
+                from_sub = state.default_state_dir(cwd=sub)
+                from_repo = state.default_state_dir(cwd=repo)
+                from_outer = state.default_state_dir(cwd=outer)
+                formula = state.project_state_dir_for(repo)
+
+            # The pivot fires from a subdirectory: both land on the repo root.
+            self.assertEqual(from_sub, from_repo)
+            # The wrapper folder is the fork: it hashes to something else.
+            self.assertNotEqual(from_repo, from_outer)
+            # git's --show-toplevel string and Path.resolve() agree.
+            self.assertEqual(from_repo, formula)
+
+
+class StateIdentityDoctorRowTests(unittest.TestCase):
+    """``puppetmaster doctor`` surfaces the fork instead of a benign optional."""
+
+    @contextlib.contextmanager
+    def _app_state(self, tmp: Path):
+        """Same call-time-resolution rule as ``StateDirIdentityTests._app_state``.
+
+        ``run_doctor`` reaches ``project_state_dir_for``/``projects_root``
+        through the detector, so both the rows and any path they are compared
+        against must be produced inside this block.
+        """
+        with patch(
+            "puppetmaster.state.app_state_root", return_value=tmp / "app-state"
+        ):
+            yield
+
+    def _row(self, root: Path, state_dir: Path):
+        checks = {c.name: c for c in run_doctor(root, state_dir)}
+        self.assertIn("state-identity", checks)
+        return checks["state-identity"]
+
+    def test_doctor_rows_never_fail_and_warn_on_a_fork(self) -> None:
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with self._app_state(root):
+                wrapper = root / "puppetmaster"
+                child = wrapper / "Puppetmaster"
+                child.mkdir(parents=True)
+                (child / ".git").mkdir()
+                active_dir = state.project_state_dir_for(wrapper)
+                child_dir = state.project_state_dir_for(child)
+                _make_jobs(active_dir, 1)
+                _make_jobs(child_dir, 5, offset=100.0)
+                explicit = root / "explicit-state"
+                explicit.mkdir()
+
+                forked = self._row(wrapper, active_dir)
+                pinned = self._row(wrapper, explicit)
+                healthy = self._row(child, child_dir)
+
+        self.assertEqual(forked.status, "warn")
+        for needle in (
+            child_dir.name,
+            "5",
+            "not a git repository",
+            "--state-dir",
+            "puppetmaster projects",
+            "dashboard --all-projects",
+        ):
+            self.assertIn(needle, forked.detail)
+
+        self.assertEqual(pinned.status, "optional")
+        self.assertEqual(healthy.status, "ok")
+
+        for row in (forked, pinned, healthy):
+            self.assertNotIn(row.status, {"fail", "error"}, row.detail)
+            self.assertTrue(row.evidence)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wrong_project_dashboard_e2e.py
+++ b/tests/test_wrong_project_dashboard_e2e.py
@@ -1,0 +1,512 @@
+"""End-to-end proof that the reported wrong-project dashboard now announces itself.
+
+THE INCIDENT THIS REPRODUCES
+============================
+A user ran ``puppetmaster dashboard`` for two repositories. One board showed
+live work; the other showed almost nothing, and nothing on screen explained
+why.
+
+``state.default_state_dir()`` hashes ``_git_root(cwd) or cwd``. The session had
+been opened at ``C:\\Projects\\puppetmaster`` — a plain wrapper folder that is
+*not* a git repository; the real checkout sits one level down at
+``C:\\Projects\\puppetmaster\\Puppetmaster``. So the ``or`` fallback fired, and
+one logical project silently forked into two state dirs:
+
+* ``puppetmaster-c3177e6032c4`` — 1 stale job. This is what the dashboard
+  served, and it served it correctly by its own identity check.
+* ``Puppetmaster-b92145e840c8`` — the real history, where every job had
+  actually been written.
+
+The board was right about *which state dir it was serving* and silent about
+*that state dir being the wrong project*. That silence is the defect.
+
+WHY THE FIXTURE IS SHAPED THIS WAY
+==================================
+Two properties of the fixture below are load-bearing rather than incidental:
+
+1. The nested repository is created with a **real** ``git init``, not a stubbed
+   ``.git`` directory and not a patched ``_git_root``. The whole incident is a
+   disagreement between what ``git rev-parse --show-toplevel`` answers from the
+   wrapper (nothing) and from the checkout (the checkout), so a fixture that
+   fakes git away would prove something else. Everything here therefore runs
+   only when a real ``git`` is on PATH.
+
+2. The wrapper's state dir is seeded with exactly **one** job — not zero. The
+   real bad dir held a single stale job, which is precisely why the dashboard's
+   empty-state branch never rendered and why nothing looked obviously broken. A
+   fixture with zero jobs would pass against a naive "warn when the dir is
+   empty" rule and would therefore not prove the reported case at all.
+
+WHAT IS PROVED
+==============
+Every surface a human or agent could have consulted at the moment of confusion
+now names the busier dir, and none of them leaks an absolute path:
+
+* the fork itself is real (two distinct hashed dirs for one project);
+* ``puppetmaster doctor``'s ``state-identity`` row warns;
+* the stderr line ``serve()`` prints beside "Reading durable state from:";
+* the dashboard's ``/api/diagnostics`` endpoint, with ``/api/meta`` asserted
+  alongside it so the identity contract that prevents duplicate dashboards is
+  visibly undisturbed.
+
+Two negative controls carry equal weight: run from the *correct* place, and run
+with an explicit ``--state-dir``, everything must stay quiet. Without them the
+suite could pass while warning about everything.
+
+This file only observes. It adds no behaviour and modifies no source; the
+detector (``puppetmaster.state_health``), the doctor row, the dashboard
+endpoint and the MCP warning are pinned unit-by-unit in
+tests/test_state_dir_identity.py and tests/test_dashboard_state_dir_warning.py.
+What is new here is assembling all of them against one real git tree.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_HERMETIC_DIR = os.path.dirname(os.path.abspath(__file__))
+if _HERMETIC_DIR not in sys.path:
+    sys.path.insert(0, _HERMETIC_DIR)
+import hermetic_env  # noqa: F401
+
+import contextlib
+import io
+import json
+import shutil
+import subprocess
+import threading
+import unittest
+import urllib.request
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import NamedTuple
+from unittest.mock import patch
+
+from puppetmaster import state
+from puppetmaster.dashboard import serve
+from puppetmaster.diagnostics import run_doctor
+from puppetmaster.state_health import (
+    diagnose_state_dir,
+    short_warning,
+    summarize_project_state_dir,
+)
+
+# Fixed mtimes keep the fixture deterministic; the detector reads them only to
+# report "last activity", never to decide.
+_JOB_EPOCH = 1_700_000_000.0
+
+# One, not zero -- see "WHY THE FIXTURE IS SHAPED THIS WAY" above. This is also
+# exactly ``diagnose_state_dir``'s ``near_empty_max`` default, so the fixture
+# sits on the boundary the real incident sat on.
+WRAPPER_JOBS = 1
+
+# "Several", standing in for the real dir's history. Enough to clear the
+# detector's materially-busier bar from a 1-job active dir.
+INNER_JOBS = 6
+
+# /api/meta is the identity contract every dashboard-reuse check reads, under a
+# short socket timeout and a bounded read. An oversized body silently becomes
+# None on the client, which reads as "not my dashboard" and makes the CLI and
+# MCP spawn duplicate servers -- so its size is part of the contract.
+META_MAX_BYTES = 4096
+
+
+class Incident(NamedTuple):
+    """The reported filesystem, resolved. See :func:`_incident`."""
+
+    base: Path
+    wrapper: Path
+    inner: Path
+    wrapper_state_dir: Path
+    inner_state_dir: Path
+
+
+def _make_jobs(state_dir: Path, count: int, *, offset: float = 0.0) -> None:
+    """Fake job history: ``<state_dir>/jobs/<id>`` directories.
+
+    Directories are the whole fixture because the detector counts them rather
+    than opening the store -- it has to stay SQLite-free so that answering a
+    diagnostic question never spins up the WAL writer.
+    """
+    jobs = state_dir / "jobs"
+    jobs.mkdir(parents=True, exist_ok=True)
+    for index in range(count):
+        job = jobs / f"job_{state_dir.name[:8]}_{index:03d}"
+        job.mkdir(exist_ok=True)
+        stamp = _JOB_EPOCH + offset + index
+        os.utime(job, (stamp, stamp))
+
+
+@contextlib.contextmanager
+def _chdir(target: Path):
+    """Run the block with ``target`` as the *process* cwd, then restore it.
+
+    Not cosmetic. ``dashboard._state_dir_diagnosis`` calls the detector with no
+    ``cwd``, so ``/api/diagnostics`` diagnoses against ``Path.cwd()`` -- the
+    serving process's cwd *is* the workspace whose jobs the user expects to
+    see. Reproducing the incident over HTTP therefore means the serving process
+    actually standing in the wrapper directory. This repo's own root is a git
+    checkout, so without the chdir the detector's "cwd is a git root" guard
+    would fire and the HTTP assertions would pass vacuously.
+    """
+    previous = os.getcwd()
+    os.chdir(target)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+@contextlib.contextmanager
+def _incident(tmp: str):
+    """Build the reported situation from scratch, with a real git repository.
+
+    ``<tmp>/wrapper`` is an ordinary folder with no repository in it or above
+    it; ``<tmp>/wrapper/Inner`` is a genuine ``git init`` checkout. That is the
+    incident's precondition, and it is left real rather than mocked: the bug is
+    a disagreement between what git answers from each directory.
+
+    ``app_state_root`` is redirected under ``<tmp>`` so both derived state dirs
+    live in the temp tree. Yields inside the patch on purpose --
+    ``projects_root``, ``project_state_dir_for`` and ``default_state_dir`` all
+    resolve that root at *call* time, so any expected value derived after the
+    block exits would silently be computed against the real AppData root and
+    would make the expectation wrong rather than the assertion.
+    """
+    base = Path(tmp).resolve()
+    wrapper = base / "wrapper"
+    inner = wrapper / "Inner"
+    inner.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=inner, check=True, capture_output=True)
+    with patch.object(state, "app_state_root", return_value=base / "app-state"):
+        wrapper_state_dir = state.project_state_dir_for(wrapper)
+        inner_state_dir = state.project_state_dir_for(inner)
+        _make_jobs(wrapper_state_dir, WRAPPER_JOBS)
+        _make_jobs(inner_state_dir, INNER_JOBS, offset=100.0)
+        yield Incident(base, wrapper, inner, wrapper_state_dir, inner_state_dir)
+
+
+@unittest.skipUnless(shutil.which("git"), "git required")
+class WrongProjectDashboardEndToEndTests(unittest.TestCase):
+    """One real git tree, every surface that could have broken the silence."""
+
+    # -- shared assertions -------------------------------------------------
+
+    def _assert_no_absolute_path(self, text: str, paths) -> None:
+        """No path from the fixture tree appears in ``text``, raw or escaped.
+
+        The escaped form matters: these strings travel through
+        ``json.dumps``, which doubles a Windows separator, so a naive
+        substring check for ``C:\\Users\\...`` would miss ``C:\\\\Users\\\\...``
+        in a JSON body and quietly pass. On POSIX the two forms coincide and
+        the second check is a harmless duplicate.
+
+        Note what is *not* asserted for a JSON body: "contains no os.sep at
+        all". ``short_warning``'s em-dash is emitted by ``json.dumps`` as the
+        escape ``\\u2014``, whose backslash is ``os.sep`` on Windows -- so that
+        stronger form would fail on an artefact of the server's own encoding.
+        """
+        for path in paths:
+            raw = str(path)
+            self.assertNotIn(raw, text, raw)
+            escaped = json.dumps(raw)[1:-1]
+            self.assertNotIn(escaped, text, escaped)
+
+    def _state_identity_row(self, root: Path, state_dir: Path):
+        """The ``state-identity`` row from a full ``run_doctor`` report.
+
+        Through ``run_doctor`` rather than the private check, because the row
+        only helps if it actually reaches the report a user runs -- and because
+        the report must survive a folder that is not a repository at all.
+        """
+        checks = {c.name: c for c in run_doctor(root, state_dir)}
+        self.assertIn("state-identity", checks)
+        row = checks["state-identity"]
+        # A diagnostic that crashes the report it lives in would be worse than
+        # the silence it replaces.
+        self.assertNotIn(row.status, {"fail", "error"}, row.detail)
+        self.assertTrue(row.evidence, row.detail)
+        return row
+
+    # -- 1. the fork is real ----------------------------------------------
+
+    def test_wrapper_and_nested_repo_fork_into_two_state_dirs(self) -> None:
+        """The or-fallback fires: one project, two hashed dirs, no error.
+
+        This is the whole root cause, stated as an equality. Both derived paths
+        are computed inside the ``app_state_root`` patch, since
+        ``project_state_dir_for`` resolves ``projects_root()`` at call time.
+        """
+        with TemporaryDirectory() as tmp, _incident(tmp) as fx:
+            from_wrapper = state.default_state_dir(cwd=fx.wrapper)
+            from_inner = state.default_state_dir(cwd=fx.inner)
+            formula_wrapper = state.project_state_dir_for(fx.wrapper)
+            formula_inner = state.project_state_dir_for(fx.inner)
+            projects_root = state.projects_root()
+            wrapper_jobs = summarize_project_state_dir(fx.wrapper_state_dir).job_count
+            inner_jobs = summarize_project_state_dir(fx.inner_state_dir).job_count
+
+            # The fork.
+            self.assertNotEqual(from_wrapper, from_inner)
+            # Real git wins from inside the checkout: --show-toplevel and
+            # Path.resolve() agree, so the formula the detector uses to map a
+            # sibling checkout to its state dir matches what the checkout
+            # itself would resolve to.
+            self.assertEqual(from_inner, formula_inner)
+            # ...and from the wrapper there is no repository to find, so cwd
+            # itself gets hashed. If this ever fails, the machine's temp dir is
+            # inside a git checkout and the fixture's precondition is void.
+            self.assertEqual(
+                from_wrapper,
+                formula_wrapper,
+                "the wrapper must not resolve to any enclosing git root",
+            )
+            # Both are project-scoped: one logical project, two siblings under
+            # the same projects/ root. That is what makes it a fork rather than
+            # two unrelated projects.
+            self.assertEqual(from_wrapper.parent, projects_root)
+            self.assertEqual(from_inner.parent, projects_root)
+            # The reported asymmetry, in the counter the detector actually uses.
+            self.assertEqual(wrapper_jobs, WRAPPER_JOBS)
+            self.assertEqual(inner_jobs, INNER_JOBS)
+
+    # -- 2. the doctor surface --------------------------------------------
+
+    def test_doctor_warns_and_names_the_busy_dir_and_every_remedy(self) -> None:
+        """``puppetmaster doctor`` stops reporting the fork as a benign optional."""
+        with TemporaryDirectory() as tmp, _incident(tmp) as fx:
+            row = self._state_identity_row(fx.wrapper, fx.wrapper_state_dir)
+            detail = row.detail
+
+            self.assertEqual(row.status, "warn", detail)
+
+            # Both job counts, each bound to the dir it belongs to. Asserting a
+            # bare "6" would be vacuous -- the 12-hex digest in either basename
+            # can contain that character by chance.
+            self.assertIn(
+                f"{fx.wrapper_state_dir.name} holds {WRAPPER_JOBS} job(s)", detail
+            )
+            self.assertIn(f"{fx.inner_state_dir.name} holds {INNER_JOBS}", detail)
+
+            # Every escape hatch, because which one applies depends on what the
+            # user was actually trying to do: move, pin, or look at everything.
+            for needle in (
+                "not a git repository",
+                "git root",
+                "--state-dir",
+                "--all-projects",
+                "puppetmaster projects",
+            ):
+                self.assertIn(needle, detail, needle)
+
+            # Basenames only. A doctor report is pasted into issues verbatim.
+            self._assert_no_absolute_path(
+                detail,
+                (
+                    fx.base,
+                    fx.wrapper,
+                    fx.inner,
+                    fx.wrapper_state_dir,
+                    fx.inner_state_dir,
+                ),
+            )
+
+    # -- 3. the launch surface --------------------------------------------
+
+    def test_short_warning_is_one_safe_sentence_naming_the_nested_repo(self) -> None:
+        """The one-line form ``serve()`` prints to stderr and MCP embeds.
+
+        ``short_warning`` names the *workspace* basename of the nested repo
+        rather than its full hashed state dir name, because it is capped at 140
+        characters for a status line. The two identify the same directory: a
+        state dir's basename is that workspace name plus a 12-hex digest, which
+        the ``startswith`` assertion below pins rather than assumes.
+        """
+        with TemporaryDirectory() as tmp, _incident(tmp) as fx:
+            diagnosis = diagnose_state_dir(
+                cwd=fx.wrapper, state_dir=fx.wrapper_state_dir
+            )
+            warning = short_warning(diagnosis)
+
+            self.assertIsInstance(warning, str)
+            self.assertTrue(warning)
+            self.assertLessEqual(len(warning), 140)
+
+            self.assertTrue(
+                fx.inner_state_dir.name.startswith(f"{fx.inner.name}-"),
+                f"{fx.inner_state_dir.name} does not name {fx.inner.name}",
+            )
+            self.assertIn(f"nested repo {fx.inner.name} has {INNER_JOBS}", warning)
+            self.assertIn(
+                f"{fx.wrapper_state_dir.name} has {WRAPPER_JOBS} job(s)", warning
+            )
+
+            # This line lands in dashboard.err.log, which users paste verbatim.
+            self._assert_no_absolute_path(
+                warning,
+                (
+                    fx.base,
+                    fx.wrapper,
+                    fx.inner,
+                    fx.wrapper_state_dir,
+                    fx.inner_state_dir,
+                ),
+            )
+            # Here -- unlike a JSON body -- the stronger form does hold: the
+            # sentence contains no path separator of any kind.
+            self.assertNotIn(os.sep, warning)
+            self.assertNotIn("/", warning)
+
+    # -- 4. the HTTP surface ----------------------------------------------
+
+    def _serve(self, state_dir: Path) -> int:
+        """Bind a real dashboard on ``state_dir`` and return its port.
+
+        ``port=0`` lets the OS pick, so a developer's own dashboard on 8787
+        cannot collide with the test. ``addCleanup`` is LIFO, so
+        ``server_close`` is registered FIRST in order to run LAST -- shutdown
+        has to stop the serving thread before the socket is closed under it.
+        """
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            httpd = serve(
+                state_dir,
+                backend="sqlite",
+                host="127.0.0.1",
+                port=0,
+                open_browser=False,
+                serve_forever=False,
+            )
+        self.addCleanup(httpd.server_close)
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        self.addCleanup(httpd.shutdown)
+        return httpd.server_address[1]
+
+    @staticmethod
+    def _get(port: int, path: str) -> dict:
+        """One GET against the live server; the raw body is kept for scanning."""
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{port}{path}", timeout=30
+        ) as resp:
+            return {"code": resp.status, "raw": resp.read().decode("utf-8")}
+
+    def test_live_dashboard_reports_the_fork_without_disturbing_its_identity(
+        self,
+    ) -> None:
+        """A real bound server: /api/diagnostics tells, /api/meta is untouched.
+
+        Both endpoints in one test on purpose. The diagnosis is the new thing;
+        /api/meta is the thing it must not have cost us, and asserting them
+        against the same running server is the only way to show that the
+        filesystem walk behind one did not leak into the other.
+        """
+        with TemporaryDirectory() as tmp, _incident(tmp) as fx:
+            # The serving process must actually stand in the wrapper: the
+            # endpoint diagnoses against Path.cwd(). See _chdir.
+            with _chdir(fx.wrapper):
+                port = self._serve(fx.wrapper_state_dir)
+                diagnostics = self._get(port, "/api/diagnostics")
+                meta = self._get(port, "/api/meta")
+
+            self.assertEqual(diagnostics["code"], 200)
+            diagnosis = json.loads(diagnostics["raw"])["diagnosis"]
+            self.assertIsNotNone(diagnosis, diagnostics["raw"])
+            self.assertTrue(diagnosis["suspect"])
+            self.assertEqual(diagnosis["candidate"], fx.inner_state_dir.name)
+            self.assertEqual(diagnosis["candidate_jobs"], INNER_JOBS)
+            # The board is still honest about what it *is* serving -- it was
+            # never wrong about that; it was only silent about it being the
+            # wrong project.
+            self.assertEqual(diagnosis["project"], fx.wrapper_state_dir.name)
+            self.assertEqual(diagnosis["jobs"], WRAPPER_JOBS)
+            self.assertTrue(diagnosis["message"])
+
+            # The endpoint is unauthenticated and reachable off-loopback under
+            # --mobile, so the body carries basenames and never a filesystem
+            # layout.
+            self._assert_no_absolute_path(
+                diagnostics["raw"],
+                (
+                    fx.base,
+                    fx.wrapper,
+                    fx.inner,
+                    fx.wrapper_state_dir,
+                    fx.inner_state_dir,
+                ),
+            )
+
+            # ...and the identity contract that guards against duplicate
+            # dashboards still answers, small and unchanged.
+            self.assertEqual(meta["code"], 200)
+            meta_body = json.loads(meta["raw"])
+            self.assertEqual(meta_body["service"], "puppetmaster-dashboard")
+            self.assertEqual(meta_body["project"], fx.wrapper_state_dir.name)
+            self.assertFalse(meta_body["all_projects"])
+            self.assertLess(len(meta["raw"].encode("utf-8")), META_MAX_BYTES)
+
+    # -- 5. negative control: run from the right place ---------------------
+
+    def test_running_from_the_nested_repo_says_nothing_at_all(self) -> None:
+        """The correct workspace on the identical filesystem must stay quiet.
+
+        As important as the positive case: without it the suite could pass
+        while warning about everything. The paired wrapper assertion at the end
+        is what makes this non-vacuous -- the same tree, the same run, one
+        warning and one silence, decided only by where you stand.
+        """
+        with TemporaryDirectory() as tmp, _incident(tmp) as fx:
+            row = self._state_identity_row(fx.inner, fx.inner_state_dir)
+            diagnosis = diagnose_state_dir(
+                cwd=fx.inner, state_dir=fx.inner_state_dir
+            )
+            warning = short_warning(diagnosis)
+            control = self._state_identity_row(fx.wrapper, fx.wrapper_state_dir)
+
+            self.assertNotEqual(row.status, "warn", row.detail)
+            self.assertNotIn(row.status, {"warn", "fail", "error"}, row.detail)
+            self.assertFalse(diagnosis.suspect, diagnosis.evidence)
+            self.assertIsNone(warning)
+            # ...and it is quiet for the *right* reason: cwd is the git root,
+            # so its state dir is correct by definition and a nested checkout
+            # would be a legitimately separate project.
+            self.assertIn("verdict:workspace-is-git-root", diagnosis.evidence)
+            self.assertIn("cwd_is_git_root:true", diagnosis.evidence)
+
+            # Not vacuous: the very same fixture still warns from the wrapper.
+            self.assertEqual(control.status, "warn", control.detail)
+
+    # -- 6. negative control: an explicit state dir is a deliberate choice --
+
+    def test_an_explicit_state_dir_is_never_second_guessed(self) -> None:
+        """``--state-dir`` / ``PUPPETMASTER_STATE_DIR`` opts out by construction.
+
+        Only the hashed ``projects/`` layout can fork, so a path the user named
+        themselves is out of scope -- contradicting it would make the documented
+        escape hatch from this very warning itself produce the warning.
+        """
+        with TemporaryDirectory() as tmp, _incident(tmp) as fx:
+            explicit = fx.base / "explicit-state"
+            _make_jobs(explicit, WRAPPER_JOBS)
+            projects_root = state.projects_root()
+
+            row = self._state_identity_row(fx.wrapper, explicit)
+            diagnosis = diagnose_state_dir(cwd=fx.wrapper, state_dir=explicit)
+            warning = short_warning(diagnosis)
+            control = self._state_identity_row(fx.wrapper, fx.wrapper_state_dir)
+
+            # The premise: this really is outside the hashed layout.
+            self.assertNotEqual(explicit.parent, projects_root)
+
+            self.assertNotEqual(row.status, "warn", row.detail)
+            self.assertEqual(row.status, "optional", row.detail)
+            self.assertFalse(diagnosis.suspect, diagnosis.evidence)
+            self.assertEqual(diagnosis.candidates, ())
+            self.assertIsNone(warning)
+
+            # Not vacuous: same cwd, same disk, same run -- only the pin
+            # differs, and unpinned still warns.
+            self.assertEqual(control.status, "warn", control.detail)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The bug

`default_state_dir()` hashes **the git root of the caller's cwd**:

```python
workspace = _git_root(cwd or Path.cwd()) or (cwd or Path.cwd())
```

Open a session at a non-git wrapper folder *above* the checkout and the `or` fallback fires, silently forking one logical project into two state dirs. Observed in the field:

| cwd | state dir | contents |
|---|---|---|
| `C:\Projects\puppetmaster` (not a repo) | `puppetmaster-c3177e6032c4` | 1 stale job — the board being watched |
| `C:\Projects\puppetmaster\Puppetmaster` (git root) | `Puppetmaster-b92145e840c8` | 29 jobs — all the real work |

Two dashboards on adjacent ports were **pixel-identical**, and the emptier one was correct by its own identity check. `dashboard_serves()` only proves *"the server on this port serves the state dir I computed"* — never *"that state dir is where this workspace's jobs go."* Every job-scoped path already pivots (`mcp_state_dir`'s `find_state_dir_for_job` branch, `_resolve_store_for_job`'s stderr note); the job **index** was the one surface with no pivot and no signal.

## What this does

**Detection is warn-only.** No existing state directory path changes, so no job history is moved or orphaned.

- **`state.py`** — extract `projects_root()` and `project_state_dir_for()` so the detector can ask *"what dir would that repo get?"* without a git probe and without duplicating the slug+digest formula. Pure extraction: the regex, `.strip("-")`, the `or "workspace"` fallback, `sha256(...)` and `hexdigest()[:12]` all move verbatim.
- **`state_health.py`** (new) — `diagnose_state_dir()` behind a six-guard chain: not-project-scoped → workspace-is-git-root → not-cwd-derived → near-empty → depth-1 sibling scan → **name-twin**. Counts `jobs/*` directories and never opens a store.
- **`diagnostics.py`** — a `state-identity` doctor row (`ok`/`warn`/`optional`, never `fail`).
- **`dashboard.py`** — a header project tag plus tab title from a pure `projectLabel()`; a stderr warning at `serve()`; a new `GET /api/diagnostics` feeding an escaped page banner.
- **`dashboard.py`** — `list_all_projects_snapshot` no longer swallows per-project read failures behind a bare `except Exception`. Unreadable projects are **reported** instead of vanishing from an `--all-projects` board.
- **`mcp_server.py`** — a `state_dir_may_be_wrong` warning appended to `run_dashboard`, folded into the existing `note` rather than replacing it. Advisory only (no `isError`), skipped for `--all-projects`.

## Two decisions worth calling out

**8 digest hex digits are load-bearing.** The two real colliding dirs differ **only by letter case** once the digest is stripped (`puppetmaster` vs `Puppetmaster`). Trimming the digest for looks would re-merge on screen exactly what the tag exists to tell apart.

**The diagnosis is deliberately NOT on `/api/meta`.** `dashboard_identity` reads at most 65536 bytes under a 1s socket timeout and `json.loads` the body, so a slow or oversized response there is silently read as *"not my dashboard"* — which is precisely how you get duplicate dashboards. The filesystem walk stays behind its own TTL-cached route. Verified: `/api/meta` is still **167 bytes** with its original six keys, and `dashboard_identity()` resolves in 0.001s.

**The name-twin trigger, not emptiness.** The bad dir held **one** stale job, so a "zero jobs" rule would have stayed silent on the actual reported case.

## Verification

- **62** tests across 5 new suites; **1275 passed / 14 skipped** on `tests/test_puppetmaster.py`.
- **`default_state_dir` proved byte-identical** before/after the extraction across 7 paths (including both real incident paths), by importing `puppetmaster.state` from a pristine baseline worktree and from this branch at the same commit and comparing real return values.
- `tests/test_cli_state_routing.py` stays green — it asserts a nested `outer` vs `outer/"Puppetmaster"` pair still resolve *differently*, which is the exact shape of this bug.
- End-to-end suite reconstructs the incident with a real `git init`, seeding the wrapper with exactly **one** job to match reality, plus two negative controls (running from the nested repo must say nothing; an explicit `--state-dir` is never second-guessed).
- Purity of `projectLabel` is established by a probe that **poisons the browser globals and then calls it** across all seven branches. The pre-existing `RENDERER_JS` node harness cannot establish this: JavaScript resolves free identifiers at *call* time and that harness only exercises `md()`.

Live, against the real directories:

```
WARNING: puppetmaster-c3177e6032c4 has 1 job(s) but nested repo Puppetmaster
         has 29 — not a git repo here; see puppetmaster projects.
```

```json
{"diagnosis": {"suspect": true, "verdict": "name-twin",
  "project": "puppetmaster-c3177e6032c4", "jobs": 1,
  "candidate": "Puppetmaster-b92145e840c8", "candidate_jobs": 29}}
```

No absolute paths leak; a non-loopback (`--mobile`) peer gets a boolean only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
