### PR TITLE
Fix scorecard evidence matching for model variants

### DIFF
--- a/puppetmaster/scorecards.py
+++ b/puppetmaster/scorecards.py
@@ -142,17 +142,13 @@ def load_community_baseline(path: Path) -> dict:
 
 
 def _identity_hit(spec: Any, entry: dict) -> bool:
+    """Match evidence to one exact registry id, never a shared wire name."""
     entry_id = entry.get("id")
-    entry_name = entry.get("adapter_model_name")
-    if isinstance(entry_id, str) and entry_id and spec.id == entry_id:
-        return True
-    if (
-        isinstance(entry_name, str)
-        and entry_name
-        and spec.adapter_model_name == entry_name
-    ):
-        return True
-    return False
+    return (
+        isinstance(entry_id, str)
+        and bool(entry_id)
+        and spec.id == entry_id
+    )
 
 
 def _copy_card(card: Any) -> Optional[dict]:
@@ -217,8 +213,8 @@ def import_community_baseline(
 ) -> "tuple[list, dict]":
     """Overlay adapter-scoped community cards onto ``specs``.
 
-    Match only when both adapter and (id or adapter_model_name) match. Never
-    copies cards across adapters. Never overwrites ``capability_score``.
+    Match only when registry id and adapter both match. Never copies cards
+    across registry variants or adapters. Never overwrites ``capability_score``.
     Existing local cards win per role unless ``replace_cards``.
     """
     existing = list(specs)

--- a/tests/test_role_scorecards.py
+++ b/tests/test_role_scorecards.py
@@ -213,12 +213,44 @@ class ImportBaselineTests(unittest.TestCase):
         self.assertEqual(report["cards_added"], 1)
         self.assertEqual(report["skipped_adapter_mismatch"], [])
 
+    def test_exact_variant_id_prevents_effort_evidence_cross_contamination(self) -> None:
+        from puppetmaster.scorecards import import_community_baseline
+
+        low = _spec(
+            id="agentic/openai-api/gpt-5.6-luna-low",
+            adapter="agentic",
+            adapter_model_name="gpt-5.6-luna",
+            payload_defaults={"provider": "openai-api", "reasoning_effort": "low"},
+        )
+        max_effort = _spec(
+            id="agentic/openai-api/gpt-5.6-luna-max",
+            adapter="agentic",
+            adapter_model_name="gpt-5.6-luna",
+            payload_defaults={"provider": "openai-api", "reasoning_effort": "max"},
+        )
+        bundle = self._bundle([
+            {
+                "id": max_effort.id,
+                "adapter": "agentic",
+                "adapter_model_name": "gpt-5.6-luna",
+                "role_scorecards": {"implement": {"quality": 0.9}},
+            }
+        ])
+
+        imported, report = import_community_baseline([low, max_effort], bundle)
+        by_id = {spec.id: spec for spec in imported}
+
+        self.assertEqual(by_id[low.id].role_scorecards, {})
+        self.assertEqual(by_id[max_effort.id].role_scorecards["implement"]["quality"], 0.9)
+        self.assertEqual(report["matched"], [max_effort.id])
+        self.assertEqual(report["cards_added"], 1)
+
     def test_skips_adapter_mismatch(self) -> None:
         from puppetmaster.scorecards import import_community_baseline
 
         specs = [
             _spec(
-                id="openai/grok-4-6",
+                id="cursor/grok-4-6",
                 adapter="openai",
                 adapter_model_name="grok-4.6",
                 capability_score=88,


### PR DESCRIPTION
## Summary

Community scorecard imports currently match by registry ID or `adapter_model_name`. Effort variants intentionally share an adapter model name, so evidence for one variant can attach to its siblings.

This removes the wire-name fallback and matches evidence by exact registry ID plus the existing adapter check. No routing, scoring, bundle-format, or provider behavior changes are included.

## Evidence

RED reproduced Max evidence attaching to the Low variant.

Focused regression suite:

```text
30 passed in 0.55s
```

Covered community imports, packaged baseline behavior, SWE-bench import, role-card qualification, routing provenance, and adapter-mismatch diagnostics.