### PR TITLE
Release Puppetmaster v1.22.42

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v1.22.42 — 2026-08-30
 
 **Stable terminal job cost receipts (#122).**
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+**Stable terminal job cost receipts (#122).**
+
+New final jobs (`complete` / `failed` / `cancelled`) freeze selected-model economics at coordinator completion. Pre-upgrade final jobs without a receipt use stable artifact-only economics (provider-reported cost and plan-billed routing stay known; registry rates are ignored). Stalled and active jobs can still reprice against the current registry and say so.
+
+- Stalled is recoverable: it never stamps or keeps a receipt. Transitions back to queued / running / stitching / stalled clear any prior receipt.
+- Unknown selected-model cost is not `$0`: unpriced work leaves job totals null, keeps any priced subtotal under `priced_subtotal_usd`, and suppresses numeric avoided spend. Plan-billed `$0` and provider-reported cost stay valid.
+- A final routing `model_id` missing from the registry is unpriced, not matched to another recorded model. Stale and superseded ROUTING artifacts are ignored before model, billing, or estimate selection. A non-empty subgraph reset reopens the coordinator job to running and clears `completed_at` plus the receipt so production finalize can stamp the new generation once. CLI says cost unavailable for unpriced work, never coerces null to zero, and still prints `priced subtotal ... $0.000000` when the known slice is plan-billed zero.
+
 ## v1.22.41 — 2026-08-29
 
 **METR leftover closures: same-turn GATE before follow-ups, live-lease writer fence, listing is still not a board.**

--- a/puppetmaster/__init__.py
+++ b/puppetmaster/__init__.py
@@ -1,5 +1,5 @@
 """Puppetmaster: distributed agent workers with stitched shared memory."""
 
 __all__ = ["__version__"]
-__version__ = "1.22.41"
+__version__ = "1.22.42"
 

--- a/puppetmaster/cli/commands_gate.py
+++ b/puppetmaster/cli/commands_gate.py
@@ -767,6 +767,20 @@ def _routing_estimate_rows(artifacts) -> tuple[list[dict], dict[str, dict], floa
     return routing_estimate_rows(artifacts)
 
 
+def _format_cost_usd(value: Any, *, prefix: str = "") -> str:
+    """Render a dollar figure; never coerce JSON null into numeric zero."""
+    if value is None:
+        return "unavailable"
+    return f"{prefix}{float(value):.6f}"
+
+
+def _model_cost_sort_key(item: tuple) -> tuple:
+    cost = item[1].get("marginal_cost_usd")
+    if cost is None:
+        return (1, 0.0)
+    return (0, -float(cost))
+
+
 def _run_cost_command(args, store) -> int:
     """Report a job's cost on two clearly-labeled bases.
 
@@ -803,46 +817,81 @@ def _run_cost_command(args, store) -> int:
     artifacts = store.list_artifacts(job_id)
     actual = payload.get("actual_cost") or {}
     has_usage = bool(actual.get("tasks"))
-    print(
-        f"job {job_id}: actual measured spend = "
-        f"${float(actual.get('total_marginal_cost_usd') or 0.0):.6f}"
-        + (
-            f"  ({float(actual.get('measured_cost_usd') or 0.0):.6f} measured / "
-            f"{float(actual.get('estimated_cost_usd') or 0.0):.6f} from estimated tokens)"
-            if has_usage
-            else ""
-        )
+    selected_unknown = bool(actual.get("unpriced_tasks")) or (
+        actual.get("total_marginal_cost_usd") is None and has_usage
     )
+    if selected_unknown:
+        print(f"job {job_id}: cost unavailable")
+    else:
+        total = actual.get("total_marginal_cost_usd")
+        print(
+            f"job {job_id}: actual measured spend = "
+            f"{_format_cost_usd(total, prefix='$')}"
+            + (
+                f"  ({_format_cost_usd(actual.get('measured_cost_usd'))} measured / "
+                f"{_format_cost_usd(actual.get('estimated_cost_usd'))} from estimated tokens)"
+                if has_usage
+                else ""
+            )
+        )
     if has_usage:
         print()
         print(f"  {'MODEL':<28}  {'CALLS':>5}  {'TOKENS':>14}  {'COST':>12}")
         by_model = actual.get("by_model") or {}
-        for mid, v in sorted(
-            by_model.items(), key=lambda kv: -kv[1]["marginal_cost_usd"]
-        ):
+        for mid, v in sorted(by_model.items(), key=_model_cost_sort_key):
             tokens = v["tokens_in"] + v["tokens_out"]
+            cost = v.get("marginal_cost_usd")
+            cost_cell = (
+                "unavailable"
+                if cost is None
+                else f"${cost:>10.6f}"
+            )
             print(
                 f"  {mid[:28]:<28}  {v['calls']:>5}  {tokens:>14,}  "
-                f"${v['marginal_cost_usd']:>10.6f}"
+                f"{cost_cell:>12}"
             )
         if actual.get("unpriced_tasks"):
             print(
                 f"\n  note: {actual['unpriced_tasks']} task(s) ran on a model not in "
-                "your registry, so their spend could not be priced (tokens still counted)."
+                "your registry, so selected-model cost is unknown (not $0)."
             )
+            priced_subtotal = actual.get("priced_subtotal_usd")
+            if actual.get("priced_tasks") and priced_subtotal is not None:
+                print(
+                    f"  priced subtotal (excludes unpriced tasks): "
+                    f"${float(priced_subtotal):.6f}"
+                )
     else:
         print(
             "  no token usage recorded for this job yet — nothing to price "
             "(the job may still be running, or produced no worker artifacts)."
         )
 
+    if payload.get("pricing_source") == "current_registry" and has_usage:
+        print(
+            "\n  note: live reprice against the current model registry; "
+            "not a completion receipt."
+        )
+    elif payload.get("pricing_source") == "legacy_artifacts" and has_usage:
+        print(
+            "\n  note: stable artifact-only economics for a completed job "
+            "with no completion receipt; ignores current registry rates."
+        )
+
     counterfactual = payload.get("counterfactual")
-    if counterfactual is not None and counterfactual.get("reference_priced"):
+    avoided = None if counterfactual is None else counterfactual.get("avoided_usd")
+    if (
+        counterfactual is not None
+        and counterfactual.get("reference_priced")
+        and counterfactual.get("actual_priced", True)
+        and avoided is not None
+        and counterfactual.get("actual_cost_usd") is not None
+    ):
         print()
         print(
             f"  counterfactual: this volume on {counterfactual['reference_model_id']} "
             f"at metered rates ≈ ${counterfactual['naive_cost_usd']:.6f}; you paid "
-            f"${counterfactual['actual_cost_usd']:.6f} → avoided ${counterfactual['avoided_usd']:.6f}."
+            f"${counterfactual['actual_cost_usd']:.6f} → avoided ${avoided:.6f}."
         )
 
     routing_rows = [

--- a/puppetmaster/cost.py
+++ b/puppetmaster/cost.py
@@ -22,19 +22,37 @@ avoided figure ≈ the naive figure.
 
 ``build_cost_report`` is the structured payload behind
 ``puppetmaster cost <job_id> --json``. CLI, MCP ``puppetmaster_job_cost``, and
-Marionette all consume that one function. It does not invent a second ledger.
+Marionette all consume that one function. A coordinator-stamped
+``Job.cost_receipt`` is returned detached after a cost-final completion.
+Pre-upgrade final jobs without a valid receipt get a labeled artifact-only
+report that ignores current registry rates. Stalled and active jobs may
+reprice against the current registry and say so.
 """
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+import copy
+from dataclasses import asdict, dataclass, field, replace
 from typing import Any, Iterable, Optional
 
-from puppetmaster.models import Artifact, ArtifactType
+from puppetmaster.models import (
+    Artifact,
+    ArtifactType,
+    Job,
+    is_cost_final_job_status,
+)
 from puppetmaster.savings import (
     Counterfactual,
     resolve_counterfactual_model,
 )
-from puppetmaster.usage import select_usage_records
+from puppetmaster.model_registry import default_registry_path, load_registry
+from puppetmaster.usage import aggregate_token_usage, select_usage_records
+from puppetmaster.validation import validation_status_of
+
+_WITHDRAWN_VALIDATION = frozenset({"stale", "superseded"})
+
+PRICING_SOURCE_TERMINAL = "terminal_receipt"
+PRICING_SOURCE_CURRENT = "current_registry"
+PRICING_SOURCE_LEGACY = "legacy_artifacts"
 
 # Published cache-read ratio; conservative vs provider-specific tiers.
 CACHE_READ_MULTIPLIER = 0.1
@@ -115,10 +133,16 @@ def _routing_created_by_rank(created_by: Optional[str]) -> int:
     return _ROUTING_CREATED_BY_RANK.get(created_by or "", 0)
 
 
+def _is_current_routing_artifact(artifact: Artifact) -> bool:
+    return validation_status_of(artifact) not in _WITHDRAWN_VALIDATION
+
+
 def final_routing_artifacts(artifacts: Iterable[Artifact]) -> dict[str, Artifact]:
     best: dict[str, tuple[int, Artifact]] = {}
     for artifact in artifacts:
         if artifact.type != ArtifactType.ROUTING:
+            continue
+        if not _is_current_routing_artifact(artifact):
             continue
         rank = _routing_created_by_rank(getattr(artifact, "created_by", None))
         task_id = getattr(artifact, "task_id", None)
@@ -130,32 +154,109 @@ def final_routing_artifacts(artifacts: Iterable[Artifact]) -> dict[str, Artifact
     return {task_id: artifact for task_id, (_rank, artifact) in best.items()}
 
 
-def _routing_model_ids(artifacts: Iterable[Artifact]) -> dict:
-    """task_id -> registry model id from the FINAL routing decision.
-
-    Prefer escalation > fallback > initial router so a failed first pick
-    (plan-billed cursor with ``sdk_not_installed``) does not price the
-    successful fallback run as $0.
-    """
-    result: dict[str, str] = {}
-    for task_id, artifact in final_routing_artifacts(artifacts).items():
-        model_id = (artifact.payload or {}).get("model_id")
-        if model_id:
-            result[task_id] = str(model_id)
-    return result
-
-
 def _usage_records(artifacts: Iterable[Artifact]) -> dict:
-    """task_id -> best usage-bearing artifact's token record + model.
-
-    Delegates to :func:`puppetmaster.usage.select_usage_records` so pricing and
-    token totals agree on which attempt counts when a task falls back.
-    """
+    """Selected usage keyed by task_id, excluding untasked artifacts."""
     return {
         task_id: record
         for task_id, record in select_usage_records(artifacts).items()
         if not str(task_id).startswith("__untasked_")
     }
+
+
+def _real_cost_usd(raw: Any) -> float:
+    try:
+        return float(raw) if raw is not None else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _job_cost_from_routes(final_routes: dict) -> JobCost:
+    result = JobCost()
+    result.route_estimated_tokens = sum(
+        int((artifact.payload or {}).get("estimated_tokens_in") or 0)
+        + int((artifact.payload or {}).get("estimated_tokens_out") or 0)
+        for artifact in final_routes.values()
+    )
+    result.route_nominal_cost_usd = round(
+        sum(
+            float((artifact.payload or {}).get("nominal_cost_usd") or 0.0)
+            for artifact in final_routes.values()
+        ),
+        6,
+    )
+    return result
+
+
+def _add_priced_task(
+    result: JobCost,
+    *,
+    task_id: str,
+    model_id: str,
+    billing: str,
+    tokens_in: int,
+    tokens_out: int,
+    estimated: bool,
+    cost: float,
+    priced: bool,
+    nominal_cost: float = 0.0,
+) -> None:
+    result.nominal_usage_cost_usd += nominal_cost
+    result.measured_usage_tokens += tokens_in + tokens_out
+    if priced:
+        result.priced_tasks += 1
+    else:
+        result.unpriced_tasks += 1
+    result.total_marginal_cost_usd += cost
+    if estimated:
+        result.estimated_cost_usd += cost
+        result.estimated_runs += 1
+    else:
+        result.measured_cost_usd += cost
+        result.measured_runs += 1
+    bucket = result.by_model.setdefault(
+        model_id,
+        {
+            "calls": 0,
+            "tokens_in": 0,
+            "tokens_out": 0,
+            "marginal_cost_usd": 0.0,
+            "billing": billing,
+        },
+    )
+    bucket["calls"] += 1
+    bucket["tokens_in"] += tokens_in
+    bucket["tokens_out"] += tokens_out
+    bucket["marginal_cost_usd"] += cost
+    result.tasks.append(
+        TaskCost(
+            task_id=task_id,
+            model_id=model_id,
+            billing=billing,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            tokens_estimated=estimated,
+            marginal_cost_usd=round(cost, 6),
+            priced=priced,
+        )
+    )
+
+
+def _finalize_job_cost(result: JobCost) -> JobCost:
+    result.total_marginal_cost_usd = round(result.total_marginal_cost_usd, 6)
+    result.measured_cost_usd = round(result.measured_cost_usd, 6)
+    result.estimated_cost_usd = round(result.estimated_cost_usd, 6)
+    for bucket in result.by_model.values():
+        bucket["marginal_cost_usd"] = round(bucket["marginal_cost_usd"], 6)
+    result.nominal_usage_cost_usd = round(result.nominal_usage_cost_usd, 6)
+    if result.route_estimated_tokens > 0:
+        result.token_estimate_drift_ratio = round(
+            result.measured_usage_tokens / result.route_estimated_tokens, 6
+        )
+    if result.route_nominal_cost_usd > 0:
+        result.nominal_cost_drift_ratio = round(
+            result.nominal_usage_cost_usd / result.route_nominal_cost_usd, 6
+        )
+    return result
 
 
 def _resolve_spec(
@@ -165,9 +266,13 @@ def _resolve_spec(
     by_adapter_name: dict,
 ):
     """Pick the registry spec a task ran on: final routing decision first, then
-    the model the adapter recorded (matched by id, then by adapter_model_name)."""
-    if routing_model_id and routing_model_id in by_id:
-        return by_id[routing_model_id]
+    the model the adapter recorded (matched by id, then by adapter_model_name).
+
+    Fail closed when a final routing ``model_id`` is present but absent from
+    the registry — do not fall through to an unrelated recorded-model match.
+    """
+    if routing_model_id:
+        return by_id.get(routing_model_id)
     if recorded_model:
         if recorded_model in by_id:
             return by_id[recorded_model]
@@ -198,53 +303,31 @@ def price_job(artifacts: Iterable[Artifact], registry: list) -> JobCost:
         for task_id, artifact in final_routes.items()
         if (artifact.payload or {}).get("model_id")
     }
-    usage = _usage_records(artifacts)
-
-    result = JobCost()
-    result.route_estimated_tokens = sum(
-        int((artifact.payload or {}).get("estimated_tokens_in") or 0)
-        + int((artifact.payload or {}).get("estimated_tokens_out") or 0)
-        for artifact in final_routes.values()
-    )
-    result.route_nominal_cost_usd = round(
-        sum(
-            float((artifact.payload or {}).get("nominal_cost_usd") or 0.0)
-            for artifact in final_routes.values()
-        ), 6
-    )
-    for task_id, record in usage.items():
+    result = _job_cost_from_routes(final_routes)
+    for task_id, record in _usage_records(artifacts).items():
         spec = _resolve_spec(
             routing_models.get(task_id), record["model"], by_id, by_adapter_name
         )
         tokens_in = record["tokens_in"]
         tokens_out = record["tokens_out"]
         tokens_cached = record["tokens_cached"]
-        real_cost = record["real_cost_usd"]
         estimated = record["tokens_estimated"]
-        try:
-            real_cost_f = float(real_cost) if real_cost is not None else 0.0
-        except (TypeError, ValueError):
-            real_cost_f = 0.0
-
+        real_cost_f = _real_cost_usd(record["real_cost_usd"])
         plan_billed = spec is not None and getattr(spec, "billing", None) == "plan"
         nominal_cost = (
             _cost_with_cache_discount(spec, tokens_in, tokens_out, tokens_cached)
             if spec is not None
             else 0.0
         )
-        result.nominal_usage_cost_usd += nominal_cost
-        result.measured_usage_tokens += tokens_in + tokens_out
 
         if plan_billed:
             model_id = spec.id
             billing = spec.billing
             cost = 0.0
             priced = True
-            result.priced_tasks += 1
         elif real_cost_f > 0:
             cost = real_cost_f
             priced = True
-            result.priced_tasks += 1
             if spec is not None:
                 model_id = spec.id
                 billing = spec.billing
@@ -259,59 +342,25 @@ def price_job(artifacts: Iterable[Artifact], registry: list) -> JobCost:
             else:
                 cost = spec.marginal_cost_usd(tokens_in, tokens_out)
             priced = True
-            result.priced_tasks += 1
         else:
             model_id = routing_models.get(task_id) or record["model"] or "<unknown>"
             billing = "unknown"
             cost = 0.0
             priced = False
-            result.unpriced_tasks += 1
 
-        result.total_marginal_cost_usd += cost
-        if estimated:
-            result.estimated_cost_usd += cost
-            result.estimated_runs += 1
-        else:
-            result.measured_cost_usd += cost
-            result.measured_runs += 1
-
-        bucket = result.by_model.setdefault(
-            model_id,
-            {"calls": 0, "tokens_in": 0, "tokens_out": 0, "marginal_cost_usd": 0.0, "billing": billing},
+        _add_priced_task(
+            result,
+            task_id=task_id,
+            model_id=model_id,
+            billing=billing,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            estimated=estimated,
+            cost=cost,
+            priced=priced,
+            nominal_cost=nominal_cost,
         )
-        bucket["calls"] += 1
-        bucket["tokens_in"] += tokens_in
-        bucket["tokens_out"] += tokens_out
-        bucket["marginal_cost_usd"] += cost
-
-        result.tasks.append(
-            TaskCost(
-                task_id=task_id,
-                model_id=model_id,
-                billing=billing,
-                tokens_in=tokens_in,
-                tokens_out=tokens_out,
-                tokens_estimated=estimated,
-                marginal_cost_usd=round(cost, 6),
-                priced=priced,
-            )
-        )
-
-    result.total_marginal_cost_usd = round(result.total_marginal_cost_usd, 6)
-    result.measured_cost_usd = round(result.measured_cost_usd, 6)
-    result.estimated_cost_usd = round(result.estimated_cost_usd, 6)
-    for bucket in result.by_model.values():
-        bucket["marginal_cost_usd"] = round(bucket["marginal_cost_usd"], 6)
-    result.nominal_usage_cost_usd = round(result.nominal_usage_cost_usd, 6)
-    if result.route_estimated_tokens > 0:
-        result.token_estimate_drift_ratio = round(
-            result.measured_usage_tokens / result.route_estimated_tokens, 6
-        )
-    if result.route_nominal_cost_usd > 0:
-        result.nominal_cost_drift_ratio = round(
-            result.nominal_usage_cost_usd / result.route_nominal_cost_usd, 6
-        )
-    return result
+    return _finalize_job_cost(result)
 
 
 def job_counterfactual(job_cost: JobCost, registry: list) -> Optional[Counterfactual]:
@@ -356,6 +405,8 @@ def routing_estimate_rows(artifacts: Iterable[Artifact]) -> tuple[list[dict], di
     for artifact in artifacts:
         if artifact.type != ArtifactType.ROUTING or artifact.created_by != "router":
             continue
+        if not _is_current_routing_artifact(artifact):
+            continue
         task_id = artifact.task_id
         if task_id:
             if task_id in seen_router_tasks:
@@ -382,38 +433,99 @@ def routing_estimate_rows(artifacts: Iterable[Artifact]) -> tuple[list[dict], di
     return rows, by_model, round(total, 6)
 
 
-def build_cost_report(store: Any, job_id: str, registry: Optional[list] = None) -> dict:
-    """Structured report behind ``puppetmaster cost <job_id> --json``.
-
-    Shared by the CLI, the MCP ``puppetmaster_job_cost`` tool, and Marionette.
-    Prices against the current registry; does not invent a second economics DB.
+def valid_terminal_cost_receipt(receipt: Any, job_id: str) -> bool:
+    """True for an additive completion receipt: matching job_id, terminal
+    pricing_source, and actual_cost / token_usage / tasks objects.
     """
-    from puppetmaster.usage import aggregate_token_usage
+    if not isinstance(receipt, dict) or not receipt:
+        return False
+    if receipt.get("job_id") != job_id:
+        return False
+    if receipt.get("pricing_source") != PRICING_SOURCE_TERMINAL:
+        return False
+    if not isinstance(receipt.get("actual_cost"), dict):
+        return False
+    if not isinstance(receipt.get("token_usage"), dict):
+        return False
+    if not isinstance(receipt.get("tasks"), list):
+        return False
+    return True
 
-    artifacts = store.list_artifacts(job_id) if store is not None else []
-    if registry is None:
-        try:
-            from puppetmaster.model_registry import default_registry_path, load_registry
 
-            registry = load_registry(default_registry_path()) or []
-        except Exception:
-            registry = []
-
-    routing_rows, routing_by_model, routing_total = routing_estimate_rows(artifacts)
-    job_cost = price_job(artifacts, registry)
-    counterfactual = job_counterfactual(job_cost, registry)
-    actual_by_model = {
-        mid: {
-            "calls": v["calls"],
-            "tokens_in": v["tokens_in"],
-            "tokens_out": v["tokens_out"],
-            "marginal_cost_usd": v["marginal_cost_usd"],
-            "billing": v["billing"],
+def _actual_cost_payload(
+    job_cost: JobCost,
+    *,
+    cost_basis: str = "measured_usage_x_registry_price",
+) -> dict:
+    """Serialize priced ledgers; unknown selected cost is null, not $0."""
+    priced_subtotal = round(
+        sum(task.marginal_cost_usd for task in job_cost.tasks if task.priced),
+        6,
+    )
+    selected_unknown = job_cost.unpriced_tasks > 0
+    unpriced_models = {task.model_id for task in job_cost.tasks if not task.priced}
+    actual_by_model = {}
+    for model_id, bucket in job_cost.by_model.items():
+        actual_by_model[model_id] = {
+            "calls": bucket["calls"],
+            "tokens_in": bucket["tokens_in"],
+            "tokens_out": bucket["tokens_out"],
+            "marginal_cost_usd": (
+                None if model_id in unpriced_models else bucket["marginal_cost_usd"]
+            ),
+            "billing": bucket["billing"],
         }
-        for mid, v in job_cost.by_model.items()
+    tasks = []
+    for task in job_cost.tasks:
+        row = asdict(task)
+        if not task.priced:
+            row["marginal_cost_usd"] = None
+        tasks.append(row)
+    return {
+        "cost_basis": cost_basis,
+        "total_marginal_cost_usd": (
+            None if selected_unknown else job_cost.total_marginal_cost_usd
+        ),
+        "measured_cost_usd": None if selected_unknown else job_cost.measured_cost_usd,
+        "estimated_cost_usd": None if selected_unknown else job_cost.estimated_cost_usd,
+        "priced_subtotal_usd": priced_subtotal,
+        "measured_runs": job_cost.measured_runs,
+        "estimated_runs": job_cost.estimated_runs,
+        "priced_tasks": job_cost.priced_tasks,
+        "unpriced_tasks": job_cost.unpriced_tasks,
+        "by_model": actual_by_model,
+        "tasks": tasks,
     }
+
+
+def _counterfactual_payload(job_cost: JobCost, registry: list) -> Optional[dict]:
+    counterfactual = job_counterfactual(job_cost, registry)
+    if counterfactual is None:
+        return None
+    payload = asdict(counterfactual)
+    actual_priced = job_cost.unpriced_tasks == 0
+    payload["actual_priced"] = actual_priced
+    if not actual_priced:
+        payload["actual_cost_usd"] = None
+        payload["avoided_usd"] = None
+    return payload
+
+
+def _report_envelope(
+    job_id: str,
+    artifacts: list,
+    job_cost: JobCost,
+    *,
+    pricing_source: str,
+    pricing_note: str,
+    actual: dict,
+    counterfactual: Optional[dict],
+) -> dict:
+    routing_rows, routing_by_model, routing_total = routing_estimate_rows(artifacts)
     return {
         "job_id": job_id,
+        "pricing_source": pricing_source,
+        "pricing_note": pricing_note,
         # Backward-compatible: the pre-flight routing estimate fields.
         "cost_basis": "preflight_routing_estimate",
         "total_estimated_cost_usd": routing_total,
@@ -430,24 +542,163 @@ def build_cost_report(store: Any, job_id: str, registry: Optional[list] = None) 
             "nominal_usage_cost_usd": job_cost.nominal_usage_cost_usd,
             "nominal_cost_ratio": job_cost.nominal_cost_drift_ratio,
         },
-        # The honest, routing-independent number.
-        "actual_cost": {
-            "cost_basis": "measured_usage_x_registry_price",
-            "total_marginal_cost_usd": job_cost.total_marginal_cost_usd,
-            "measured_cost_usd": job_cost.measured_cost_usd,
-            "estimated_cost_usd": job_cost.estimated_cost_usd,
-            "measured_runs": job_cost.measured_runs,
-            "estimated_runs": job_cost.estimated_runs,
-            "priced_tasks": job_cost.priced_tasks,
-            "unpriced_tasks": job_cost.unpriced_tasks,
-            "by_model": actual_by_model,
-            "tasks": [asdict(t) for t in job_cost.tasks],
-        },
-        "counterfactual": (
-            asdict(counterfactual) if counterfactual is not None else None
-        ),
-        # When the job auto-routed, the per-task routing rows; otherwise the
-        # priced-usage rows so the task breakdown is never empty for a run
-        # that actually consumed tokens.
-        "tasks": routing_rows if routing_rows else [asdict(t) for t in job_cost.tasks],
+        "actual_cost": actual,
+        "counterfactual": counterfactual,
+        "tasks": routing_rows if routing_rows else list(actual["tasks"]),
     }
+
+
+def build_current_registry_cost_report(
+    job_id: str,
+    artifacts: Iterable[Artifact],
+    registry: Optional[list] = None,
+) -> dict:
+    """Live selected-model report against the registry supplied (or current).
+
+    Does not read or write ``Job.cost_receipt``. Used to stamp a new
+    completion receipt and to label stalled/active jobs that have none.
+    """
+    artifacts = list(artifacts)
+    if registry is None:
+        try:
+            registry = load_registry(default_registry_path()) or []
+        except Exception:
+            registry = []
+    job_cost = price_job(artifacts, registry)
+    return _report_envelope(
+        job_id,
+        artifacts,
+        job_cost,
+        pricing_source=PRICING_SOURCE_CURRENT,
+        pricing_note=(
+            "Live reprice against the current model registry; not a completion receipt."
+        ),
+        actual=_actual_cost_payload(job_cost),
+        counterfactual=_counterfactual_payload(job_cost, registry),
+    )
+
+
+def price_job_from_artifacts(artifacts: Iterable[Artifact]) -> JobCost:
+    """Price from persisted artifacts only — no current registry rates.
+
+    Provider-reported ``real_cost_usd`` stays known. A final ROUTING
+    artifact with ``billing=plan`` is a known plan-billed zero. API usage
+    without an artifact price stays honestly unpriced.
+    """
+    artifacts = list(artifacts)
+    final_routes = final_routing_artifacts(artifacts)
+    result = _job_cost_from_routes(final_routes)
+    for task_id, record in _usage_records(artifacts).items():
+        route = final_routes.get(task_id)
+        route_payload = route.payload or {} if route is not None else {}
+        tokens_in = record["tokens_in"]
+        tokens_out = record["tokens_out"]
+        estimated = record["tokens_estimated"]
+        real_cost_f = _real_cost_usd(record["real_cost_usd"])
+        model_id = str(
+            route_payload.get("model_id") or record["model"] or "<unknown>"
+        )
+        if route_payload.get("billing") == "plan":
+            billing = "plan"
+            cost = 0.0
+            priced = True
+        elif real_cost_f > 0:
+            billing = "reported"
+            cost = real_cost_f
+            priced = True
+        else:
+            billing = "unknown"
+            cost = 0.0
+            priced = False
+        _add_priced_task(
+            result,
+            task_id=task_id,
+            model_id=model_id,
+            billing=billing,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            estimated=estimated,
+            cost=cost,
+            priced=priced,
+        )
+    return _finalize_job_cost(result)
+
+
+def build_legacy_artifact_cost_report(
+    job_id: str,
+    artifacts: Iterable[Artifact],
+) -> dict:
+    """Stable economics for a pre-upgrade final job with no valid receipt.
+
+    Ignores caller/current registry rates so a later registry add / change /
+    remove cannot rewrite completed-job dollars.
+    """
+    artifacts = list(artifacts)
+    job_cost = price_job_from_artifacts(artifacts)
+    return _report_envelope(
+        job_id,
+        artifacts,
+        job_cost,
+        pricing_source=PRICING_SOURCE_LEGACY,
+        pricing_note=(
+            "Stable artifact-only economics for a completed job with no "
+            "completion receipt; ignores current registry rates."
+        ),
+        actual=_actual_cost_payload(
+            job_cost, cost_basis="measured_usage_x_artifact_price"
+        ),
+        counterfactual=None,
+    )
+
+
+def maybe_stamp_terminal_cost_receipt(store: Any, job: Job) -> Job:
+    """Best-effort freeze of current-registry economics onto a cost-final job.
+
+    Does not stamp when there is no selected usage yet, so a status write
+    before artifacts flush cannot freeze numeric zero. A valid existing
+    receipt is first-writer-wins. Failure must never block the status write.
+    """
+    if valid_terminal_cost_receipt(job.cost_receipt, job.id):
+        return job
+    if not is_cost_final_job_status(job.status):
+        return job
+    try:
+        artifacts = store.list_artifacts(job.id)
+        if not _usage_records(artifacts):
+            return job
+        receipt = copy.deepcopy(build_current_registry_cost_report(job.id, artifacts))
+        receipt["pricing_source"] = PRICING_SOURCE_TERMINAL
+        receipt["pricing_note"] = (
+            "Frozen at job completion against the registry then in force."
+        )
+        return replace(job, cost_receipt=receipt)
+    except Exception:
+        return job
+
+
+def build_cost_report(store: Any, job_id: str, registry: Optional[list] = None) -> dict:
+    """Structured report behind ``puppetmaster cost <job_id> --json``.
+
+    Shared by the CLI, the MCP ``puppetmaster_job_cost`` tool, and Marionette.
+    A valid cost-final ``Job.cost_receipt`` is returned detached (no recompute,
+    no write). Pre-upgrade final jobs without one get a labeled artifact-only
+    report. Stalled and active jobs get a labeled current-registry reprice.
+    """
+    job = None
+    if store is not None:
+        try:
+            job = store.get_job(job_id)
+        except Exception:
+            job = None
+    receipt = job.cost_receipt if job is not None else None
+    if (
+        job is not None
+        and is_cost_final_job_status(job.status)
+        and valid_terminal_cost_receipt(receipt, job_id)
+    ):
+        return copy.deepcopy(receipt)
+
+    artifacts = store.list_artifacts(job_id) if store is not None else []
+    if job is not None and is_cost_final_job_status(job.status):
+        return build_legacy_artifact_cost_report(job_id, artifacts)
+    return build_current_registry_cost_report(job_id, artifacts, registry)

--- a/puppetmaster/models.py
+++ b/puppetmaster/models.py
@@ -56,6 +56,16 @@ TERMINAL_JOB_STATUSES = frozenset(
     }
 )
 
+# Cost-final jobs may own an immutable receipt. STALLED is recoverable
+# and is terminal for liveness, not for selected-model economics.
+COST_FINAL_JOB_STATUSES = frozenset(
+    {
+        JobStatus.COMPLETE,
+        JobStatus.FAILED,
+        JobStatus.CANCELLED,
+    }
+)
+
 
 class DeliveryVerdict(StringEnum):
     """Operator-facing delivery result, distinct from raw lifecycle status."""
@@ -80,6 +90,14 @@ class JobRef:
 def is_terminal_job_status(status: JobStatus) -> bool:
     """Return whether ``status`` represents a job that will do no more work."""
     return status in TERMINAL_JOB_STATUSES
+
+
+def is_cost_final_job_status(status: JobStatus) -> bool:
+    """True when ``status`` may own an immutable ``Job.cost_receipt``.
+
+    ``stalled`` is recoverable and must never stamp or retain a receipt.
+    """
+    return status in COST_FINAL_JOB_STATUSES
 
 
 class TaskStatus(StringEnum):
@@ -129,6 +147,10 @@ class Job:
     wait_reason: Optional[str] = None
     subgraph_owner: Optional[str] = None
     subgraph_hold: Optional[str] = None
+    # Coordinator-stamped selected-model economics at cost-final status.
+    # Older records omit the key. JSON on the job row only — not a new
+    # ArtifactType or store table. STALLED must not keep a receipt.
+    cost_receipt: Optional[dict[str, Any]] = None
 
 
 @dataclass(frozen=True)
@@ -366,6 +388,7 @@ def _job_status_or_stalled(raw: Any) -> JobStatus:
 
 
 def job_from_dict(data: dict[str, Any]) -> Job:
+    raw_receipt = data.get("cost_receipt")
     return Job(
         id=data["id"],
         goal=data["goal"],
@@ -380,6 +403,7 @@ def job_from_dict(data: dict[str, Any]) -> Job:
         wait_reason=data.get("wait_reason"),
         subgraph_owner=data.get("subgraph_owner"),
         subgraph_hold=data.get("subgraph_hold"),
+        cost_receipt=raw_receipt if isinstance(raw_receipt, dict) else None,
     )
 
 

--- a/puppetmaster/sqlite_store.py
+++ b/puppetmaster/sqlite_store.py
@@ -22,12 +22,14 @@ from puppetmaster.models import (
     TaskStatus,
     artifact_from_dict,
     graph_edge_from_dict,
+    is_cost_final_job_status,
     job_from_dict,
     make_graph_edge,
     now_iso,
     task_from_dict,
     to_jsonable,
 )
+from puppetmaster.cost import maybe_stamp_terminal_cost_receipt
 from puppetmaster.fs_permissions import chmod_private_file, mkdir_private
 from puppetmaster.store import (
     ActiveTaskLeaseError,
@@ -586,6 +588,8 @@ class SQLiteSwarmStore(SwarmStore):
         if refused is not None:
             return refused
         updated = self._job_with_status(job, status)
+        if is_cost_final_job_status(status):
+            updated = maybe_stamp_terminal_cost_receipt(self, updated)
         payload = {"status": str(status), "actor": actor or "coordinator"}
         with self._session() as connection:
             connection.execute(
@@ -1236,8 +1240,9 @@ class SQLiteSwarmStore(SwarmStore):
         """Idempotent subgraph reset in a single SQLite transaction/batch.
 
         Unlike the file backend (per-task writes), all selected task clears,
-        QUEUED/BLOCKED re-derivation, superseded artifact labeling, and the
-        canonical ``subgraph.reset`` event (including
+        QUEUED/BLOCKED re-derivation, superseded artifact labeling, coordinator
+        job reopen (RUNNING, cleared ``completed_at`` / ``cost_receipt``), and
+        the canonical ``subgraph.reset`` event (including
         ``superseded_artifact_ids``) commit together so a busy/crash mid-reset
         cannot leave a partial subgraph.
         """
@@ -1391,6 +1396,16 @@ class SQLiteSwarmStore(SwarmStore):
                     "superseded_artifact_ids": superseded_ids,
                 },
             )
+            row = connection.execute(
+                "SELECT data FROM jobs WHERE id = ?",
+                (job_id,),
+            ).fetchone()
+            if row is not None:
+                job = job_from_dict(json.loads(row["data"]))
+                connection.execute(
+                    "UPDATE jobs SET data = ? WHERE id = ?",
+                    (self._dumps(self._reopened_job_after_reset(job)), job_id),
+                )
         return ResetSubgraphResult(finalized, superseded_ids)
 
     def delete_edge(self, job_id: str, edge_id: str) -> bool:

--- a/puppetmaster/store.py
+++ b/puppetmaster/store.py
@@ -24,6 +24,7 @@ from puppetmaster.models import (
     Task,
     TaskStatus,
     artifact_from_dict,
+    is_cost_final_job_status,
     graph_edge_from_dict,
     job_from_dict,
     make_graph_edge,
@@ -34,6 +35,7 @@ from puppetmaster.models import (
     task_from_dict,
     to_jsonable,
 )
+from puppetmaster.cost import maybe_stamp_terminal_cost_receipt
 from puppetmaster.redaction import redact_payload_for_storage
 from puppetmaster.fs_permissions import chmod_private_file, mkdir_private
 from puppetmaster.state import ensure_state_dir, resolve_state_dir
@@ -361,6 +363,8 @@ class SwarmStore:
         if refused is not None:
             return refused
         updated = self._job_with_status(job, status)
+        if is_cost_final_job_status(status):
+            updated = maybe_stamp_terminal_cost_receipt(self, updated)
         self.save_job(updated)
         self.emit(job_id, "job.status", {"status": str(status), "actor": actor or "coordinator"})
         return updated
@@ -406,10 +410,16 @@ class SwarmStore:
             JobStatus.STALLED,
             JobStatus.CANCELLED,
         }
+        # Recoverable / in-flight statuses must not keep a prior receipt so
+        # later work cannot reuse stale economics.
+        cost_receipt = (
+            job.cost_receipt if is_cost_final_job_status(status) else None
+        )
         return replace(
             job,
             status=status,
             completed_at=now_iso() if terminal else job.completed_at,
+            cost_receipt=cost_receipt,
         )
 
     def bind_job_contract(
@@ -2105,6 +2115,21 @@ class SwarmStore:
             return False
         return not SwarmStore.is_task_stale(task)
 
+    @staticmethod
+    def _reopened_job_after_reset(job: Job) -> Job:
+        """Coordinator job after an accepted non-empty reset.
+
+        Production finalize only stamps COMPLETE from a non-complete status.
+        Reopening to RUNNING and clearing ``completed_at`` / ``cost_receipt``
+        lets the next finalize freeze the new generation exactly once.
+        """
+        return replace(
+            job,
+            status=JobStatus.RUNNING,
+            completed_at=None,
+            cost_receipt=None,
+        )
+
     def reset_subgraph(
         self,
         job_id: str,
@@ -2120,7 +2145,9 @@ class SwarmStore:
         retained. Produced outputs are labeled ``superseded`` (audit retained).
 
         Emits one canonical ``subgraph.reset`` event whose payload includes
-        ``superseded_artifact_ids``.
+        ``superseded_artifact_ids``. A non-empty accepted reset reopens the
+        coordinator job to RUNNING and clears ``completed_at`` and
+        ``cost_receipt``.
 
         Refuses the whole reset when any selected task still holds an active
         (non-expired RUNNING) lease, so a live worker cannot be fenced into
@@ -2142,6 +2169,10 @@ class SwarmStore:
         ]
         if active:
             raise ActiveTaskLeaseError(active)
+        # Reopen and clear the job before mutating tasks/artifacts so a
+        # crash cannot leave a cost-final job with a valid receipt over
+        # superseded outputs. SQLite applies the same fields in one txn.
+        self.save_job(self._reopened_job_after_reset(self.get_job(job_id)))
         reset: list[Task] = []
         for task in tasks:
             if task.id not in selected:

--- a/puppetmaster/usage.py
+++ b/puppetmaster/usage.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from typing import Any, Iterable, Optional
 
 from puppetmaster.models import Artifact
+from puppetmaster.validation import validation_status_of
 
 # Rough bytes-per-token for the char/4 fallback. Deliberately conservative and
 # labeled as an estimate wherever it's surfaced — never presented as measured.
@@ -137,12 +138,17 @@ def select_usage_records(artifacts: Iterable[Artifact]) -> dict:
     When a task retries after a failed first adapter (cursor -> agentic), both
     attempts stamp tokens. Prefer the successful / measured / higher-volume
     record so totals and pricing follow the run that actually did the work.
+    Artifacts whose canonical validation status is ``stale`` or ``superseded``
+    are excluded so a reset generation cannot be priced from withdrawn output.
     Untasked artifacts (no task_id) each contribute once under a unique key.
     """
     records: dict = {}
     scores: dict = {}
     untasked = 0
     for artifact in artifacts:
+        status = validation_status_of(artifact)
+        if status in {"stale", "superseded"}:
+            continue
         payload = getattr(artifact, "payload", None) or {}
         if "tokens_in" not in payload and "tokens_out" not in payload:
             continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "puppetmaster-ai"
-version = "1.22.41"
+version = "1.22.42"
 description = "Gunicorn-style agent swarms with Redis-like shared memory and artifact stitching. (Imported as `puppetmaster`; published as `puppetmaster-ai` because the bare PyPI name is held by an abandoned 2019 project, name-reassignment pending.)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_cost_report.py
+++ b/tests/test_cost_report.py
@@ -13,79 +13,297 @@ import contextlib
 import inspect
 import io
 import json
+import sqlite3
 import unittest
+from dataclasses import replace
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Optional
 from unittest.mock import patch
 
+from puppetmaster import mcp_server
 from puppetmaster.cli import main as cli_main
+from puppetmaster.cli.commands_gate import _run_cost_command
+from puppetmaster.cli.commands_jobs import _run_finalize_command
+from puppetmaster.cost import (
+    build_cost_report,
+    build_current_registry_cost_report,
+    final_routing_artifacts,
+    price_job,
+    routing_estimate_rows,
+    valid_terminal_cost_receipt,
+)
 from puppetmaster.model_registry import ModelSpec, save_registry
-from puppetmaster.models import Artifact, ArtifactType
+from puppetmaster.models import (
+    Artifact,
+    ArtifactType,
+    JobStatus,
+    Task,
+    TaskStatus,
+    job_from_dict,
+    to_jsonable,
+)
 from puppetmaster.store_factory import create_store
+from puppetmaster.usage import aggregate_token_usage, select_usage_records
+from puppetmaster.validation import validation_status_of
+
+_RECOVERABLE_STATUSES = (
+    JobStatus.QUEUED,
+    JobStatus.RUNNING,
+    JobStatus.STITCHING,
+    JobStatus.STALLED,
+)
+_COST_FINAL_NON_COMPLETE = (JobStatus.FAILED, JobStatus.CANCELLED)
+_BACKENDS = ("file", "sqlite")
+
+
+def _spec(
+    model_id: str,
+    adapter_model_name: str,
+    score: int,
+    inp: float,
+    out: float,
+    *,
+    adapter: str = "claude-code",
+    billing: str = "api",
+) -> ModelSpec:
+    return ModelSpec(
+        id=model_id,
+        adapter=adapter,
+        adapter_model_name=adapter_model_name,
+        capability_score=score,
+        input_per_mtok_usd=inp,
+        output_per_mtok_usd=out,
+        billing=billing,
+    )
 
 
 def _registry():
     return [
-        ModelSpec(
-            id="mid-model",
-            adapter="claude-code",
-            adapter_model_name="mid-v1",
-            capability_score=80,
-            input_per_mtok_usd=3.0,
-            output_per_mtok_usd=15.0,
-            billing="api",
-        ),
-        ModelSpec(
-            id="flagship-model",
-            adapter="claude-code",
-            adapter_model_name="flagship-v1",
-            capability_score=99,
-            input_per_mtok_usd=15.0,
-            output_per_mtok_usd=75.0,
-            billing="api",
-        ),
+        _spec("mid-model", "mid-v1", 80, 3.0, 15.0),
+        _spec("flagship-model", "flagship-v1", 99, 15.0, 75.0),
     ]
 
 
-def _usage_verification(job_id: str) -> Artifact:
+def _flagship_only():
+    return [spec for spec in _registry() if spec.id == "flagship-model"]
+
+
+def _plan_registry():
+    return [
+        _spec(
+            "plan/cursor",
+            "default",
+            80,
+            5.0,
+            25.0,
+            adapter="cursor",
+            billing="plan",
+        ),
+        *_flagship_only(),
+    ]
+
+
+def _cheaper_mid():
+    return [_spec("mid-model", "mid-v1", 80, 0.01, 0.01)]
+
+
+def _routing(
+    job_id: str,
+    task_id: str,
+    model_id: str,
+    *,
+    billing: Optional[str] = None,
+    created_by: str = "router",
+    estimated_cost_usd: Optional[float] = None,
+    validation: Optional[dict] = None,
+) -> Artifact:
+    payload = {"model_id": model_id, "adapter": "claude-code", "policy": "balanced"}
+    if billing is not None:
+        payload["billing"] = billing
+    if estimated_cost_usd is not None:
+        payload["estimated_cost_usd"] = estimated_cost_usd
+    if validation is not None:
+        payload["validation"] = validation
     return Artifact(
         job_id=job_id,
-        task_id="task-1",
+        task_id=task_id,
+        type=ArtifactType.ROUTING,
+        created_by=created_by,
+        confidence=0.9,
+        evidence=["role:audit"],
+        payload=payload,
+    )
+
+
+def _usage(
+    job_id: str,
+    task_id: str = "t1",
+    *,
+    model: str = "mid-v1",
+    tokens_in: int = 1_000_000,
+    tokens_out: int = 1_000_000,
+    real_cost_usd: Optional[float] = None,
+    validation: Optional[dict] = None,
+) -> Artifact:
+    payload = {
+        "adapter": "test",
+        "check": "do the thing",
+        "result": "passed",
+        "model": model,
+        "tokens_in": tokens_in,
+        "tokens_out": tokens_out,
+        "tokens_estimated": False,
+    }
+    if real_cost_usd is not None:
+        payload["real_cost_usd"] = real_cost_usd
+    if validation is not None:
+        payload["validation"] = validation
+    return Artifact(
+        job_id=job_id,
+        task_id=task_id,
         type=ArtifactType.VERIFICATION,
         created_by="worker-1",
         confidence=0.9,
         evidence=["adapter:test"],
-        payload={
-            "adapter": "test",
-            "check": "do the thing",
-            "result": "passed",
-            "model": "mid-v1",
-            "tokens_in": 1_000_000,
-            "tokens_out": 1_000_000,
-            "tokens_estimated": False,
-        },
+        payload=payload,
+    )
+
+
+@contextlib.contextmanager
+def _models_path(path: Path):
+    prior = os.environ.get("PUPPETMASTER_MODELS_PATH")
+    os.environ["PUPPETMASTER_MODELS_PATH"] = str(path)
+    try:
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop("PUPPETMASTER_MODELS_PATH", None)
+        else:
+            os.environ["PUPPETMASTER_MODELS_PATH"] = prior
+
+
+def _make_store(backend: str, tmp: str):
+    state_dir = Path(tmp) / f".puppetmaster-{backend}"
+    store = create_store(backend, state_dir)
+    store.init()
+    return store
+
+
+@contextlib.contextmanager
+def _harness(backend: str = "file", registry=None):
+    specs = list(_registry() if registry is None else registry)
+    with TemporaryDirectory() as tmp:
+        registry_path = Path(tmp) / "models.json"
+        save_registry(specs, registry_path)
+        yield _make_store(backend, tmp), registry_path
+
+
+def _job_with_usage(store, goal: str, **usage_kwargs):
+    job = store.create_job(goal)
+    store.save_artifacts([_usage(job.id, **usage_kwargs)])
+    return job
+
+
+def _write_receipt(store, job_id: str, status: JobStatus, receipt):
+    store.save_job(
+        replace(store.get_job(job_id), status=status, cost_receipt=receipt)
+    )
+
+
+def _assert_immune_to_registry_churn(
+    test, store, job_id: str, registry_path: Path, first: dict, registries
+) -> None:
+    for registry in registries:
+        save_registry(registry, registry_path)
+        test.assertEqual(build_cost_report(store, job_id, registry=registry), first)
+    mutated = build_cost_report(store, job_id, registry=registries[-1])
+    mutated["actual_cost"]["total_marginal_cost_usd"] = 99.0
+    test.assertEqual(build_cost_report(store, job_id, registry=registries[-1]), first)
+
+
+def _stamp(store, job_id: str, status: JobStatus, registry_path: Path):
+    with _models_path(registry_path):
+        return store.update_job_status(job_id, status)
+
+
+def _finalize_production(store, job_id: str, registry_path: Path):
+    """Production finalize: stitch, then COMPLETE only when the job is open."""
+
+    class Args:
+        pass
+
+    Args.job_id = job_id
+    with _models_path(registry_path), contextlib.redirect_stdout(io.StringIO()):
+        return _run_finalize_command(Args(), store)
+
+
+def _seed_priced_job(store, registry_path: Path, registry):
+    save_registry(registry, registry_path)
+    job = store.create_job("stable cost")
+    task = Task(
+        job_id=job.id,
+        role="audit",
+        instruction="price me",
+        status=TaskStatus.COMPLETE,
+    )
+    store.save_task(task)
+    store.save_artifacts([_usage(job.id, task.id)])
+    _stamp(store, job.id, JobStatus.COMPLETE, registry_path)
+    return job, task
+
+
+def _cost_args(job_id: str, registry_path: Path, *, as_json: bool = False):
+    class Args:
+        pass
+
+    Args.json = as_json
+    Args.job_id = job_id
+    Args.registry_path = str(registry_path)
+    return Args()
+
+
+def _run_cost_text(store, job_id: str, registry_path: Path, *, as_json: bool = False):
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out):
+        rc = _run_cost_command(_cost_args(job_id, registry_path, as_json=as_json), store)
+    return rc, out.getvalue()
+
+
+def _job_payload(**overrides):
+    data = {
+        "id": "job_1",
+        "goal": "g",
+        "status": "queued",
+        "created_at": "2026-08-30T00:00:00+00:00",
+    }
+    data.update(overrides)
+    return data
+
+
+def _complete_legacy(store, job_id: str):
+    store.save_job(replace(store.get_job(job_id), status=JobStatus.COMPLETE))
+
+
+def _assert_source_total(test, report, source: str, total):
+    test.assertEqual(report["pricing_source"], source)
+    if total is None:
+        test.assertIsNone(report["actual_cost"]["total_marginal_cost_usd"])
+        return
+    test.assertAlmostEqual(
+        report["actual_cost"]["total_marginal_cost_usd"], total, places=6
     )
 
 
 class BuildCostReportTests(unittest.TestCase):
     def test_build_cost_report_matches_mari_signature(self) -> None:
-        from puppetmaster.cost import build_cost_report
-
         params = inspect.signature(build_cost_report).parameters
         self.assertEqual(list(params)[:2], ["store", "job_id"])
         self.assertIn("registry", params)
 
     def test_cli_json_matches_build_cost_report(self) -> None:
-        from puppetmaster.cost import build_cost_report
-
-        with TemporaryDirectory() as tmp:
-            registry_path = Path(tmp) / "models.json"
-            save_registry(_registry(), registry_path)
-            state_dir = Path(tmp) / ".puppetmaster"
-            store = create_store("file", state_dir)
-            store.init()
-            job = store.create_job("cost extract")
-            store.save_artifacts([_usage_verification(job.id)])
+        with _harness() as (store, registry_path):
+            job = _job_with_usage(store, "cost extract")
             report = build_cost_report(store, job.id, registry=_registry())
             self.assertEqual(report["job_id"], job.id)
             self.assertIn("actual_cost", report)
@@ -94,16 +312,13 @@ class BuildCostReportTests(unittest.TestCase):
             self.assertAlmostEqual(
                 report["actual_cost"]["total_marginal_cost_usd"], 18.0, places=6
             )
-
-            prior = os.environ.get("PUPPETMASTER_MODELS_PATH")
-            os.environ["PUPPETMASTER_MODELS_PATH"] = str(registry_path)
-            try:
+            with _models_path(registry_path):
                 stdout = io.StringIO()
                 with contextlib.redirect_stdout(stdout):
                     code = cli_main(
                         [
                             "--state-dir",
-                            str(state_dir),
+                            str(registry_path.parent / ".puppetmaster-file"),
                             "--backend",
                             "file",
                             "cost",
@@ -111,48 +326,27 @@ class BuildCostReportTests(unittest.TestCase):
                             "--json",
                         ]
                     )
-            finally:
-                if prior is None:
-                    os.environ.pop("PUPPETMASTER_MODELS_PATH", None)
-                else:
-                    os.environ["PUPPETMASTER_MODELS_PATH"] = prior
             self.assertEqual(code, 0)
             self.assertEqual(json.loads(stdout.getvalue()), report)
 
     def test_cli_and_mcp_call_build_cost_report(self) -> None:
-        from puppetmaster import mcp_server
-        from puppetmaster.cli.commands_gate import _run_cost_command
-
-        with TemporaryDirectory() as tmp:
-            registry_path = Path(tmp) / "models.json"
-            save_registry(_registry(), registry_path)
-            state_dir = Path(tmp) / ".puppetmaster"
-            store = create_store("file", state_dir)
-            store.init()
-            job = store.create_job("cost wiring")
-            store.save_artifacts([_usage_verification(job.id)])
+        with _harness() as (store, registry_path):
+            job = _job_with_usage(store, "cost wiring")
             sentinel = {
                 "job_id": job.id,
                 "cost_basis": "preflight_routing_estimate",
                 "total_estimated_cost_usd": 0.0,
                 "actual_cost": {"total_marginal_cost_usd": 18.0},
             }
-
-            class Args:
-                pass
-            Args.json = True
-            Args.job_id = job.id
-            Args.registry_path = str(registry_path)
-
             with patch(
                 "puppetmaster.cost.build_cost_report", return_value=sentinel
             ) as mocked:
-                out = io.StringIO()
-                with contextlib.redirect_stdout(out):
-                    rc = _run_cost_command(Args(), store)
+                rc, text = _run_cost_text(
+                    store, job.id, registry_path, as_json=True
+                )
                 self.assertEqual(rc, 0)
                 mocked.assert_called_once()
-                self.assertEqual(json.loads(out.getvalue()), sentinel)
+                self.assertEqual(json.loads(text), sentinel)
 
             with patch(
                 "puppetmaster.cost.build_cost_report", return_value=sentinel
@@ -160,16 +354,639 @@ class BuildCostReportTests(unittest.TestCase):
                 result = mcp_server.run_job_cost(
                     {
                         "job_id": job.id,
-                        "state_dir": str(state_dir),
+                        "state_dir": str(registry_path.parent / ".puppetmaster-file"),
                         "backend": "file",
                         "registry_path": str(registry_path),
-                        "cwd": tmp,
+                        "cwd": str(registry_path.parent),
                     }
                 )
                 mocked.assert_called_once()
                 self.assertFalse(result.get("isError"))
                 body = json.loads(result["content"][0]["text"])
                 self.assertEqual(json.loads(body["stdout"]), sentinel)
+
+
+class JobCostReceiptRoundTripTests(unittest.TestCase):
+    def test_job_from_dict_cost_receipt(self) -> None:
+        job = job_from_dict(
+            _job_payload(
+                status="complete",
+                cost_receipt={"job_id": "job_1", "pricing_source": "terminal_receipt"},
+            )
+        )
+        self.assertEqual(job.status, JobStatus.COMPLETE)
+        self.assertEqual(job.cost_receipt["pricing_source"], "terminal_receipt")
+        self.assertEqual(job_from_dict(to_jsonable(job)).cost_receipt, job.cost_receipt)
+        self.assertIsNone(job_from_dict(_job_payload()).cost_receipt)
+        self.assertIsNone(
+            job_from_dict(_job_payload(id="job_2", cost_receipt="not-a-dict")).cost_receipt
+        )
+
+
+class TerminalReceiptLifecycleTests(unittest.TestCase):
+    def _assert_stable_across_registry_churn(self, backend: str) -> None:
+        with _harness(backend) as (store, registry_path):
+            job, _task = _seed_priced_job(store, registry_path, _registry())
+            first = build_cost_report(store, job.id, registry=_registry())
+            _assert_source_total(self, first, "terminal_receipt", 18.0)
+            added = list(_registry()) + [_spec("new-model", "new-v1", 50, 1.0, 1.0)]
+            _assert_immune_to_registry_churn(
+                self,
+                store,
+                job.id,
+                registry_path,
+                first,
+                (added, _cheaper_mid(), _flagship_only()),
+            )
+            self.assertEqual(store.get_job(job.id).status, JobStatus.COMPLETE)
+
+    def test_terminal_receipt_stable_across_registry_churn(self) -> None:
+        for backend in _BACKENDS:
+            with self.subTest(backend=backend):
+                self._assert_stable_across_registry_churn(backend)
+
+    def test_running_and_stalled_reprice_without_stamping(self) -> None:
+        cases = (
+            ("still running", None, False),
+            ("recoverable stall", JobStatus.STALLED, True),
+        )
+        for backend in _BACKENDS:
+            for goal, status, check_receipt in cases:
+                with self.subTest(backend=backend, goal=goal):
+                    with _harness(backend) as (store, registry_path):
+                        job = _job_with_usage(store, goal)
+                        if status is not None:
+                            _stamp(store, job.id, status, registry_path)
+                            if check_receipt:
+                                self.assertIsNone(store.get_job(job.id).cost_receipt)
+                        live = build_cost_report(store, job.id, registry=_registry())
+                        _assert_source_total(self, live, "current_registry", 18.0)
+                        ghost = build_cost_report(store, job.id, registry=_flagship_only())
+                        _assert_source_total(self, ghost, "current_registry", None)
+                        self.assertEqual(ghost["actual_cost"]["unpriced_tasks"], 1)
+
+    def test_failed_and_cancelled_stamp_once(self) -> None:
+        for backend in _BACKENDS:
+            for status in _COST_FINAL_NON_COMPLETE:
+                with self.subTest(backend=backend, status=str(status)):
+                    with _harness(backend) as (store, registry_path):
+                        job = _job_with_usage(store, f"cost-final {status}")
+                        _stamp(store, job.id, status, registry_path)
+                        report = build_cost_report(store, job.id, registry=_flagship_only())
+                        _assert_source_total(self, report, "terminal_receipt", 18.0)
+
+    def test_recoverable_transitions_clear_receipt(self) -> None:
+        for backend in _BACKENDS:
+            for status in _RECOVERABLE_STATUSES:
+                with self.subTest(backend=backend, status=str(status)):
+                    with _harness(backend) as (store, registry_path):
+                        job, _task = _seed_priced_job(store, registry_path, _registry())
+                        self.assertIsNotNone(store.get_job(job.id).cost_receipt)
+                        store.update_job_status(job.id, status)
+                        loaded = store.get_job(job.id)
+                        self.assertEqual(loaded.status, status)
+                        self.assertIsNone(loaded.cost_receipt)
+                        report = build_cost_report(store, job.id, registry=_registry())
+                        _assert_source_total(self, report, "current_registry", 18.0)
+
+    def test_complete_without_usage_does_not_stamp_zero(self) -> None:
+        for backend in _BACKENDS:
+            with self.subTest(backend=backend):
+                with _harness(backend) as (store, registry_path):
+                    job = store.create_job("flush later")
+                    completed = _stamp(store, job.id, JobStatus.COMPLETE, registry_path)
+                    self.assertEqual(completed.status, JobStatus.COMPLETE)
+                    self.assertIsNone(completed.cost_receipt)
+                    store.save_artifacts(
+                        [_usage(job.id, model="ghost-model", tokens_in=500, tokens_out=500, real_cost_usd=0.42)]
+                    )
+                    report = build_cost_report(store, job.id, registry=_registry())
+                    _assert_source_total(self, report, "legacy_artifacts", 0.42)
+                    self.assertIsNone(store.get_job(job.id).cost_receipt)
+                    again = _stamp(store, job.id, JobStatus.COMPLETE, registry_path)
+                    self.assertTrue(valid_terminal_cost_receipt(again.cost_receipt, job.id))
+                    frozen = build_cost_report(store, job.id, registry=_flagship_only())
+                    _assert_source_total(self, frozen, "terminal_receipt", 0.42)
+
+    def test_repeated_final_transition_is_first_writer_wins(self) -> None:
+        for backend in _BACKENDS:
+            with self.subTest(backend=backend):
+                with _harness(backend) as (store, registry_path):
+                    job, _task = _seed_priced_job(store, registry_path, _registry())
+                    first = build_cost_report(store, job.id)
+                    save_registry(_cheaper_mid(), registry_path)
+                    _stamp(store, job.id, JobStatus.COMPLETE, registry_path)
+                    self.assertEqual(
+                        build_cost_report(store, job.id, registry=_cheaper_mid()), first
+                    )
+
+    def test_worker_completion_does_not_stamp_receipt(self) -> None:
+        for backend in _BACKENDS:
+            with self.subTest(backend=backend):
+                with _harness(backend) as (store, registry_path):
+                    job = _job_with_usage(store, "worker cannot complete")
+                    with _models_path(registry_path):
+                        refused = store.update_job_status(
+                            job.id, JobStatus.COMPLETE, actor="worker-1"
+                        )
+                    self.assertEqual(refused.status, JobStatus.QUEUED)
+                    self.assertIsNone(store.get_job(job.id).cost_receipt)
+
+    def test_stamp_failure_does_not_block_completion(self) -> None:
+        with _harness("sqlite") as (store, _registry_path):
+            job = store.create_job("stamp boom")
+            with patch(
+                "puppetmaster.cost.build_current_registry_cost_report",
+                side_effect=RuntimeError("registry exploded"),
+            ):
+                completed = store.update_job_status(job.id, JobStatus.COMPLETE)
+            self.assertEqual(completed.status, JobStatus.COMPLETE)
+            self.assertIsNone(completed.cost_receipt)
+
+    def _assert_reset_reopens_job(self, store, job_id: str) -> None:
+        reopened = store.get_job(job_id)
+        self.assertEqual(reopened.status, JobStatus.RUNNING)
+        self.assertIsNone(reopened.completed_at)
+        self.assertIsNone(reopened.cost_receipt)
+
+    def _reset_clears_and_refreezes(self, backend: str) -> None:
+        with _harness(backend) as (store, registry_path):
+            job, task = _seed_priced_job(store, registry_path, _registry())
+            first = build_cost_report(store, job.id)
+            self.assertEqual(first["pricing_source"], "terminal_receipt")
+            store.reset_subgraph(job.id, [task.id], include_descendants=False)
+            self._assert_reset_reopens_job(store, job.id)
+            after_reset = build_cost_report(store, job.id, registry=_flagship_only())
+            self.assertEqual(after_reset["pricing_source"], "current_registry")
+            self.assertEqual(after_reset["token_usage"]["total_tokens"], 0)
+
+            store.save_artifacts([_usage(job.id, task.id, tokens_in=1_000, tokens_out=1_000)])
+            save_registry(_cheaper_mid(), registry_path)
+            self.assertEqual(store.get_job(job.id).status, JobStatus.RUNNING)
+            self.assertEqual(_finalize_production(store, job.id, registry_path), 0)
+            self.assertEqual(store.get_job(job.id).status, JobStatus.COMPLETE)
+            refrozen = build_cost_report(store, job.id, registry=_registry())
+            self.assertEqual(refrozen["pricing_source"], "terminal_receipt")
+            self.assertEqual(refrozen["actual_cost"]["tasks"][0]["tokens_in"], 1_000)
+            self.assertEqual(refrozen["actual_cost"]["tasks"][0]["tokens_out"], 1_000)
+            self.assertAlmostEqual(
+                refrozen["actual_cost"]["total_marginal_cost_usd"], 0.00002, places=6
+            )
+            self.assertNotEqual(refrozen["actual_cost"]["total_marginal_cost_usd"], 18.0)
+
+    def test_reset_clears_and_refreezes(self) -> None:
+        for backend in _BACKENDS:
+            with self.subTest(backend=backend):
+                self._reset_clears_and_refreezes(backend)
+
+    def test_reset_supersedes_plan_route_and_refreezes_new_generation(self) -> None:
+        for backend in _BACKENDS:
+            with self.subTest(backend=backend):
+                with _harness(backend, registry=_plan_registry()) as (
+                    store,
+                    registry_path,
+                ):
+                    job = store.create_job("plan then metered")
+                    task = Task(
+                        job_id=job.id,
+                        role="audit",
+                        instruction="price me",
+                        status=TaskStatus.COMPLETE,
+                    )
+                    store.save_task(task)
+                    store.save_artifacts(
+                        [
+                            _routing(
+                                job.id,
+                                task.id,
+                                "plan/cursor",
+                                billing="plan",
+                                estimated_cost_usd=1.5,
+                            ),
+                            _usage(job.id, task.id, model="plan/cursor"),
+                        ]
+                    )
+                    _stamp(store, job.id, JobStatus.COMPLETE, registry_path)
+                    first = build_cost_report(store, job.id, registry=_plan_registry())
+                    _assert_source_total(self, first, "terminal_receipt", 0.0)
+                    self.assertEqual(first["actual_cost"]["tasks"][0]["billing"], "plan")
+
+                    store.reset_subgraph(job.id, [task.id], include_descendants=False)
+                    self._assert_reset_reopens_job(store, job.id)
+                    routes = [
+                        artifact
+                        for artifact in store.list_artifacts(job.id)
+                        if artifact.type == ArtifactType.ROUTING
+                    ]
+                    self.assertTrue(routes)
+                    self.assertTrue(
+                        all(
+                            validation_status_of(artifact) == "superseded"
+                            for artifact in routes
+                        )
+                    )
+                    after_reset = build_cost_report(
+                        store, job.id, registry=_plan_registry()
+                    )
+                    self.assertEqual(after_reset["pricing_source"], "current_registry")
+                    self.assertEqual(after_reset["token_usage"]["total_tokens"], 0)
+                    self.assertEqual(after_reset["total_estimated_cost_usd"], 0.0)
+                    self.assertEqual(final_routing_artifacts(store.list_artifacts(job.id)), {})
+
+                    store.save_artifacts(
+                        [
+                            _routing(
+                                job.id,
+                                task.id,
+                                "flagship-model",
+                                billing="api",
+                                estimated_cost_usd=9.0,
+                                validation={"status": "fresh", "generation": 1},
+                            ),
+                            _usage(
+                                job.id,
+                                task.id,
+                                model="flagship-v1",
+                                tokens_in=1_000,
+                                tokens_out=1_000,
+                            ),
+                        ]
+                    )
+                    self.assertEqual(store.get_job(job.id).status, JobStatus.RUNNING)
+                    self.assertEqual(_finalize_production(store, job.id, registry_path), 0)
+                    frozen = build_cost_report(store, job.id, registry=_cheaper_mid())
+                    self.assertEqual(frozen["pricing_source"], "terminal_receipt")
+                    priced = frozen["actual_cost"]["tasks"][0]
+                    self.assertEqual(priced["tokens_in"], 1_000)
+                    self.assertEqual(priced["tokens_out"], 1_000)
+                    self.assertEqual(priced["model_id"], "flagship-model")
+                    self.assertNotEqual(priced["billing"], "plan")
+                    self.assertAlmostEqual(
+                        frozen["actual_cost"]["total_marginal_cost_usd"], 0.09, places=6
+                    )
+                    self.assertAlmostEqual(frozen["total_estimated_cost_usd"], 9.0, places=6)
+
+    def test_sqlite_receipt_clear_rolls_back_with_reset(self) -> None:
+        with _harness("sqlite") as (store, registry_path):
+            job, task = _seed_priced_job(store, registry_path, _registry())
+            self.assertIsNotNone(store.get_job(job.id).cost_receipt)
+            real_session = store._session
+
+            @contextlib.contextmanager
+            def boom_after_writes():
+                with real_session() as connection:
+                    yield connection
+                    raise sqlite3.OperationalError("simulated busy/crash")
+
+            with patch.object(store, "_session", boom_after_writes):
+                with self.assertRaises(sqlite3.OperationalError):
+                    store.reset_subgraph(job.id, [task.id], include_descendants=False)
+            self.assertIsNotNone(store.get_job(job.id).cost_receipt)
+            self.assertEqual(store.get_job(job.id).status, JobStatus.COMPLETE)
+
+
+class UnpricedAndIdentityTests(unittest.TestCase):
+    def test_selected_cost_identity(self) -> None:
+        mixed = [
+            _usage("job_x", "priced", tokens_out=0),
+            _usage("job_x", "ghost", model="ghost-v1", tokens_in=500_000, tokens_out=0),
+        ]
+        plan = [_usage("job_x", model="plan/cursor")]
+        reported = [
+            _usage(
+                "job_x",
+                model="ghost-model",
+                tokens_in=500,
+                tokens_out=500,
+                real_cost_usd=0.05,
+            )
+        ]
+        with self.subTest(case="mixed_unpriced"):
+            report = build_current_registry_cost_report("job_x", mixed, _registry())
+            actual = report["actual_cost"]
+            self.assertEqual(actual["priced_tasks"], 1)
+            self.assertEqual(actual["unpriced_tasks"], 1)
+            self.assertIsNone(actual["total_marginal_cost_usd"])
+            self.assertIsNone(actual["measured_cost_usd"])
+            self.assertAlmostEqual(actual["priced_subtotal_usd"], 3.0, places=6)
+            self.assertAlmostEqual(
+                actual["by_model"]["mid-model"]["marginal_cost_usd"], 3.0, places=6
+            )
+            self.assertIsNone(actual["by_model"]["ghost-v1"]["marginal_cost_usd"])
+            ghost_task = next(t for t in actual["tasks"] if t["task_id"] == "ghost")
+            self.assertFalse(ghost_task["priced"])
+            self.assertIsNone(ghost_task["marginal_cost_usd"])
+            cf = report["counterfactual"]
+            self.assertFalse(cf["actual_priced"])
+            self.assertIsNone(cf["actual_cost_usd"])
+            self.assertIsNone(cf["avoided_usd"])
+
+        with self.subTest(case="plan_zero"):
+            report = build_current_registry_cost_report("job_x", plan, _plan_registry())
+            actual = report["actual_cost"]
+            self.assertEqual(actual["priced_tasks"], 1)
+            self.assertEqual(actual["unpriced_tasks"], 0)
+            self.assertEqual(actual["total_marginal_cost_usd"], 0.0)
+            self.assertEqual(actual["priced_subtotal_usd"], 0.0)
+            self.assertTrue(actual["tasks"][0]["priced"])
+            cf = report["counterfactual"]
+            self.assertTrue(cf["actual_priced"])
+            self.assertEqual(cf["actual_cost_usd"], 0.0)
+            self.assertAlmostEqual(cf["avoided_usd"], 90.0, places=6)
+
+        with self.subTest(case="provider_reported"):
+            report = build_current_registry_cost_report("job_x", reported, _registry())
+            actual = report["actual_cost"]
+            self.assertEqual(actual["unpriced_tasks"], 0)
+            self.assertAlmostEqual(actual["total_marginal_cost_usd"], 0.05, places=6)
+            self.assertEqual(actual["tasks"][0]["billing"], "reported")
+
+    def test_final_route_absent_id_does_not_fall_through(self) -> None:
+        artifacts = [
+            _routing("job_x", "t1", "missing-routed-id"),
+            _usage("job_x"),
+        ]
+        cost = price_job(artifacts, _registry())
+        self.assertEqual(cost.unpriced_tasks, 1)
+        self.assertEqual(cost.priced_tasks, 0)
+        self.assertNotIn("mid-model", cost.by_model)
+        self.assertIn("missing-routed-id", cost.by_model)
+
+    def test_select_usage_excludes_stale_and_superseded(self) -> None:
+        artifacts = [
+            _usage("job_x", validation={"status": "superseded", "generation": 0}),
+            _usage("job_x", tokens_in=10, tokens_out=10, validation={"status": "stale"}),
+            _usage(
+                "job_x",
+                tokens_in=1_000,
+                tokens_out=1_000,
+                validation={"status": "fresh", "generation": 1},
+            ),
+        ]
+        selected = select_usage_records(artifacts)
+        self.assertEqual(selected["t1"]["tokens_in"], 1_000)
+        self.assertEqual(selected["t1"]["tokens_out"], 1_000)
+        roll = aggregate_token_usage(artifacts)
+        self.assertEqual(roll["measured_tokens_in"], 1_000)
+        self.assertEqual(roll["total_tokens"], 2_000)
+        cost = price_job(artifacts, _registry())
+        self.assertEqual(len(cost.tasks), 1)
+        self.assertEqual(cost.tasks[0].tokens_in, 1_000)
+        self.assertAlmostEqual(cost.total_marginal_cost_usd, 0.018, places=6)
+
+    def test_withdrawn_routing_is_excluded_before_selection(self) -> None:
+        artifacts = [
+            _routing(
+                "job_x",
+                "t1",
+                "plan/cursor",
+                billing="plan",
+                created_by="router-escalation",
+                estimated_cost_usd=5.0,
+                validation={"status": "superseded", "generation": 0},
+            ),
+            _routing(
+                "job_x",
+                "t1",
+                "mid-model",
+                estimated_cost_usd=2.0,
+                validation={"status": "stale"},
+            ),
+            _routing(
+                "job_x",
+                "t1",
+                "flagship-model",
+                billing="api",
+                estimated_cost_usd=1.0,
+                validation={"status": "fresh", "generation": 1},
+            ),
+            _usage("job_x", model="flagship-v1", tokens_in=1_000, tokens_out=1_000),
+        ]
+        finals = final_routing_artifacts(artifacts)
+        self.assertEqual(list(finals), ["t1"])
+        self.assertEqual((finals["t1"].payload or {}).get("model_id"), "flagship-model")
+        rows, _by_model, total = routing_estimate_rows(artifacts)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["model_id"], "flagship-model")
+        self.assertAlmostEqual(total, 1.0, places=6)
+        cost = price_job(artifacts, _registry())
+        self.assertEqual(cost.priced_tasks, 1)
+        self.assertEqual(cost.tasks[0].model_id, "flagship-model")
+        self.assertAlmostEqual(cost.total_marginal_cost_usd, 0.09, places=6)
+        unlabeled = [
+            _routing("job_x", "t2", "mid-model", estimated_cost_usd=3.0),
+            _usage("job_x", "t2"),
+        ]
+        self.assertIn("t2", final_routing_artifacts(unlabeled))
+        _rows, _models, unlabeled_total = routing_estimate_rows(unlabeled)
+        self.assertAlmostEqual(unlabeled_total, 3.0, places=6)
+
+
+class LegacyArtifactCostTests(unittest.TestCase):
+    def test_legacy_completed_job_stable_across_registry_churn(self) -> None:
+        with _harness(registry=_flagship_only()) as (store, registry_path):
+            job = _job_with_usage(store, "pre-upgrade complete")
+            _complete_legacy(store, job.id)
+            self.assertIsNone(store.get_job(job.id).cost_receipt)
+
+            first = build_cost_report(store, job.id, registry=_flagship_only())
+            _assert_source_total(self, first, "legacy_artifacts", None)
+            self.assertIsNone(first["counterfactual"])
+            self.assertEqual(first["actual_cost"]["unpriced_tasks"], 1)
+            self.assertIsNone(store.get_job(job.id).cost_receipt)
+            _assert_immune_to_registry_churn(
+                self,
+                store,
+                job.id,
+                registry_path,
+                first,
+                (_registry(), _cheaper_mid(), _flagship_only()),
+            )
+            self.assertIsNone(store.get_job(job.id).cost_receipt)
+            self.assertIsNone(
+                build_cost_report(store, job.id, registry=_registry())[
+                    "actual_cost"
+                ]["total_marginal_cost_usd"]
+            )
+
+    def test_legacy_known_artifact_prices(self) -> None:
+        cases = (
+            (
+                "legacy plan",
+                lambda job_id: [
+                    _routing(job_id, "t1", "plan/cursor", billing="plan"),
+                    _usage(job_id, model="plan/cursor"),
+                ],
+                [],
+                0.0,
+                "plan",
+            ),
+            (
+                "legacy reported",
+                lambda job_id: [
+                    _usage(
+                        job_id,
+                        model="ghost-model",
+                        tokens_in=500,
+                        tokens_out=500,
+                        real_cost_usd=0.05,
+                    )
+                ],
+                _cheaper_mid(),
+                0.05,
+                "reported",
+            ),
+        )
+        for goal, artifacts_for, registry, total, billing in cases:
+            with self.subTest(goal=goal):
+                with _harness() as (store, _registry_path):
+                    job = store.create_job(goal)
+                    store.save_artifacts(artifacts_for(job.id))
+                    _complete_legacy(store, job.id)
+                    report = build_cost_report(store, job.id, registry=registry)
+                    _assert_source_total(self, report, "legacy_artifacts", total)
+                    self.assertEqual(report["actual_cost"]["tasks"][0]["billing"], billing)
+                    if billing == "plan":
+                        self.assertTrue(report["actual_cost"]["tasks"][0]["priced"])
+                    self.assertIsNone(report["counterfactual"])
+
+
+class ReceiptValidationTests(unittest.TestCase):
+    def test_malformed_receipt_falls_back_to_legacy(self) -> None:
+        cases = (
+            {},
+            {"job_id": "job_1", "pricing_source": "terminal_receipt"},
+            {
+                "job_id": "other",
+                "pricing_source": "terminal_receipt",
+                "actual_cost": {},
+                "token_usage": {},
+                "tasks": [],
+            },
+            {
+                "job_id": "job_1",
+                "pricing_source": "current_registry",
+                "actual_cost": {},
+                "token_usage": {},
+                "tasks": [],
+            },
+        )
+        for blob in cases:
+            with self.subTest(blob=blob):
+                with _harness() as (store, _registry_path):
+                    job = _job_with_usage(
+                        store,
+                        "bad receipt",
+                        model="ghost-model",
+                        tokens_in=10,
+                        tokens_out=0,
+                        real_cost_usd=0.01,
+                    )
+                    _write_receipt(
+                        store,
+                        job.id,
+                        JobStatus.COMPLETE,
+                        dict(blob, job_id=blob.get("job_id", job.id)),
+                    )
+                    self.assertIsInstance(store.get_job(job.id).cost_receipt, dict)
+                    report = build_cost_report(store, job.id, registry=_registry())
+                    _assert_source_total(self, report, "legacy_artifacts", 0.01)
+
+    def test_valid_receipt_shape_is_additive(self) -> None:
+        good = {
+            "job_id": "job_1",
+            "pricing_source": "terminal_receipt",
+            "actual_cost": {},
+            "token_usage": {},
+            "tasks": [],
+        }
+        self.assertTrue(valid_terminal_cost_receipt(good, "job_1"))
+        self.assertFalse(valid_terminal_cost_receipt(good, "job_2"))
+        self.assertFalse(valid_terminal_cost_receipt({}, "job_1"))
+        self.assertFalse(valid_terminal_cost_receipt(None, "job_1"))
+
+    def test_stalled_leftover_receipt_is_not_returned(self) -> None:
+        with _harness() as (store, _registry_path):
+            job = _job_with_usage(store, "stalled leftover")
+            leftover = {
+                "job_id": job.id,
+                "pricing_source": "terminal_receipt",
+                "actual_cost": {"total_marginal_cost_usd": 18.0},
+                "token_usage": {},
+                "tasks": [],
+            }
+            _write_receipt(store, job.id, JobStatus.STALLED, leftover)
+            report = build_cost_report(store, job.id, registry=_flagship_only())
+            _assert_source_total(self, report, "current_registry", None)
+
+
+class CostCliHumanTests(unittest.TestCase):
+    def test_human_output_unknown_versus_plan_zero(self) -> None:
+        with _harness(registry=_flagship_only()) as (store, registry_path):
+            job = _job_with_usage(store, "unpriced cli", tokens_out=0)
+            rc, text = _run_cost_text(store, job.id, registry_path)
+            self.assertEqual(rc, 0)
+            self.assertIn("cost unavailable", text)
+            self.assertNotIn("$0.000000", text)
+            self.assertNotIn("avoided $", text)
+            self.assertNotIn("→ avoided", text)
+
+        with _harness(registry=_plan_registry()) as (store, registry_path):
+            job = _job_with_usage(store, "plan zero cli", model="plan/cursor")
+            rc, text = _run_cost_text(store, job.id, registry_path)
+            self.assertEqual(rc, 0)
+            self.assertIn("actual measured spend = $0.000000", text)
+            self.assertNotIn("cost unavailable", text)
+            self.assertIn("avoided $", text)
+
+            mixed = build_current_registry_cost_report(
+                job.id,
+                [
+                    _usage(job.id, "priced", tokens_out=0),
+                    _usage(job.id, "ghost", model="ghost-v1", tokens_in=10, tokens_out=0),
+                ],
+                _registry(),
+            )
+            store.save_job(replace(store.get_job(job.id), cost_receipt=None))
+            with patch("puppetmaster.cost.build_cost_report", return_value=mixed):
+                rc, mixed_text = _run_cost_text(store, job.id, registry_path)
+            self.assertEqual(rc, 0)
+            self.assertIn("cost unavailable", mixed_text)
+            self.assertIn("unavailable", mixed_text)
+            self.assertNotIn("→ avoided", mixed_text)
+            mid_at = mixed_text.find("mid-model")
+            ghost_at = mixed_text.find("ghost-v1")
+            self.assertNotEqual(mid_at, -1)
+            self.assertNotEqual(ghost_at, -1)
+            self.assertLess(mid_at, ghost_at)
+
+    def test_human_output_priced_subtotal_zero_with_unpriced(self) -> None:
+        mixed = build_current_registry_cost_report(
+            "job_x",
+            [
+                _usage("job_x", "plan", model="plan/cursor"),
+                _usage("job_x", "ghost", model="ghost-v1", tokens_in=10, tokens_out=0),
+            ],
+            _plan_registry(),
+        )
+        actual = mixed["actual_cost"]
+        self.assertEqual(actual["priced_tasks"], 1)
+        self.assertEqual(actual["unpriced_tasks"], 1)
+        self.assertEqual(actual["priced_subtotal_usd"], 0.0)
+        self.assertIsNone(actual["total_marginal_cost_usd"])
+        self.assertIsNone(actual["by_model"]["ghost-v1"]["marginal_cost_usd"])
+        self.assertEqual(actual["by_model"]["plan/cursor"]["marginal_cost_usd"], 0.0)
+
+        with _harness(registry=_plan_registry()) as (store, registry_path):
+            job = store.create_job("mixed plan zero")
+            with patch("puppetmaster.cost.build_cost_report", return_value=mixed):
+                rc, text = _run_cost_text(store, job.id, registry_path)
+            self.assertEqual(rc, 0)
+            self.assertIn("cost unavailable", text)
+            self.assertIn(
+                "priced subtotal (excludes unpriced tasks): $0.000000", text
+            )
+            self.assertNotIn("→ avoided", text)
 
 
 if __name__ == "__main__":

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -28,6 +28,7 @@ from puppetmaster.models import (
     ArtifactType,
     GraphEdgeType,
     GraphNodeKind,
+    JobStatus,
     Task,
     TaskStatus,
     graph_edge_identity,
@@ -766,6 +767,8 @@ class SubgraphResetTests(unittest.TestCase):
             job, plan, implement, verify = self._seed_chain(store)
 
             first = store.reset_subgraph(job.id, [implement.id])
+            self.assertEqual(store.get_job(job.id).status, JobStatus.RUNNING)
+            self.assertIsNone(store.get_job(job.id).completed_at)
             by_id = {task.id: task for task in first}
             self.assertIn(implement.id, by_id)
             self.assertIn(verify.id, by_id)
@@ -1237,6 +1240,8 @@ class SqliteAtomicResetAndDoctorTests(unittest.TestCase):
                 side_effect=AssertionError("reset_subgraph must not call save_task"),
             ):
                 reset = store.reset_subgraph(job.id, [implement.id])
+            self.assertEqual(store.get_job(job.id).status, JobStatus.RUNNING)
+            self.assertIsNone(store.get_job(job.id).completed_at)
             by_id = {task.id: task for task in reset}
             self.assertEqual(by_id[implement.id].status, TaskStatus.QUEUED)
             self.assertEqual(by_id[verify.id].status, TaskStatus.BLOCKED)


### PR DESCRIPTION
## Summary
- freeze completed-job cost receipts against the registry in force at terminal status
- keep unpriced selected-model cost unknown instead of turning it into zero-dollar savings
- refreeze economics correctly after reset generations across file and SQLite stores

## Test plan
- [x] focused cost, reset, and coordinator lifecycle suites (63 passed)
- [x] full unittest discovery (2521 passed, 32 skipped)
- [x] release-focused `tests.test_puppetmaster` (1294 passed, 27 skipped)
- [x] absorb PR cross-platform CI matrix