### PR TITLE
Reuse bound job reference during CLI await

### DIFF
--- a/puppetmaster/cli/commands_jobs.py
+++ b/puppetmaster/cli/commands_jobs.py
@@ -73,7 +73,8 @@ from puppetmaster.workers import WorkerSpec
 from puppetmaster.cli.helpers import _registry_path_from_args
 
 
-def read_job_state(store, job_id: str, *, timed_out: bool = False, stall_after_seconds=None) -> dict:
+def read_job_state(store, job_id: str, *, timed_out: bool = False, stall_after_seconds=None,
+                   reference=None) -> dict:
     """Return the canonical non-blocking state payload for one durable job."""
     if stall_after_seconds is None:
         _reap_quietly(store)
@@ -92,7 +93,7 @@ def read_job_state(store, job_id: str, *, timed_out: bool = False, stall_after_s
         "timed_out": bool(timed_out),
         "completed_at": job.completed_at,
         "budget_policy": dataclasses.asdict(job.budget_policy) if job.budget_policy else None,
-        "job_ref": (getattr(store, "_legacy_read_ref", None) or store.job_ref(job_id)).as_dict(),
+        "job_ref": (reference or getattr(store, "_legacy_read_ref", None) or store.job_ref(job_id)).as_dict(),
         "delivery": snapshot.get("delivery"),
         "progress": snapshot.get("progress"),
     }
@@ -124,7 +125,8 @@ def await_job_state(
     while True:
         try:
             with read_deadline(deadline):
-                state = read_job_state(store, job_id, stall_after_seconds=stall_after_seconds)
+                state = read_job_state(store, job_id, stall_after_seconds=stall_after_seconds,
+                                       reference=reference)
         except ReadUnavailable:
             if deadline is not None and time.monotonic() >= deadline:
                 return {**state, "timed_out": True}

--- a/tests/test_cli_read_availability.py
+++ b/tests/test_cli_read_availability.py
@@ -73,6 +73,18 @@ class PollAvailabilityTests(unittest.TestCase):
             readonly._cleanup.maintain(limit=len(readonly._cleanup.owners))
             self.assertIsNone(readonly._read_deadline.get())
 
+    def test_await_reuses_bound_reference_without_reopening(self):
+        with TemporaryDirectory() as root:
+            store = SQLiteSwarmStore(root)
+            job = store.create_job('bound reference')
+            store.update_job_status(job.id, JobStatus.CANCELLED)
+            expected = store.job_ref(job.id)
+            with patch.object(store, 'job_ref', side_effect=AssertionError('redundant reference read')):
+                state = commands_jobs.await_job_state(store, job.id, timeout_seconds=1)
+            self.assertEqual(state['job_ref'], expected.as_dict())
+            self.assertEqual(state['status'], 'cancelled')
+            self.assertTrue(state['terminal'])
+
     def test_four_child_bindings_and_awaits_survive_real_writer(self):
         script = r'''
 import sys


### PR DESCRIPTION
The post-merge `dev` matrix exposed a macOS lock race in the CLI await path: `read_job_state()` reopened SQLite only to reconstruct a job reference that `await_job_state()` had already bound, and that redundant open could exhaust the caller deadline and surface a lock traceback.

This passes the already-bound reference into each state read and adds a regression test that fails if await tries to reopen the store for identity. The terminal job read, snapshot, and identity binding remain unchanged.

Validation:
- `python3 -m unittest tests.test_cli_read_availability tests.test_readonly_retry_deadline tests.test_readonly_concurrent_reuse` (17 passed)
- real-writer availability case repeated 20 times (20/20 passed)
- `python3 -m unittest discover -s tests -p 'test_readonly*.py'` (120 passed, 2 skipped)

Source failure: dev CI run 34132595408, macOS job 101776038353.
