### PR TITLE
Fix direct OpenAI GPT-5.6 worker effort

### DIFF
--- a/puppetmaster/adapters/agentic.py
+++ b/puppetmaster/adapters/agentic.py
@@ -483,20 +483,7 @@ class AgenticAdapter(FullEditWorkerAdapter):
             extra["temperature"] = float(task.payload["temperature"])
         provider = self._resolve_provider(task)
         direct_openai_api = provider in ("openai", "openai-api")
-        model = str(
-            task.payload.get("model") or task.payload.get("adapter_model_name") or ""
-        ).strip().lower()
-        model_leaf = model.split("/")[-1]
-        # Catalog alias `gpt-5.6` is Sol; hyphenated ids are the named tiers.
-        # Direct OpenAI GPT-5.6 Chat Completions defaults reasoning on when the
-        # field is omitted, then rejects function tools. Explicit `none` is the
-        # accepted tool contract. Older GPT-5 rejects `none`, so omit it there.
-        direct_openai_gpt56 = direct_openai_api and (
-            model_leaf == "gpt-5.6" or model_leaf.startswith("gpt-5.6-")
-        )
-        if direct_openai_gpt56:
-            extra["reasoning_effort"] = "none"
-        elif task.payload.get("reasoning_effort") and not direct_openai_api:
+        if task.payload.get("reasoning_effort"):
             extra["reasoning_effort"] = str(task.payload["reasoning_effort"])
         elif _provider_is_openai_compatible(provider) and not direct_openai_api:
             # Swarm workers on OpenRouter / OpenAI-compatible endpoints often

--- a/puppetmaster/providers.py
+++ b/puppetmaster/providers.py
@@ -1956,6 +1956,43 @@ def _prepare_opencode_go_call(
     return bare, mode, prepared, url
 
 
+def _openai_api_chat(
+    *, base_url: str, api_key: Optional[str], model: str, messages: list[dict],
+    tools: Optional[list[dict]], extra: dict, headers: dict, timeout: int,
+    stream: bool = False, on_delta: Optional[Callable[[str, str], None]] = None,
+) -> AssistantTurn:
+    """Direct OpenAI call with GPT-5.6 reasoning transport ownership."""
+    model_leaf = str(model or "").strip().lower().split("/")[-1]
+    prepared = dict(extra or {})
+    effort = str(prepared.get("reasoning_effort") or "").strip().lower()
+    gpt56 = model_leaf == "gpt-5.6" or model_leaf.startswith("gpt-5.6-")
+    if gpt56 and effort not in ("", "none"):
+        responses = _openai_responses_chat_stream if stream else _openai_responses_chat
+        kwargs = {
+            "base_url": base_url, "api_key": api_key, "model": model,
+            "messages": messages, "tools": tools, "extra": prepared,
+            "headers": headers, "timeout": timeout,
+        }
+        if stream:
+            kwargs["on_delta"] = on_delta
+        return responses(**kwargs)
+
+    if gpt56:
+        prepared["reasoning_effort"] = "none"
+    else:
+        prepared.pop("reasoning_effort", None)
+    if stream:
+        return _openai_chat_stream(
+            base_url=base_url, api_key=api_key, model=model, messages=messages,
+            tools=tools, extra=prepared, headers=headers, timeout=timeout,
+            on_delta=on_delta,
+        )
+    return _openai_chat(
+        base_url=base_url, api_key=api_key, model=model, messages=messages,
+        tools=tools, extra=prepared, headers=headers, timeout=timeout,
+    )
+
+
 def _openai_codex_chat(
     *,
     base_url: str,
@@ -2165,6 +2202,12 @@ def _provider_chat_streaming_inner(
             tools=tools, extra=extra, headers=dict(desc.default_headers),
             timeout=timeout, on_delta=on_delta,
         )
+    if desc.slug in ("openai", "openai-api"):
+        return _openai_api_chat(
+            base_url=url, api_key=key, model=model, messages=messages,
+            tools=tools, extra=extra, headers=dict(desc.default_headers),
+            timeout=timeout, stream=True, on_delta=on_delta,
+        )
     if desc.wire == "anthropic":
         return _anthropic_chat_stream(
             base_url=url, api_key=key, model=model, messages=messages,
@@ -2283,6 +2326,11 @@ def _provider_chat_inner(
             base_url=url, api_key=key, model=model, messages=messages,
             tools=tools, extra=extra, headers=dict(desc.default_headers),
             timeout=timeout,
+        )
+    if desc.slug in ("openai", "openai-api"):
+        return _openai_api_chat(
+            base_url=url, api_key=key, model=model, messages=messages,
+            tools=tools, extra=extra, headers=dict(desc.default_headers), timeout=timeout,
         )
     if desc.wire == "anthropic":
         return _anthropic_chat(

--- a/tests/test_agentic_standalone.py
+++ b/tests/test_agentic_standalone.py
@@ -45,56 +45,101 @@ class AgenticReasoningEffortTests(unittest.TestCase):
     def _openai_wire_body(self, provider: str, model: str, **payload: object) -> dict:
         captured: dict = {}
 
-        def fake_post_json(*_args, **kwargs):
-            captured.update(kwargs["body"])
+        def fake_post_json(url, *, headers, body, timeout):
+            captured.update(url=url, body=body)
             return {"choices": [{"message": {"content": "ok"}}], "usage": {}}
 
         extra = self._extra(provider, model=model, **payload)
         with mock.patch.object(providers, "_post_json", side_effect=fake_post_json):
-            providers._openai_chat(
-                base_url="https://api.openai.com/v1",
-                api_key=None,
+            providers.provider_chat(
+                provider=provider,
                 model=model,
                 messages=[{"role": "user", "content": "test"}],
                 tools=[{"type": "function", "function": {"name": "submit_findings"}}],
                 extra=extra,
-                headers={},
-                timeout=10,
+                api_key="test-key",
             )
         return captured
 
-    def test_direct_openai_gpt56_tool_requests_send_none(self) -> None:
+    def test_direct_openai_gpt56_without_selected_effort_keeps_none_fallback(self) -> None:
         for provider in ("openai", "openai-api"):
             for model in ("gpt-5.6", "gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"):
                 with self.subTest(provider=provider, model=model):
-                    self.assertEqual(
-                        self._extra(provider, model=model).get("reasoning_effort"),
-                        "none",
-                    )
-                    self.assertEqual(
-                        self._openai_wire_body(provider, model).get("reasoning_effort"),
-                        "none",
-                    )
+                    captured = self._openai_wire_body(provider, model)
+                    self.assertEqual(captured["url"], "https://api.openai.com/v1/chat/completions")
+                    self.assertEqual(captured["body"]["reasoning_effort"], "none")
+
+    def test_direct_openai_gpt56_selected_effort_reaches_responses_with_tools(self) -> None:
+        captured: dict = {}
+
+        def fake_post_json(url, *, headers, body, timeout):
+            captured.update(url=url, body=body)
+            return {
+                "status": "completed",
+                "output": [{
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "submit_findings",
+                    "arguments": '{"findings": []}',
+                }],
+                "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            }
+
+        tools = [{"type": "function", "function": {"name": "submit_findings"}}]
+        extra = self._extra(
+            "openai-api", model="gpt-5.6-luna", reasoning_effort="max",
+        )
+        with mock.patch.object(providers, "_post_json", side_effect=fake_post_json):
+            turn = providers.provider_chat(
+                provider="openai-api",
+                model="gpt-5.6-luna",
+                messages=[{"role": "user", "content": "inspect"}],
+                tools=tools,
+                extra=extra,
+                api_key="test-key",
+            )
+
+        self.assertEqual(captured["url"], "https://api.openai.com/v1/responses")
+        self.assertEqual(captured["body"]["reasoning"], {"effort": "max", "summary": "auto"})
+        self.assertEqual(captured["body"]["tools"][0]["name"], "submit_findings")
+        self.assertEqual(turn.tool_calls[0]["name"], "submit_findings")
+
+    def test_direct_openai_gpt56_selected_effort_streams_responses(self) -> None:
+        tools = [{"type": "function", "function": {"name": "submit_findings"}}]
+        extra = self._extra(
+            "openai-api", model="gpt-5.6-luna", reasoning_effort="max",
+        )
+        expected = object()
+        with mock.patch.object(
+            providers, "_openai_responses_chat_stream", return_value=expected,
+        ) as responses:
+            turn = providers.provider_chat_streaming(
+                provider="openai-api",
+                model="gpt-5.6-luna",
+                messages=[{"role": "user", "content": "inspect"}],
+                tools=tools,
+                extra=extra,
+                api_key="test-key",
+                on_delta=lambda _kind, _text: None,
+            )
+
+        self.assertIs(turn, expected)
+        self.assertEqual(responses.call_args.kwargs["extra"]["reasoning_effort"], "max")
+        self.assertEqual(responses.call_args.kwargs["tools"], tools)
 
     def test_direct_openai_older_gpt5_tool_requests_omit_reasoning(self) -> None:
         for provider in ("openai", "openai-api"):
             for model in ("gpt-5", "gpt-5.5"):
                 with self.subTest(provider=provider, model=model):
                     self.assertNotIn("reasoning_effort", self._extra(provider, model=model))
-                    self.assertNotIn(
-                        "reasoning_effort",
-                        self._extra(provider, model=model, reasoning_effort="high"),
+                    captured = self._openai_wire_body(
+                        provider, model, reasoning_effort="high",
                     )
-                    self.assertNotIn(
-                        "reasoning_effort",
-                        self._openai_wire_body(provider, model),
-                    )
+                    self.assertNotIn("reasoning_effort", captured["body"])
 
     def test_direct_openai_gpt56_prefixed_alias_sends_none(self) -> None:
-        self.assertEqual(
-            self._extra("openai-api", model="openai/gpt-5.6").get("reasoning_effort"),
-            "none",
-        )
+        captured = self._openai_wire_body("openai-api", "openai/gpt-5.6")
+        self.assertEqual(captured["body"]["reasoning_effort"], "none")
 
     def test_other_openai_wire_provider_keeps_reasoning_effort(self) -> None:
         self.assertEqual(

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -11108,24 +11108,6 @@ class ModelRouterTests(unittest.TestCase):
         )
         self.assertNotIn("reasoning_effort", adapter._extra_params(anthropic_task))
 
-        # Direct OpenAI Chat Completions requires explicit `none` for GPT-5.6
-        # function tools, while older GPT-5 models reject `none` and work with
-        # the field omitted.
-        for provider in ("openai", "openai-api"):
-            for model in ("gpt-5.6", "gpt-5.6-luna"):
-                gpt56_task = Task(
-                    job_id="j", role="explore", instruction="x",
-                    payload={"provider": provider, "model": model},
-                )
-                self.assertEqual(
-                    adapter._extra_params(gpt56_task).get("reasoning_effort"), "none"
-                )
-            older_task = Task(
-                job_id="j", role="explore", instruction="x",
-                payload={"provider": provider, "model": "gpt-5"},
-            )
-            self.assertNotIn("reasoning_effort", adapter._extra_params(older_task))
-
         # openai-codex still gets the Chat Completions key; provider_chat maps
         # it to nested Responses ``reasoning`` (bare key would HTTP 400).
         openai_codex_task = Task(


### PR DESCRIPTION
## Summary

Direct OpenAI GPT-5.6 agentic workers accepted a selected reasoning effort but replaced it with `none`. This routes selected effort through the existing Responses transport while preserving the current no-effort Chat Completions fallback. Older GPT-5 behavior is unchanged.

No routing, registry, or scoring policy changes are included.

## Evidence

Focused tests:

```text
4 passed in 0.08s
```

Live bounded PM worker smoke:

```text
provider=openai-api
model=gpt-5.6-luna
endpoint=/responses
reasoning=max
tools=7
typed_artifact=finding
failures=0
wire_confirmed=true
```