### PR TITLE
absorb #128: selected-model usage cost language

### DIFF
--- a/puppetmaster/cli/commands_gate.py
+++ b/puppetmaster/cli/commands_gate.py
@@ -825,7 +825,7 @@ def _run_cost_command(args, store) -> int:
     else:
         total = actual.get("total_marginal_cost_usd")
         print(
-            f"job {job_id}: actual measured spend = "
+            f"job {job_id}: selected-model usage cost = "
             f"{_format_cost_usd(total, prefix='$')}"
             + (
                 f"  ({_format_cost_usd(actual.get('measured_cost_usd'))} measured / "
@@ -877,6 +877,12 @@ def _run_cost_command(args, store) -> int:
             "\n  note: stable artifact-only economics for a completed job "
             "with no completion receipt; ignores current registry rates."
         )
+    if has_usage:
+        print(
+            "\n  note: selected-model usage cost uses plan-zero, then "
+            "provider-reported real_cost_usd, then tokens × registry price. "
+            "It is not a provider billing API total."
+        )
 
     counterfactual = payload.get("counterfactual")
     avoided = None if counterfactual is None else counterfactual.get("avoided_usd")
@@ -890,8 +896,9 @@ def _run_cost_command(args, store) -> int:
         print()
         print(
             f"  counterfactual: this volume on {counterfactual['reference_model_id']} "
-            f"at metered rates ≈ ${counterfactual['naive_cost_usd']:.6f}; you paid "
-            f"${counterfactual['actual_cost_usd']:.6f} → avoided ${avoided:.6f}."
+            f"at metered rates ≈ ${counterfactual['naive_cost_usd']:.6f}; "
+            f"selected-model total ${counterfactual['actual_cost_usd']:.6f} "
+            f"→ difference ${avoided:.6f}."
         )
 
     routing_rows = [

--- a/puppetmaster/cost.py
+++ b/puppetmaster/cost.py
@@ -293,8 +293,16 @@ def _cost_with_cache_discount(spec, tokens_in: int, tokens_out: int, tokens_cach
 
 
 def price_job(artifacts: Iterable[Artifact], registry: list) -> JobCost:
-    """Price a job's measured/estimated token usage against the registry price
-    of the model each task actually ran on. Independent of routing."""
+    """Price each task, then sum a selected-model usage cost.
+
+    Per-task precedence (unchanged): matching registry model with
+    ``billing="plan"`` → $0 marginal; else positive artifact
+    ``real_cost_usd`` → that reported value; else matching registry model →
+    tokens × registry prices (cache-read discount + output multiplier);
+    else unpriced (aggregate unknown, not $0). Measured vs estimated
+    describes the token source, not the billing basis. Independent of
+    routing.
+    """
     artifacts = list(artifacts)
     by_id, by_adapter_name = _model_index(registry)
     final_routes = final_routing_artifacts(artifacts)

--- a/puppetmaster/mcp_server.py
+++ b/puppetmaster/mcp_server.py
@@ -1345,15 +1345,16 @@ def _build_tools() -> list[McpTool]:
         McpTool(
             name="puppetmaster_job_cost",
             description=(
-                "Report a job's cost on two bases: ACTUAL measured spend "
-                "(tokens actually consumed × registry price of the model each "
-                "task ran on — works for pinned, auto-routed, or plan-billed "
-                "runs) plus a counterfactual ('what this volume would cost on "
-                "the flagship'), and the PRE-FLIGHT routing estimate when the "
+                "Report a job's selected-model usage cost on two bases: the "
+                "mixed-basis ledger (plan-billed tasks are $0 marginal, else "
+                "positive artifact real_cost_usd, else tokens × registry "
+                "price; unpriced tasks stay unknown rather than $0) plus a "
+                "counterfactual ('what this volume would cost on the "
+                "flagship'), and the PRE-FLIGHT routing estimate when the "
                 "job auto-routed. Returns per-model breakdowns + totals. Use to "
                 "answer 'how much did this swarm cost?' or 'which model ate the "
-                "most tokens?'. Prices come from the user-asserted registry — "
-                "Puppetmaster does not call a billing API."
+                "most tokens?'. The aggregate is not a provider billing total "
+                "— Puppetmaster does not call a billing API."
             ),
             input_schema=job_schema(required=True),
             handler=run_job_cost,

--- a/tests/test_cost_report.py
+++ b/tests/test_cost_report.py
@@ -935,9 +935,13 @@ class CostCliHumanTests(unittest.TestCase):
             job = _job_with_usage(store, "plan zero cli", model="plan/cursor")
             rc, text = _run_cost_text(store, job.id, registry_path)
             self.assertEqual(rc, 0)
-            self.assertIn("actual measured spend = $0.000000", text)
+            self.assertIn("selected-model usage cost = $0.000000", text)
+            self.assertNotIn("actual measured spend", text)
+            self.assertNotIn("you paid", text)
             self.assertNotIn("cost unavailable", text)
-            self.assertIn("avoided $", text)
+            self.assertIn("difference $", text)
+            self.assertNotIn("→ avoided", text)
+            self.assertIn("not a provider billing API total", text)
 
             mixed = build_current_registry_cost_report(
                 job.id,
@@ -987,6 +991,48 @@ class CostCliHumanTests(unittest.TestCase):
                 "priced subtotal (excludes unpriced tasks): $0.000000", text
             )
             self.assertNotIn("→ avoided", text)
+
+    def test_human_output_unknown_billing_is_registry_valuation(self) -> None:
+        registry = [
+            _spec(
+                "api/unknown-bill",
+                "unknown-v1",
+                70,
+                1.0,
+                2.0,
+                billing="unknown",
+            ),
+            *_flagship_only(),
+        ]
+        with _harness(registry=registry) as (store, registry_path):
+            job = _job_with_usage(
+                store,
+                "unknown billing valuation",
+                model="unknown-v1",
+                tokens_in=1_000_000,
+                tokens_out=1_000_000,
+            )
+            rc, text = _run_cost_text(store, job.id, registry_path)
+            self.assertEqual(rc, 0)
+            self.assertIn("selected-model usage cost = $3.000000", text)
+            self.assertIn("not a provider billing API total", text)
+            self.assertNotIn("you paid", text)
+            self.assertNotIn("actual measured spend", text)
+
+    def test_job_cost_mcp_description_is_neutral(self) -> None:
+        from puppetmaster.mcp_server import handle_message
+
+        response = handle_message(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+        )
+        tools = {
+            tool["name"]: tool["description"]
+            for tool in response["result"]["tools"]
+        }
+        description = tools["puppetmaster_job_cost"]
+        self.assertIn("selected-model usage cost", description)
+        self.assertIn("not a provider billing total", description)
+        self.assertNotIn("ACTUAL measured spend", description)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why
Benton asked whether mixed-basis job cost should be called actual spend when billing can be plan-zero, provider-reported, or registry-valued (`billing=unknown` included).

## Scope
Wording only. CLI headline is selected-model usage cost. Counterfactual says selected-model total / difference. MCP description discloses precedence and that the aggregate is not a provider billing total. `price_job` arithmetic and JSON keys (`actual_cost`, `avoided_usd`) stay.

## Tradeoffs
No schema aliases or per-task basis migration. Mixed reports still use one aggregate `cost_basis`.

## Verification
- `pytest -q tests/test_cost_report.py` — 28 passed, 37 subtests passed
- Includes the `billing=unknown` registry-valuation case and MCP description assertion

Credit: @kbentonferguson