### PR TITLE
Fix Windows cell sqlite unlink after inspect

### DIFF
--- a/puppetmaster/cell.py
+++ b/puppetmaster/cell.py
@@ -101,16 +101,44 @@ class CellRegistry:
 
     @contextmanager
     def _connect(self, path: Path):
+        """Open a cell DB, apply PRAGMAs, and ALWAYS close the handle.
+
+        ``with sqlite3.connect(...) as conn`` is a *transaction* context
+        manager — it commits/rolls back but leaves the OS file handle
+        open. Windows holds a mandatory lock on that handle, so a later
+        unlink / TemporaryDirectory cleanup fails with ``WinError 32``.
+        Fetch ``journal_mode`` so the result row does not linger unread.
+        """
         connection = sqlite3.connect(str(path), timeout=_BUSY_TIMEOUT_MS / 1000.0)
-        connection.row_factory = sqlite3.Row
-        connection.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
-        connection.execute("PRAGMA journal_mode = WAL")
-        connection.execute("PRAGMA synchronous = NORMAL")
-        connection.execute("PRAGMA foreign_keys = ON")
         try:
+            connection.row_factory = sqlite3.Row
+            connection.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+            connection.execute("PRAGMA journal_mode = WAL").fetchone()
+            connection.execute("PRAGMA synchronous = NORMAL")
+            connection.execute("PRAGMA foreign_keys = ON")
             yield connection
         finally:
             connection.close()
+
+    def close(self) -> None:
+        """Drop live workers and checkpoint every cell file.
+
+        Call this before deleting a temporary state dir so Windows can
+        unlink ``*.sqlite`` (and ``-wal`` / ``-shm``) after inspect.
+        Connections are already closed per ``_connect``; the checkpoint
+        releases WAL sidecar locks that otherwise race teardown.
+        """
+        self._live.clear()
+        if not self.cells_dir.is_dir():
+            return
+        for path in sorted(self.cells_dir.glob("*.sqlite")):
+            connection = sqlite3.connect(str(path), timeout=_BUSY_TIMEOUT_MS / 1000.0)
+            try:
+                connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            except sqlite3.Error:
+                pass
+            finally:
+                connection.close()
 
     def _init_schema(self, connection: sqlite3.Connection, cell_id: str) -> None:
         connection.executescript(
@@ -470,4 +498,8 @@ def registry_for_store(store: Any) -> CellRegistry:
 
 def interned_poll(store: Any, *, now: Optional[float] = None) -> list[dict[str, Any]]:
     """Process due cell alarms from an in-process daemon poll."""
-    return registry_for_store(store).tick(now=now)
+    registry = registry_for_store(store)
+    try:
+        return registry.tick(now=now)
+    finally:
+        registry.close()

--- a/puppetmaster/cli/commands_cell.py
+++ b/puppetmaster/cli/commands_cell.py
@@ -51,6 +51,8 @@ def _run_cell_status_command(args, store) -> int:
     except (CellNotFoundError, InvalidCellIdError) as exc:
         print(f"error: {exc}")
         return 1
+    finally:
+        registry.close()
     return _print_status(payload, json_mode=json_mode)
 
 
@@ -66,6 +68,8 @@ def _run_cell_inspect_command(args, store) -> int:
     except (CellNotFoundError, InvalidCellIdError) as exc:
         print(f"error: {exc}")
         return 1
+    finally:
+        registry.close()
     if json_mode:
         print(json.dumps(payload, indent=2, default=str))
         return 0

--- a/tests/test_cell_inbox.py
+++ b/tests/test_cell_inbox.py
@@ -31,9 +31,23 @@ from puppetmaster.mcp_server import handle_message, tools
 
 
 class CellInboxTests(unittest.TestCase):
-    def test_serial_inbox_two_enqueues_one_at_a_time(self) -> None:
+    @contextlib.contextmanager
+    def _cells(self):
+        """Cell registry whose sqlite handles are closed before rmdir.
+
+        Windows cannot unlink ``*.sqlite`` while a connection is open
+        (WinError 32). Product ``CellRegistry.close()`` checkpoints WAL
+        so TemporaryDirectory teardown succeeds on every platform.
+        """
         with TemporaryDirectory() as tmp:
             registry = CellRegistry(tmp)
+            try:
+                yield registry
+            finally:
+                registry.close()
+
+    def test_serial_inbox_two_enqueues_one_at_a_time(self) -> None:
+        with self._cells() as registry:
             first = registry.enqueue("job-alpha", "ping", {"n": 1})
             second = registry.enqueue("job-alpha", "ping", {"n": 2})
             self.assertLess(first, second)
@@ -55,8 +69,7 @@ class CellInboxTests(unittest.TestCase):
             self.assertEqual(event_a["id"] + 1, event_b["id"])
 
     def test_never_two_handlers_concurrently(self) -> None:
-        with TemporaryDirectory() as tmp:
-            registry = CellRegistry(tmp)
+        with self._cells() as registry:
             registry.enqueue("job-mutex", "hold", {"n": 1})
             registry.enqueue("job-mutex", "next", {"n": 2})
             started = threading.Event()
@@ -86,8 +99,7 @@ class CellInboxTests(unittest.TestCase):
             self.assertEqual(leftover["inbox_depth"], 1)
 
     def test_hibernate_then_alarm_resume(self) -> None:
-        with TemporaryDirectory() as tmp:
-            registry = CellRegistry(tmp)
+        with self._cells() as registry:
             registry.enqueue("job-sleep", "work", {"step": "once"})
             registry.process_one("job-sleep")
             hibernated = registry.status("job-sleep")
@@ -108,14 +120,13 @@ class CellInboxTests(unittest.TestCase):
             self.assertEqual(alarm["kind"], "alarm")
             registry.set_alarm("job-sleep", time.time() - 5)
             registry.hibernate("job-sleep")
-            store = type("Store", (), {"root": Path(tmp)})()
+            store = type("Store", (), {"root": registry.root})()
             polled = interned_poll(store)
             self.assertEqual(len(polled), 1)
             self.assertFalse(polled[0]["hibernating"])
 
     def test_inspectable_on_disk_sqlite(self) -> None:
-        with TemporaryDirectory() as tmp:
-            registry = CellRegistry(tmp)
+        with self._cells() as registry:
             registry.enqueue("job-disk", "note", {"hello": "world"})
             status = registry.status("job-disk")
             path = Path(status["path"])
@@ -123,7 +134,11 @@ class CellInboxTests(unittest.TestCase):
             self.assertTrue(is_sqlite_file(path))
             with path.open("rb") as handle:
                 self.assertEqual(handle.read(16), SQLITE_MAGIC)
-            with sqlite3.connect(str(path)) as connection:
+            # sqlite3.connect-as-context is a transaction manager: it does
+            # not close the OS handle. Close explicitly so Windows can
+            # later unlink the inspectable file (WinError 32 otherwise).
+            connection = sqlite3.connect(str(path))
+            try:
                 kinds = [
                     row[0]
                     for row in connection.execute("SELECT kind FROM inbox ORDER BY id")
@@ -133,27 +148,35 @@ class CellInboxTests(unittest.TestCase):
                     "SELECT value FROM cell_meta WHERE key = 'hibernating'"
                 ).fetchone()[0]
                 self.assertIn(hibernating, ("0", "1"))
+            finally:
+                connection.close()
             inspect = registry.inspect("job-disk")
             self.assertEqual(inspect["inbox_depth"], 1)
             self.assertEqual(inspect["inbox"][0]["kind"], "note")
             self.assertTrue(inspect["sqlite"])
+            registry.close()
+            path.unlink()
+            self.assertFalse(path.exists())
 
 
 class CellCliMcpTests(unittest.TestCase):
     def test_cli_cell_status_json(self) -> None:
         with TemporaryDirectory() as tmp:
             registry = CellRegistry(tmp)
-            registry.enqueue("job-cli", "ping", {"ok": True})
-            stdout = io.StringIO()
-            with contextlib.redirect_stdout(stdout):
-                code = cli_main(["--state-dir", tmp, "cell-status", "job-cli", "--json"])
-            self.assertEqual(code, 0)
-            payload = json.loads(stdout.getvalue())
-            self.assertEqual(payload["cell_id"], "job-cli")
-            self.assertEqual(payload["inbox_depth"], 1)
-            self.assertIn("hibernating", payload)
-            self.assertIn("next_alarm", payload)
-            self.assertTrue(Path(payload["path"]).is_file())
+            try:
+                registry.enqueue("job-cli", "ping", {"ok": True})
+                stdout = io.StringIO()
+                with contextlib.redirect_stdout(stdout):
+                    code = cli_main(["--state-dir", tmp, "cell-status", "job-cli", "--json"])
+                self.assertEqual(code, 0)
+                payload = json.loads(stdout.getvalue())
+                self.assertEqual(payload["cell_id"], "job-cli")
+                self.assertEqual(payload["inbox_depth"], 1)
+                self.assertIn("hibernating", payload)
+                self.assertIn("next_alarm", payload)
+                self.assertTrue(Path(payload["path"]).is_file())
+            finally:
+                registry.close()
 
     def test_mcp_tool_is_additive(self) -> None:
         names = {tool.name for tool in tools()}


### PR DESCRIPTION
## Summary
- Close cell sqlite connections (and WAL-checkpoint on `CellRegistry.close()`) so Windows can unlink inspectable `*.sqlite` files.
- Stop using `with sqlite3.connect(...)` in `test_inspectable_on_disk_sqlite` — that context manager is a transaction manager and leaves the OS handle open (`WinError 32` on TemporaryDirectory teardown).
- No version bump (CI/handle fix only).

## Test plan
- [x] `python -m unittest tests.test_cell_inbox`
- [x] `python -m unittest discover -s tests` (Linux box)
- [ ] CI `test (windows-latest, 3.12)` green on main after equate