### PR TITLE
Document Grok Bot as a first-class remote MCP pilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/professorpalmer/Puppetmaster/blob/main/LICENSE)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://github.com/professorpalmer/Puppetmaster/blob/main/pyproject.toml)
 
-Puppetmaster runs multi-step engineering work through the agent tools you already use: Cursor, Claude Code, Codex, Hermes, Antigravity (Gemini 3.7 / 3.6 / 3.5 / 3.1 Pro), or a provider API. It starts independent workers, routes tasks to an available model, and stores their typed results in SQLite so jobs can be inspected and resumed. It is aimed at developers who want durable state and reviewable output for repository investigations, audits, refactors, and implementations.
+Puppetmaster runs multi-step engineering work through the agent tools you already use: Cursor, Grok Bot, Claude Code, Codex, Hermes, Antigravity (Gemini 3.7 / 3.6 / 3.5 / 3.1 Pro), or a provider API. It starts independent workers, routes tasks to an available model, and stores their typed results in SQLite so jobs can be inspected and resumed. It is aimed at developers who want durable state and reviewable output for repository investigations, audits, refactors, and implementations.
+
+**Grok Bot:** only remote MCP, not the stdio server Cursor Agent uses. Puppetmaster is the durable worker runtime behind that chat — same jobs, artifacts, and `effort-index`, over streamable HTTP. See [Grok Bot](#grok-bot).
 
 ## Measured results
 
@@ -17,6 +19,7 @@ Puppetmaster runs multi-step engineering work through the agent tools you alread
 ## Contents
 
 - [Install](#install)
+- [Grok Bot](#grok-bot)
 - [Quickstart](#quickstart)
 - [How it works](#how-it-works)
 - [Evidence](#evidence)
@@ -44,11 +47,30 @@ puppetmaster setup --platforms omp
 
 Restart Cursor, Codex, Claude, Antigravity, Hermes, Pi, or OMP after setup. The host then has the `puppetmaster_*` MCP tools and, where supported, hooks that suggest delegation for larger tasks. Disable those hooks with `PUPPETMASTER_AUTO_INVOKE_DISABLED=1`. For CI, use `--platforms <comma-list>` or `--platforms all`. Add another adapter later with `puppetmaster platform enable <name>`.
 
+Grok Bot does not use that stdio install. Start remote MCP and add the printed connector instead ([Grok Bot](#grok-bot)).
+
 The built-in `agentic` adapter needs only a provider API key, so it can run without an external CLI. See [adapter setup](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/ADAPTERS.md) for provider, Antigravity, and Hermes details.
+
+## Grok Bot
+
+Cursor's Grok Bot assistant attaches **remote** MCP connectors only (streamable HTTP / SSE). It cannot register `python -m puppetmaster.mcp_server` the way Cursor Agent, Claude Desktop, and Codex do. Serve the same tool handlers over HTTP and Grok Bot can start and watch durable jobs on this box:
+
+```bash
+export PUPPETMASTER_MCP_TOKEN="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+python -m puppetmaster mcp serve-remote --scope supervise
+# equivalent: puppetmaster-mcp-remote --scope supervise
+# one-shot PoC (prints connector JSON): ./scripts/grok-bot-remote-poc.sh
+```
+
+In Grok Bot → Add MCP server, use the printed `/mcp` URL and `Authorization: Bearer <token>`. Use a TLS tunnel if the bot is off-box. Confirm tools load, then `puppetmaster_doctor` and `puppetmaster_start_implement` or `puppetmaster_start_agentic`.
+
+When Cursor is not installed on that host, implement / prewalk / swarm pick keys-only **agentic** workers (`OPENROUTER_API_KEY`, `OPENAI_API_KEY`, …). There is no `grok-bot` adapter and no CreateAgent fleet. Default `--scope supervise` omits implement/edit; pass `--scope implement` only when you want the remote client to start full-edit workers.
+
+Connector JSON, handshake notes, and auth: [GROK_BOT.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/GROK_BOT.md).
 
 ## Quickstart
 
-Inside Cursor Agent or Codex:
+Inside Cursor Agent, Grok Bot, or Codex:
 
 ```text
 Use Puppetmaster to run doctor in this repo and summarize what is missing.
@@ -79,10 +101,11 @@ More recipes are in [DAILY_DRIVER.md](https://github.com/professorpalmer/Puppetm
 
 ## How it works
 
-Puppetmaster is a supervisor and job store for agent CLIs and provider adapters:
+Puppetmaster is a supervisor and job store for agent CLIs and provider adapters. Grok Bot, Cursor Agent, Pi, and OMP are *pilots* (they call MCP tools); cursor / claude-code / agentic / … are *adapters* (leased workers):
 
 ```text
-Cursor / Claude Code / Codex / Hermes / Antigravity / agentic
+pilots (MCP):  Cursor Agent / Grok Bot / Claude Desktop / Pi / OMP
+workers:       cursor / claude-code / codex / hermes / antigravity / agentic
                                 |
                                 v
       supervisor -> model router -> independent workers -> SQLite artifacts
@@ -116,7 +139,8 @@ These are measurements of the included workflows, not guarantees for every repos
 
 The [docs index](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/README.md) covers:
 
-- [FEATURES.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/FEATURES.md) — adapters and shipped features
+- [GROK_BOT.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/GROK_BOT.md) — Grok Bot as remote MCP pilot (streamable HTTP; not a worker adapter)
+- [FEATURES.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/FEATURES.md) — adapters, pilots, and shipped features
 - [SECURITY.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/SECURITY.md) — safety and threat model
 - [DASHBOARD.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/DASHBOARD.md) — live job dashboard
 - [CONCURRENT_SESSIONS.md](https://github.com/professorpalmer/Puppetmaster/blob/main/docs/CONCURRENT_SESSIONS.md) — operating concurrent agent sessions, state scope, dashboard URLs, and worktrees

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -1,6 +1,6 @@
 # How Puppetmaster compares
 
-Short version: **Puppetmaster is not another agent framework.** LangGraph, CrewAI, AutoGen/AG2, and the Claude Agent SDK are libraries you write code against to *build* an agent. Puppetmaster sits one layer up — it's a **supervisor that drives the agent CLIs/SDKs you already pay for** (Cursor, Claude Code, Codex, the OpenAI API, and Hermes), routes each task to the cheapest model that can handle it, keeps the spend inside your existing subscription, and stores every worker's output as a typed artifact so follow-ups cost zero tokens.
+Short version: **Puppetmaster is not another agent framework.** LangGraph, CrewAI, AutoGen/AG2, and the Claude Agent SDK are libraries you write code against to *build* an agent. Puppetmaster sits one layer up — it's a **supervisor that drives the agent CLIs/SDKs you already pay for** (Cursor, Grok Bot, Claude Code, Codex, the OpenAI API, and Hermes), routes each task to the cheapest model that can handle it, keeps the spend inside your existing subscription, and stores every worker's output as a typed artifact so follow-ups cost zero tokens.
 
 So this isn't "Puppetmaster vs LangGraph, who wins." They solve different problems and compose fine. This page is here to answer the only question that matters at a glance: *given what I'm trying to do, do I want this?*
 
@@ -9,7 +9,7 @@ So this isn't "Puppetmaster vs LangGraph, who wins." They solve different proble
 | | **Puppetmaster** | LangGraph | CrewAI | Claude Agent SDK / Code subagents | Native IDE subagents (Cursor / Claude built-in) |
 |---|---|---|---|---|---|
 | What it fundamentally is | A cost-aware **orchestrator** over existing agent CLIs | A library to build **stateful agent graphs** | A library for **role-based agent crews** | An SDK + CLI to build/run **one Anthropic agent loop** | Built-in helpers that spawn subagents for a task |
-| You interact by | MCP tools / CLI (no code to write) | Writing Python graph code | Writing Python role/task code | Writing code / using the CLI | Asking the IDE agent |
+| You interact by | MCP tools / CLI (stdio, or remote HTTP for Grok Bot) | Writing Python graph code | Writing Python role/task code | Writing code / using the CLI | Asking the IDE agent |
 | Fan a single run across **multiple vendors** (Cursor + Claude + Codex + OpenAI) | **Yes** — that's the point | You wire it yourself | Per-agent LLM config | Anthropic only | The host vendor only |
 | **Task → model cost routing** (auto-pick cheapest sufficient) | **Yes**, auditable per task | No (you choose models) | No (per-role models) | No | No |
 | **Subscription / plan-billing containment** (keep spend in the plan you already pay for) | **Yes** — plan-first routing + detection | No | No | Plan or API, single vendor | Yes (it's the vendor's own plan) |
@@ -34,6 +34,7 @@ Overlap is real and worth stating plainly: **LangGraph also gives you durable st
 - You need **auditable** per-task model decisions (why did this task run on that model? what did it reject and why?) — not a model picked by vibes.
 - You want a swarm to **survive a dead/over-quota provider** instead of returning a degraded run.
 - You want follow-up questions about a finished job to be **free** (durable typed artifacts, not a transcript replay).
+- You want **Grok Bot** as the always-on chat and durable workers on your box. Grok Bot cannot attach local stdio MCP; Puppetmaster's remote transport is the connector ([GROK_BOT.md](GROK_BOT.md)).
 
 ## Honest caveats
 

--- a/docs/DAILY_DRIVER.md
+++ b/docs/DAILY_DRIVER.md
@@ -1,6 +1,6 @@
 # Daily Driver
 
-Puppetmaster is meant to make repeated Cursor swarm work inspectable and replayable.
+Puppetmaster is meant to make repeated swarm work inspectable and replayable — from Cursor Agent, Grok Bot, or the CLI.
 
 ## Using it from the chat window (recommended)
 
@@ -19,6 +19,17 @@ conversational questions yourself without a job.
 ```
 
 **Don't route every message through Puppetmaster.** It's intentionally *not* a conversational tool — a durable worker per chat turn would add cost and latency to the cheapest asks and fight the IDE's message routing. The win is the split: instant cheap chat for talk, the full durable machine for work. Context still compounds, because each delegated job leaves typed artifacts and promoted memory the next job reuses — you don't need to feed the chitchat through it to get that.
+
+## Grok Bot (remote MCP)
+
+Grok Bot is the same split with a different transport. It cannot load the stdio MCP server Cursor Agent uses. Serve remote MCP, add the connector, then run the same start / poll / show loop:
+
+```bash
+export PUPPETMASTER_MCP_TOKEN="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+python -m puppetmaster mcp serve-remote --scope supervise
+```
+
+In Grok Bot chat: `puppetmaster_doctor`, then `puppetmaster_start_implement` or `puppetmaster_start_agentic` (agentic is the contained default when Cursor is not installed). Do not lead with `puppetmaster_start_cursor_swarm`. Full connector and handshake notes: [GROK_BOT.md](GROK_BOT.md).
 
 ## Recommended Loop
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2,6 +2,17 @@
 
 A full map of what ships today, plus the adapter matrix. For the design rationale behind these, see [docs/WHY.md](WHY.md); for the proof behind the headline claims, see [docs/CLAIMS.md](CLAIMS.md).
 
+## Pilots
+
+A *pilot* starts and watches jobs. An *adapter* is a leased worker that claims tasks. Do not invent a `grok-bot`, `pi`, or `omp` worker adapter.
+
+| Pilot | Transport | Setup |
+|---|---|---|
+| Cursor Agent, Claude Desktop, Codex, Hermes | stdio MCP | `puppetmaster setup` / `install-*-mcp` |
+| Grok Bot | remote streamable HTTP only (cannot attach stdio) | `python -m puppetmaster mcp serve-remote` — [GROK_BOT.md](GROK_BOT.md). Contained path defaults to keys-only **agentic** when Cursor is not installed (v1.22.22+) |
+| Pi TUI | stdio MCP | `setup --platforms pi` — [PI.md](PI.md) |
+| OMP / oh-my-pi TUI | stdio MCP | `setup --platforms omp` — [OMP.md](OMP.md) |
+
 ## Adapters
 
 Six production adapters live plus the keys-only `agentic` standalone worker; curated tiers across Cursor, Claude, OpenAI, Codex, Antigravity (Gemini 3.7 / 3.6 / 3.5 / 3.1 Pro), and Hermes. Tier and pricing details in [docs/MODEL_ROUTING.md](MODEL_ROUTING.md); adapter wiring details in [docs/ADAPTERS.md](ADAPTERS.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,15 +2,16 @@
 
 The full documentation set. Start at the [project README](../README.md) for the 60-second tour and install; come here when you want depth.
 
-**Current release:** [v1.22.36](CHANGELOG.md#v12236) — headed Chrome auth handoff with a durable profile and shared CDP attach; see [CHANGELOG.md](CHANGELOG.md), [WHY.md](WHY.md), and [CLAIMS.md](CLAIMS.md).
+**Current release:** [v1.22.36](CHANGELOG.md#v12236) — headed Chrome auth handoff with a durable profile and shared CDP attach; see [CHANGELOG.md](CHANGELOG.md), [WHY.md](WHY.md), and [CLAIMS.md](CLAIMS.md). Grok Bot remote MCP (streamable HTTP pilot) is first-class — start at [GROK_BOT.md](GROK_BOT.md).
 
 ## Start here
 
 | Doc | What's in it |
 |---|---|
+| [GROK_BOT.md](GROK_BOT.md) | Cursor Grok Bot as the chat; Puppetmaster as the remote-MCP worker runtime (not a `grok-bot` adapter) |
 | [WHY.md](WHY.md) | Design rationale: what shared-transcript subagents get wrong, what durable state fixes |
 | [CLAIMS.md](CLAIMS.md) | The four headline claims with reproducible receipts from [`bench/`](../bench/) |
-| [FEATURES.md](FEATURES.md) | Full feature matrix + the adapter table |
+| [FEATURES.md](FEATURES.md) | Pilots (including Grok Bot remote MCP), adapters, and the full feature matrix |
 | [COMPARISON.md](COMPARISON.md) | How it differs from LangGraph / CrewAI / Claude Agent SDK / native subagents + "pick X instead if…" |
 | [SECURITY.md](SECURITY.md) | Threat model: what it can do, what it touches, network egress, and how to run it safely |
 | [DAILY_DRIVER.md](DAILY_DRIVER.md) | Prompt recipes for review, swarm, implement, post-job inspection |

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,9 +16,8 @@ puppetmaster run "demo goal" --config examples/enterprise-workflow.json
 | [`claude-code-full-edit.json`](claude-code-full-edit.json) | Full-edit implementation via the `claude` CLI, emitting patch artifacts |
 | [`agentic-analyze.json`](agentic-analyze.json) | Read-only audit via the keys-only `agentic` adapter (provider API key only) |
 | [`agentic-implement.json`](agentic-implement.json) | Full-edit implement via `agentic` with PATCH attribution |
+| [`grok-bot-remote-e2e/`](grok-bot-remote-e2e) | Fixture cwd for Grok Bot Plugins → remote MCP review/implement ([GROK_BOT.md](../docs/GROK_BOT.md)) |
 
 The [`transcripts/`](transcripts) folder holds captured example outputs for reference.
-
-[`grok-bot-remote-e2e/`](grok-bot-remote-e2e) is a tiny Node fixture workspace for Grok Bot Plugins → Puppetmaster remote MCP review/implement validation (see [docs/GROK_BOT.md](../docs/GROK_BOT.md)).
 
 The workflow config schema (roles, adapters, payloads, routing overrides, DAG edges) is documented in [docs/CLI_REFERENCE.md](../docs/CLI_REFERENCE.md).

--- a/puppetmaster/README.md
+++ b/puppetmaster/README.md
@@ -7,7 +7,8 @@ The Python package. This is an orientation map, not API docs — for the object 
 | Module | Role |
 |---|---|
 | `__main__.py` / `cli.py` | The `puppetmaster` CLI — every subcommand, arg wiring, read-only state-dir auto-pivot |
-| `mcp_server.py` | The MCP server Cursor/Codex/Claude talk to: tool dispatch, long-poll, await, heartbeat |
+| `mcp_server.py` | The stdio MCP server Cursor/Codex/Claude/Pi/OMP talk to: tool dispatch, long-poll, await, heartbeat |
+| `mcp_remote.py` | Streamable HTTP / SSE MCP for pilots that cannot attach stdio (Grok Bot). `puppetmaster mcp serve-remote` / `puppetmaster-mcp-remote` |
 
 ## Orchestration runtime
 


### PR DESCRIPTION
## Summary
- Put Grok Bot on the README pitch, contents, install path, and a dedicated remote-MCP section (same jobs/artifacts over streamable HTTP; no `grok-bot` adapter).
- Surface it in the docs index, FEATURES pilots table, daily-driver loop, comparison "choose when", and examples fixture list.
- Docs only. No version bump, tag, or PyPI.

## Test plan
- [ ] README lead + Grok Bot section match `docs/GROK_BOT.md` (remote MCP, supervise default, agentic when Cursor is missing).
- [ ] Docs index Start here lists GROK_BOT.md.
- [ ] No `pyproject.toml` / version / changelog change in this PR.