### PR TITLE
Retry transient Windows readonly source opens

### DIFF
--- a/puppetmaster/readonly.py
+++ b/puppetmaster/readonly.py
@@ -453,14 +453,17 @@ class ReadConnection:
                 except sqlite3.OperationalError as exc:
                     write_race = getattr(exc, 'same_store_write', False)
                     topology_race = attach_binding and getattr(exc, 'launch_topology_change', False)
+                    source_open_contention = (
+                        attach_binding and getattr(exc, 'source_open_contention', False)
+                    )
                     locked = _locked(exc)
                     unavailable = isinstance(exc, ReadUnavailable) and any(
                         reason in str(exc) for reason in ('live sidecars', 'active reader'))
                     launch_transient = launch_binding and _launch_transient(exc)
-                    if not (write_race or topology_race or locked or
+                    if not (write_race or topology_race or source_open_contention or locked or
                             (launch_transient if launch_binding else unavailable)):
                         raise
-                    candidate = (write_deadline if write_race or topology_race or locked and not launch_binding
+                    candidate = (write_deadline if write_race or topology_race or source_open_contention or locked and not launch_binding
                                  else open_deadline if launch_transient or locked and launch_binding
                                  else ordinary_deadline)
                     retry_deadline = candidate if retry_deadline is None else min(retry_deadline, candidate)
@@ -561,6 +564,7 @@ class ReadConnection:
                          sqlite3.OperationalError if kind == 'OperationalError' else sqlite3.DatabaseError)(result['error'])
                 error.session_closed = result.get('session_closed') is True
                 error.launch_topology_change = result.get('launch_topology_change') is True
+                error.source_open_contention = result.get('source_open_contention') is True
                 error.same_store_write = (kind == 'unavailable' and
                     result['error'] == 'unable to open database: source changed' and
                     result.get('same_store_write') is True)

--- a/puppetmaster/readonly_worker.py
+++ b/puppetmaster/readonly_worker.py
@@ -231,7 +231,11 @@ def main(path, *, wal_snapshot=False):
     # source bytes are written. This excludes new WAL openers during the read,
     # so our lock cannot strand a writer's final checkpoint/sidecar cleanup.
     if os.name == 'nt':
-        source = open_windows_source(path)
+        try:
+            source = open_windows_source(path)
+        except OSError as exc:
+            exc.source_open_contention = getattr(exc, 'winerror', None) in (5, 32, 33)
+            raise
         exclusive = True
     else:
         try:
@@ -425,11 +429,20 @@ def serve(path=None):
 
         emit = session_output
         try:
+            released = False
             try:
                 released = main(path, wal_snapshot=wal_snapshot)
             except OSError as exc:
-                output(dict(kind='unavailable', error='unable to open database: source changed or unavailable: ' + str(exc)))
-                return
+                response = dict(
+                    kind='unavailable',
+                    error='unable to open database: source changed or unavailable: ' + str(exc),
+                    source_open_contention=getattr(exc, 'source_open_contention', False),
+                )
+                if response['source_open_contention']:
+                    emit(response)
+                else:
+                    output(response)
+                    return
             except sqlite3.Error as exc:
                 output(dict(kind=type(exc).__name__, error=str(exc), code=getattr(exc, 'sqlite_errorcode', None)))
                 return

--- a/puppetmaster/store.py
+++ b/puppetmaster/store.py
@@ -2600,6 +2600,8 @@ class SwarmStore(StoreContracts):
         return receipt
 
     def reconcile_completions(self, job_id: str) -> None:
+        if not any(not record["done"] for record in self._completion_records(job_id)):
+            return
         with self._completion_scope(job_id) as acquired:
             if not acquired:
                 return

--- a/tests/test_completion_contention.py
+++ b/tests/test_completion_contention.py
@@ -26,6 +26,18 @@ class CompletionContentionTests(unittest.TestCase):
                        completed_at=now_iso())
         return task, run
 
+    def test_empty_reconciliation_does_not_reserve_sqlite_writer(self):
+        with TemporaryDirectory() as tmp:
+            store = SQLiteSwarmStore(Path(tmp))
+            job = store.create_job('empty completion journal')
+            with patch.object(
+                store,
+                '_completion_scope',
+                side_effect=AssertionError('reserved writer for empty journal'),
+            ) as completion_scope:
+                store.reconcile_completions(job.id)
+            completion_scope.assert_not_called()
+
     def test_simultaneous_completions(self):
         for backend in (SwarmStore, SQLiteSwarmStore):
             for mode in ('different', 'duplicate', 'conflict'):

--- a/tests/test_readonly_sqlite_open_identity.py
+++ b/tests/test_readonly_sqlite_open_identity.py
@@ -214,7 +214,9 @@ class SQLiteOpenIdentityTests(unittest.TestCase):
     def test_only_windows_guard_open_marks_sharing_denial_as_contention(self):
         denied = PermissionError('Access is denied')
         denied.winerror = 5
-        with patch.object(worker, 'stamps', return_value=[
+        native_path = type(Path())
+        with patch.object(worker, 'Path', native_path), \
+                patch.object(worker, 'stamps', return_value=[
                 (1, 2, 3, 4, 5), None, None, None]), \
                 patch.object(worker, 'open_windows_source', side_effect=denied), \
                 patch.object(worker.os, 'name', 'nt'):

--- a/tests/test_readonly_sqlite_open_identity.py
+++ b/tests/test_readonly_sqlite_open_identity.py
@@ -194,6 +194,34 @@ class SQLiteOpenIdentityTests(unittest.TestCase):
             with self.assertRaisesRegex(PermissionError, 'sharing violation'):
                 worker.open_windows_source('source.sqlite3')
 
+    def test_windows_guard_sharing_denial_closes_session_and_reuses_helper(self):
+        denied = PermissionError('Access is denied')
+        denied.winerror = 5
+        denied.source_open_contention = True
+        responses = []
+        with patch.object(worker, 'main', side_effect=(denied, True)) as main, \
+                patch.object(worker, 'emit', side_effect=responses.append), \
+                patch.object(worker.os, 'name', 'nt'), \
+                patch.object(worker.sys, 'stdin', io.StringIO(
+                    '{"open":"source.sqlite3"}\n')):
+            worker.serve('source.sqlite3')
+        self.assertTrue(responses[0]['source_open_contention'])
+        self.assertTrue(responses[0]['session_closed'])
+        self.assertIn('Access is denied', responses[0]['error'])
+        self.assertEqual(responses[1], {'rows': [], 'names': []})
+        self.assertEqual(main.call_count, 2)
+
+    def test_only_windows_guard_open_marks_sharing_denial_as_contention(self):
+        denied = PermissionError('Access is denied')
+        denied.winerror = 5
+        with patch.object(worker, 'stamps', return_value=[
+                (1, 2, 3, 4, 5), None, None, None]), \
+                patch.object(worker, 'open_windows_source', side_effect=denied), \
+                patch.object(worker.os, 'name', 'nt'):
+            with self.assertRaises(PermissionError) as caught:
+                worker.main('source.sqlite3')
+        self.assertTrue(caught.exception.source_open_contention)
+
     def test_windows_guard_closes_handle_if_crt_transfer_fails(self):
         closed = []
         def create(*args):

--- a/tests/test_readonly_windows_sequence.py
+++ b/tests/test_readonly_windows_sequence.py
@@ -202,6 +202,50 @@ class WindowsSequenceTests(unittest.TestCase):
             self.assertEqual([request['wal_snapshot'] for request in requests], [False, True])
             connection.close()
 
+    def test_windows_attach_retries_transient_guard_open_denial(self):
+        with TemporaryDirectory() as tmp:
+            store = SQLiteSwarmStore(tmp)
+            store.ensure_schema()
+            replies = iter([
+                json.dumps(dict(
+                    session_closed=True,
+                    kind='unavailable',
+                    error='unable to open database: source changed or unavailable: '
+                          '[WinError 5] Access is denied.',
+                    source_open_contention=True,
+                )),
+                json.dumps(dict(journal='delete')),
+            ])
+
+            class Permit:
+                def release(self):
+                    pass
+
+            class Transport:
+                def __init__(self, path, deadline=None):
+                    self.closed = False
+                    self.busy = threading.Lock()
+                    self.process = SimpleNamespace(stdin=io.StringIO())
+                    self.responses = SimpleNamespace(get=lambda timeout: next(replies))
+                    self.token = readonly._cleanup.register(self, readonly.selection(store)[1])
+
+                def ready(self, deadline):
+                    pass
+
+                def close(self, deadline=None):
+                    self.closed = True
+
+            with patch.object(readonly, '_Transport', Transport), \
+                    patch.object(readonly, 'ReaderAdmission', return_value=Permit()), \
+                    patch.object(readonly, 'source_stamp', return_value=(1, 2, 3, 4, 5)), \
+                    patch.object(readonly, '_source_stamp', return_value=(
+                        (1, 2, 3, 4, 5), None, None, None, None, None)):
+                connection = readonly.ReadConnection(
+                    store, 1, attach_binding=True, attach_deadline=time.monotonic() + 1)
+            requests = connection.process.stdin.getvalue().splitlines()
+            self.assertEqual(len(requests), 2)
+            connection.close()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-import os
+import faulthandler
 import json
+import os
 import sqlite3
 import sys
 import threading
+import time
 import traceback
 
 _HERMETIC_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -34,6 +36,8 @@ def _attach_claim_complete_worker(
     state_dir: str, job_id: str, worker_id: str, error_path: str
 ) -> None:
     """Spawn-safe worker body: attach only, then claim/complete local tasks."""
+    error_file = Path(error_path).open("w", encoding="utf-8")
+    faulthandler.dump_traceback_later(45, file=error_file)
     thread_errors: list[str] = []
     previous_hook = threading.excepthook
     threading.excepthook = lambda args: thread_errors.append(
@@ -53,14 +57,15 @@ def _attach_claim_complete_worker(
         )
         runtime.run_until_idle()
     except Exception:  # noqa: BLE001 — surface in the parent assert
-        Path(error_path).write_text(
-            traceback.format_exc(), encoding="utf-8"
-        )
+        error_file.write(traceback.format_exc())
     finally:
+        faulthandler.cancel_dump_traceback_later()
         threading.excepthook = previous_hook
         if thread_errors:
-            with Path(error_path).open("a", encoding="utf-8") as output:
-                output.write("\n".join(thread_errors))
+            error_file.write("\n".join(thread_errors))
+        error_file.close()
+        if Path(error_path).stat().st_size == 0:
+            Path(error_path).unlink()
 
 
 class SqliteAttachEnsureTests(unittest.TestCase):
@@ -806,12 +811,20 @@ class SqliteMultiprocessAttachTests(unittest.TestCase):
                 process.start()
 
             errors: list[str] = []
+            deadline = time.monotonic() + 60
             for process, error_path in processes:
-                process.join(timeout=60)
+                process.join(timeout=max(0, deadline - time.monotonic()))
+            timed_out = [(process, error_path) for process, error_path in processes
+                         if process.is_alive()]
+            for process, _ in timed_out:
+                process.terminate()
+            for process, error_path in timed_out:
+                process.join(timeout=5)
+                errors.append(f"timeout:{error_path.name}")
                 if process.is_alive():
-                    process.terminate()
+                    process.kill()
                     process.join(timeout=5)
-                    errors.append(f"timeout:{error_path.name}")
+            for process, error_path in processes:
                 if process.exitcode not in (0, None):
                     errors.append(f"exit:{error_path.name}={process.exitcode}")
                 if error_path.is_file():


### PR DESCRIPTION
Windows can transiently reject the readonly helper's deny-delete source handle with `WinError 5` while many workers attach. The helper reported that as a generic source-change failure, so attach refused its normal bounded retry even though no database snapshot had opened.

This change marks only Windows sharing/open errors 5, 32, and 33 as source-open contention and retries them inside the existing attach deadline. Proven or unclassified source changes still fail closed.

Validation:
- `python -m unittest discover -s tests -p 'test_readonly*.py' -v` (122 passed, 2 skipped)
- focused attach and 32-process concurrency tests (10/10 repeated passes)
- regression coverage for worker classification and the in-helper retry path
