### PR TITLE
Distribute claim sweeps and retry Windows metadata contention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,12 @@ jobs:
       - name: Smoke check Cursor runner syntax
         run: npm run smoke:cursor-runner
       - name: Run Python tests
-        run: python -m unittest discover -s tests -v
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            python -m unittest -v tests.test_sqlite_concurrency.SqliteMultiprocessAttachTests.test_supervisor_ensure_then_n_workers_attach_claim_complete
+          else
+            python -m unittest discover -s tests -v
+          fi
       - name: Smoke check CLI metadata
         run: |
           python -m puppetmaster --help

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,7 @@ jobs:
       - name: Smoke check Cursor runner syntax
         run: npm run smoke:cursor-runner
       - name: Run Python tests
-        run: |
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            python -m unittest -v tests.test_sqlite_concurrency.SqliteMultiprocessAttachTests.test_supervisor_ensure_then_n_workers_attach_claim_complete
-          else
-            python -m unittest discover -s tests -v
-          fi
+        run: python -m unittest discover -s tests -v
       - name: Smoke check CLI metadata
         run: |
           python -m puppetmaster --help

--- a/.github/workflows/windows-store.yml
+++ b/.github/workflows/windows-store.yml
@@ -1,0 +1,26 @@
+name: Windows store canary
+
+# Fast Windows signal for the attach herd and crash-demo. Does not replace
+# the required CI matrix (`python -m unittest discover` on all four legs).
+# Do not skip, xfail, or raise timeouts here.
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  windows-store:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Run SQLite attach concurrency tests
+        run: python -m unittest tests.test_sqlite_concurrency -v
+      - name: Run crash-demo
+        if: ${{ !cancelled() }}
+        run: python -m puppetmaster crash-demo

--- a/puppetmaster/readonly_worker.py
+++ b/puppetmaster/readonly_worker.py
@@ -158,6 +158,19 @@ def open_windows_source(path):
         raise
 
 
+def _retryable_windows_contention(exc):
+    if os.name == 'nt' and getattr(exc, 'winerror', None) in (5, 32, 33):
+        exc.source_open_contention = True
+    return exc
+
+
+def _stamps_after_open(path):
+    try:
+        return stamps(path)
+    except OSError as exc:
+        raise _retryable_windows_contention(exc)
+
+
 def descriptor_uri(fd):
     """Select a source descriptor URI; Linux additionally attests SQLite's fd."""
     expected = os.fstat(fd)
@@ -307,7 +320,7 @@ def main(path, *, wal_snapshot=False):
             except BlockingIOError:
                 emit(dict(kind='OperationalError', error='database is locked'))
                 return
-        after = stamps(path)
+        after = _stamps_after_open(path)
         if not wal_snapshot and after != before:
             emit(dict(kind='unavailable', error='unable to open database: source changed',
                       launch_topology_change=after[0] == before[0] and after[1:] != before[1:],
@@ -322,7 +335,7 @@ def main(path, *, wal_snapshot=False):
                       error='unable to open database: live sidecars; retry after checkpoint',
                       code=5))
             return
-        after = stamps(path)
+        after = _stamps_after_open(path)
         if not wal_snapshot and after != before:
             emit(dict(kind='unavailable', error='unable to open database: source changed',
                       launch_topology_change=after[0] == before[0] and after[1:] != before[1:]))
@@ -344,7 +357,7 @@ def main(path, *, wal_snapshot=False):
             c.execute('PRAGMA synchronous=NORMAL')
             c.execute('BEGIN')
             c.execute('SELECT rootpage FROM sqlite_master LIMIT 1').fetchone()
-            if not wal_snapshot and stamps(path) != before:
+            if not wal_snapshot and _stamps_after_open(path) != before:
                 emit(dict(kind='unavailable', error='unable to open database: source changed'))
                 return
             def unchanged():

--- a/puppetmaster/store.py
+++ b/puppetmaster/store.py
@@ -1470,6 +1470,15 @@ class SwarmStore(StoreContracts):
         # a per-edge file glob / SQLite SELECT on every claim sweep).
         tasks = self.list_tasks(job_id)
         task_map = {task.id: task for task in tasks}
+        if len(tasks) > 1:
+            # Workers otherwise stampede the first queued task, then repeat the
+            # same losing writer reservation for every task already claimed by
+            # a peer. A stable per-worker rotation spreads those first CAS
+            # attempts across the queue without changing eligibility or
+            # allowing a claim outside the store's atomic fence.
+            digest = hashlib.sha256(worker_id.encode("utf-8")).digest()
+            offset = int.from_bytes(digest[:8], "big") % len(tasks)
+            tasks = tasks[offset:] + tasks[:offset]
         for task in tasks:
             if task.status != TaskStatus.QUEUED:
                 continue

--- a/tests/test_readonly_sqlite_open_identity.py
+++ b/tests/test_readonly_sqlite_open_identity.py
@@ -224,6 +224,108 @@ class SQLiteOpenIdentityTests(unittest.TestCase):
                 worker.main('source.sqlite3')
         self.assertTrue(caught.exception.source_open_contention)
 
+    def test_windows_snapshot_sharing_denial_is_session_closed_and_retried(self):
+        before = [(1, 2, 3, 4, 5), None, None, None]
+        responses = []
+
+        class Source:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def fileno(self):
+                return 11
+
+            def read(self, size):
+                return b'\x00' * size
+
+        calls = {'count': 0}
+        native_path = type(Path())
+        run = worker.main
+
+        def stamps(_path):
+            calls['count'] += 1
+            if calls['count'] == 1:
+                return before
+            denied = PermissionError('Access is denied')
+            denied.winerror = 5
+            raise denied
+
+        def main(path, *, wal_snapshot=False):
+            if calls['count']:
+                return True
+            return run(path, wal_snapshot=wal_snapshot)
+
+        with patch.object(worker, 'stamps', side_effect=stamps), \
+                patch.object(worker, 'main', side_effect=main) as main_mock, \
+                patch.object(worker, 'open_windows_source', return_value=Source()), \
+                patch.object(worker, 'source_stamp', return_value=before[0]), \
+                patch.object(worker, 'emit', side_effect=responses.append), \
+                patch.object(worker, 'Path', native_path), \
+                patch.object(worker.os, 'name', 'nt'), \
+                patch.object(ctypes, 'WinDLL', return_value=SimpleNamespace(
+                    LockFileEx=lambda *args: True), create=True), \
+                patch.dict(sys.modules, msvcrt=SimpleNamespace(
+                    open_osfhandle=lambda handle, flags: handle,
+                    get_osfhandle=lambda fd: fd)), \
+                patch.object(worker.sys, 'stdin', io.StringIO(
+                    '{"open":"source.sqlite3"}\n')):
+            worker.serve('source.sqlite3')
+        self.assertEqual(main_mock.call_count, 2)
+        self.assertEqual(len(responses), 2)
+        self.assertTrue(responses[0]['source_open_contention'])
+        self.assertTrue(responses[0]['session_closed'])
+        self.assertIn('Access is denied', responses[0]['error'])
+        self.assertEqual(responses[1], {'rows': [], 'names': []})
+
+    def test_windows_snapshot_identity_failure_is_terminal(self):
+        failure = OSError('SQLite fd attestation: existing descriptors changed')
+        responses = []
+
+        class Source:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def fileno(self):
+                return 11
+
+            def read(self, size):
+                return b'\x00' * size
+
+        calls = {'count': 0}
+        native_path = type(Path())
+
+        def stamps(_path):
+            calls['count'] += 1
+            if calls['count'] == 1:
+                return [(1, 2, 3, 4, 5), None, None, None]
+            raise failure
+
+        with patch.object(worker, 'stamps', side_effect=stamps), \
+                patch.object(worker, 'main', wraps=worker.main) as main, \
+                patch.object(worker, 'open_windows_source', return_value=Source()), \
+                patch.object(worker, 'source_stamp', return_value=(1, 2, 3, 4, 5)), \
+                patch.object(worker, 'emit', side_effect=responses.append), \
+                patch.object(worker, 'Path', native_path), \
+                patch.object(worker.os, 'name', 'nt'), \
+                patch.object(ctypes, 'WinDLL', return_value=SimpleNamespace(
+                    LockFileEx=lambda *args: True), create=True), \
+                patch.dict(sys.modules, msvcrt=SimpleNamespace(
+                    open_osfhandle=lambda handle, flags: handle,
+                    get_osfhandle=lambda fd: fd)), \
+                patch.object(worker.sys, 'stdin', io.StringIO(
+                    '{"open":"source.sqlite3"}\n')):
+            worker.serve('source.sqlite3')
+        self.assertEqual(main.call_count, 1)
+        self.assertEqual(len(responses), 1)
+        self.assertNotIn('session_closed', responses[0])
+        self.assertIn('existing descriptors changed', responses[0]['error'])
+
     def test_windows_guard_closes_handle_if_crt_transfer_fails(self):
         closed = []
         def create(*args):

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -148,7 +148,8 @@ class SqliteAttachEnsureTests(unittest.TestCase):
                 for thread in threads:
                     thread.join()
 
-            self.assertEqual(errors, [])
+            if errors:
+                self.fail("\n\n".join(errors[:2]))
             self.assertEqual(scripts, [])
             self.assertEqual(metadata_inserts, [])
 

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -156,7 +156,7 @@ class SqliteAttachEnsureTests(unittest.TestCase):
                     thread.join()
 
             if errors:
-                self.fail("\n\n".join(errors[:2]))
+                self.fail("\n\n".join(str(error) for error in errors[:2]))
             self.assertEqual(scripts, [])
             self.assertEqual(metadata_inserts, [])
 

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -38,7 +38,13 @@ def _attach_claim_complete_worker(
     """Spawn-safe worker body: attach only, then claim/complete local tasks."""
     error_file = Path(error_path).open("w", encoding="utf-8")
     diagnostic_file = Path(diagnostic_path).open("w", encoding="utf-8")
-    faulthandler.dump_traceback_later(45, file=diagnostic_file)
+    diagnostic_worker = worker_id == "w-0"
+    if diagnostic_worker:
+        # One representative stack is enough to diagnose a shared attach
+        # stall. Arming every spawned process at the same instant creates a
+        # 32-writer traceback storm that can itself push healthy workers past
+        # the parent deadline on Windows.
+        faulthandler.dump_traceback_later(45, file=diagnostic_file)
     thread_errors: list[str] = []
     previous_hook = threading.excepthook
     threading.excepthook = lambda args: thread_errors.append(
@@ -60,7 +66,8 @@ def _attach_claim_complete_worker(
     except Exception:  # noqa: BLE001 — surface in the parent assert
         error_file.write(traceback.format_exc())
     finally:
-        faulthandler.cancel_dump_traceback_later()
+        if diagnostic_worker:
+            faulthandler.cancel_dump_traceback_later()
         threading.excepthook = previous_hook
         if thread_errors:
             error_file.write("\n".join(thread_errors))


### PR DESCRIPTION
Concurrent workers all began at the same queued task. Under SQLite this created a writer-reservation herd: every loser serialized on already-claimed candidates, and the native Windows stress lane could time out. Once the herd was removed, the lane exposed one transient `WinError 5` while the readonly helper rechecked source metadata after opening its guarded handle.

Rotate each worker claim scan by a stable worker-derived offset. Mark Windows sharing errors from post-open metadata snapshots as source-open contention so the existing bounded helper retry can handle them. Limit the stress test to one representative delayed traceback: arming all 32 subprocesses at 45 seconds caused simultaneous diagnostic writes that could push otherwise healthy workers beyond the unchanged 60-second parent deadline.

Eligibility, dependency checks, SQLite's atomic claim fence, source identity checks, and production retry deadlines are unchanged.

Verification:
- `python -m unittest -v tests.test_readonly_sqlite_open_identity tests.test_attach_reader_contention tests.test_sqlite_concurrency.SqliteMultiprocessAttachTests.test_supervisor_ensure_then_n_workers_attach_claim_complete` (21 passed, 1 platform skip)
- `python -m unittest discover -v -s tests -p 'test_readonly*.py'` (125 passed, 2 platform skips)
- focused native Windows stress run passed with 32 spawned workers
- `git diff --check`

No timeout widening or source-change retry was added.
