### PR TITLE
Harden Windows worker attach and launch contention

### DIFF
--- a/.github/workflows/windows-store.yml
+++ b/.github/workflows/windows-store.yml
@@ -24,3 +24,6 @@ jobs:
       - name: Run crash-demo
         if: ${{ !cancelled() }}
         run: python -m puppetmaster crash-demo
+      - name: Run crash-recovery regression
+        if: ${{ !cancelled() }}
+        run: python -m unittest tests.test_puppetmaster.PuppetmasterTests.test_crash_recovery_demo_reclaims_abandoned_task -v

--- a/puppetmaster/identity.py
+++ b/puppetmaster/identity.py
@@ -1,6 +1,7 @@
 """Store incarnation identity, independent of the path-derived state identity."""
 from __future__ import annotations
 
+import threading
 from uuid import UUID, uuid4
 
 from puppetmaster.models import JobRef
@@ -9,6 +10,10 @@ from puppetmaster.state import state_identity
 
 class StoreIdentityError(ValueError):
     """Missing, corrupt, legacy or replaced identity; never implicitly rebind."""
+
+
+_launch_prepare_lock = threading.Lock()
+_prepared_launch_roots: set[str] = set()
 
 
 def read_identity(c, backend):
@@ -81,10 +86,36 @@ def reference_at(root, job_id, *, expected_incarnation=None, launch_binding=Fals
 def prepare_launch(root, backend, job_ref=None):
     """Supervisor bootstrap before detaching; the child must attach this identity."""
     from puppetmaster.store_factory import create_store
-    store = create_store(backend, root)
-    if job_ref is not None:
-        store.bind_job_ref(job_ref)
-    store.init()
-    # init captured this identity inside the supervisor transaction. Reopening
-    # a metadata reader here races other launchers and their live WAL.
-    return store._incarnation
+
+    def prepare():
+        store = create_store(backend, root)
+        if job_ref is not None:
+            store.bind_job_ref(job_ref)
+        root_key = str(store.root.resolve())
+        if (
+            backend == "sqlite"
+            and root_key in _prepared_launch_roots
+            and store.db_path.exists()
+        ):
+            connection = store._connect_with_lock_retry()
+            try:
+                version = store._assert_schema(connection)
+                if str(version) == str(store.schema_version):
+                    store._incarnation = read_identity(connection, "sqlite")
+                    return store._incarnation
+            finally:
+                connection.close()
+        store.init()
+        if backend == "sqlite":
+            _prepared_launch_roots.add(root_key)
+        # init captured this identity inside the supervisor transaction.
+        # Reopening a metadata reader here races other launchers and their WAL.
+        return store._incarnation
+
+    if backend == "sqlite":
+        # Detach calls can arrive concurrently in one MCP host. Ensure schema
+        # once per root and process (including trigger refresh after upgrades);
+        # followers validate identity without replaying DDL under a writer lock.
+        with _launch_prepare_lock:
+            return prepare()
+    return prepare()

--- a/puppetmaster/orchestrator.py
+++ b/puppetmaster/orchestrator.py
@@ -2411,16 +2411,14 @@ class Orchestrator:
         roles = sorted({task.role for task in tasks})
         record_orchestrator_heartbeat(self.store, job.id)
         processes = [
-            self._spawn_worker(job.id, role, lease_seconds=lease_seconds)
+            (role, self._spawn_worker(job.id, role, lease_seconds=lease_seconds))
             for role in roles
         ]
         try:
-            for process in processes:
+            for role, process in processes:
                 self._wait_for_worker(process, job, tasks)
                 if process.returncode != 0:
-                    raise RuntimeError(
-                        f"worker process failed with exit code {process.returncode}"
-                    )
+                    raise self._worker_exit_error(job.id, role, process)
 
             if self.store.has_incomplete_tasks(job.id):
                 recovered = self.store.recover_stale_tasks(job.id)
@@ -2465,7 +2463,7 @@ class Orchestrator:
                 elif self._should_fail_closed(job, allowed_task_ids):
                     raise RuntimeError("swarm exited with incomplete tasks")
         finally:
-            for process in processes:
+            for _role, process in processes:
                 if process.poll() is None:
                     process.terminate()
                     try:
@@ -2584,21 +2582,21 @@ class Orchestrator:
         roles = sorted({task.role for task in dependencies})
         self._ensure_store_schema()
         processes = [
-            self._spawn_worker(job.id, role, lease_seconds=lease_seconds)
+            (role, self._spawn_worker(job.id, role, lease_seconds=lease_seconds))
             for role in roles
         ]
         try:
-            for process in processes:
+            for role, process in processes:
                 process.wait(timeout=self._worker_wait_timeout(dependencies))
                 if process.returncode != 0:
-                    raise RuntimeError(
-                        f"prerequisite worker failed with exit code {process.returncode}"
+                    raise self._worker_exit_error(
+                        job.id, role, process, phase="prerequisite worker"
                     )
         finally:
             # If a wait timed out or a prerequisite failed mid-batch, don't
             # leave the remaining workers running as orphans — terminate (then
             # kill) any that are still alive so they don't outlive the job.
-            for process in processes:
+            for _role, process in processes:
                 if process.poll() is None:
                     process.terminate()
                     try:
@@ -2656,6 +2654,30 @@ class Orchestrator:
             env["TRACEPARENT"] = self._traceparent
             env["PUPPETMASTER_TRACEPARENT"] = self._traceparent
         return subprocess.Popen(command, env=env)
+
+    def _worker_exit_error(
+        self,
+        job_id: str,
+        role: str,
+        process: subprocess.Popen,
+        *,
+        phase: str = "worker",
+    ) -> RuntimeError:
+        """Include the worker's durable failure traceback when one exists."""
+        message = f"{phase} {role!r} failed with exit code {process.returncode}"
+        expected = f"startup_error-worker-{role}-{process.pid}.log"
+        task_dir = self.store.job_dir(job_id) / "tasks"
+        try:
+            error_file = next(
+                path for path in task_dir.glob("startup_error-*.log")
+                if path.name == expected
+            )
+            detail = error_file.read_text(encoding="utf-8", errors="replace").strip()
+        except (OSError, StopIteration):
+            detail = ""
+        if detail:
+            message += f"\n{detail[-8000:]}"
+        return RuntimeError(message)
 
     @staticmethod
     def _worker_wait_timeout(tasks: list[Task]) -> int:

--- a/puppetmaster/store.py
+++ b/puppetmaster/store.py
@@ -2334,10 +2334,15 @@ class SwarmStore(StoreContracts):
             try:
                 with connection(self, metadata_only=True) as c:
                     return read_identity(c, self.backend_name)
-            except sqlite3.OperationalError as exc:
-                transient = str(exc) == 'database is locked' or (
-                    isinstance(exc, ReadUnavailable) and any(reason in str(exc)
-                    for reason in ('source changed', 'active reader', 'live sidecars')))
+            except (sqlite3.OperationalError, ReadUnavailable) as exc:
+                transient = (
+                    isinstance(exc, sqlite3.OperationalError)
+                    and str(exc) == 'database is locked'
+                ) or (
+                    isinstance(exc, ReadUnavailable)
+                    and any(reason in str(exc)
+                            for reason in ('source changed', 'active reader', 'live sidecars'))
+                )
                 if not transient or time.monotonic() >= deadline:
                     raise
                 time.sleep(.01)

--- a/puppetmaster/worker_runtime.py
+++ b/puppetmaster/worker_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import sqlite3
 import threading
 import time
 from dataclasses import replace
@@ -494,7 +495,17 @@ class WorkerRuntime:
         lease_id: Optional[str] = None,
     ) -> None:
         while not stop.wait(self._heartbeat_interval()):
-            run, renewed = self._heartbeat_run_and_lease(run, task_id, lease_id)
+            try:
+                run, renewed = self._heartbeat_run_and_lease(run, task_id, lease_id)
+            except sqlite3.OperationalError as exc:
+                from puppetmaster.sqlite_store import _is_sqlite_lock_error
+
+                if not _is_sqlite_lock_error(exc):
+                    raise
+                # A failed reservation did not mutate either record. Let the
+                # next heartbeat determine whether the lease still belongs to
+                # this worker instead of killing the background thread.
+                continue
             if renewed is None:
                 self._lease_lost.set()
                 stop.set()

--- a/puppetmaster/worker_runtime.py
+++ b/puppetmaster/worker_runtime.py
@@ -600,14 +600,18 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _write_startup_error(state_dir, job_id: str, worker_id: str, exc: BaseException) -> None:
-    """Record a worker that died before/while starting so the failure isn't a
-    silent 0-byte log.
+def _write_startup_error(
+    backend: str,
+    state_dir,
+    job_id: str,
+    worker_id: str,
+    exc: BaseException,
+) -> None:
+    """Record a worker that died during startup or execution.
 
-    A worker that fails to start (bad env, import error, store init failure)
-    used to vanish with no trace — indistinguishable from "never launched". We
-    drop a startup-error file next to the job's task logs and, if the store is
-    usable, emit a ``worker.startup_failed`` event so it shows up in the feed.
+    A worker that exits outside normal Exception handling can otherwise vanish
+    with no trace. Keep the existing startup-error file/event contract while
+    preserving the traceback for both startup and execution failures.
     """
     import traceback
 
@@ -618,14 +622,14 @@ def _write_startup_error(state_dir, job_id: str, worker_id: str, exc: BaseExcept
         crash_dir = Path(state_dir) / "jobs" / job_id / "tasks"
         crash_dir.mkdir(parents=True, exist_ok=True)
         (crash_dir / f"startup_error-{worker_id}.log").write_text(
-            f"worker {worker_id} for job {job_id} failed to start:\n\n{detail}",
+            f"worker {worker_id} for job {job_id} failed to start or run:\n\n{detail}",
             encoding="utf-8",
             errors="replace",
         )
     except Exception:
         pass
     try:
-        create_store("sqlite", state_dir, mode="attach").emit(
+        create_store(backend, state_dir, mode="attach").emit(
             job_id,
             "worker.startup_failed",
             {"worker_id": worker_id, "error": str(exc)},
@@ -660,12 +664,15 @@ def main(argv: Optional[list[str]] = None) -> int:
             crash_after_claim=args.crash_after_claim,
         )
         return 0 if runtime.run_until_idle() >= 0 else 1
-    except SystemExit:
-        # An intentional exit (e.g. the crash-after-claim demo) is not a
-        # startup failure — let it propagate untouched.
+    except SystemExit as exc:
+        # Only the crash-after-claim path owns exit 77. Other SystemExit values
+        # are unexpected worker failures and need the same durable traceback as
+        # any other BaseException; otherwise the supervisor sees only exit 1.
+        if not (args.crash_after_claim and exc.code == 77):
+            _write_startup_error(args.backend, state_dir, args.job_id, worker_id, exc)
         raise
     except BaseException as exc:  # noqa: BLE001 — last-resort trace before dying
-        _write_startup_error(state_dir, args.job_id, worker_id, exc)
+        _write_startup_error(args.backend, state_dir, args.job_id, worker_id, exc)
         raise
 
 

--- a/tests/test_incarnation_history.py
+++ b/tests/test_incarnation_history.py
@@ -398,6 +398,26 @@ class IncarnationHistoryTests(unittest.TestCase):
             self.assertIn('store replaced', result.stderr)
             self.assertEqual(replacement.incarnation, identity)
 
+    def test_concurrent_prepare_launch_ensures_current_schema_once(self):
+        from puppetmaster.identity import prepare_launch
+
+        original = SQLiteSwarmStore._execute_schema_script
+        schema_ensures = []
+
+        def counted(connection, script):
+            schema_ensures.append(root)
+            return original(connection, script)
+
+        with TemporaryDirectory() as tmp, patch.object(
+            SQLiteSwarmStore, '_execute_schema_script', new=staticmethod(counted)
+        ):
+            root = Path(tmp) / 'state'
+            with ThreadPoolExecutor(max_workers=8) as pool:
+                incarnations = list(pool.map(lambda _: prepare_launch(root, 'sqlite'), range(16)))
+
+        self.assertEqual(len(set(incarnations)), 1)
+        self.assertEqual(schema_ensures, [root])
+
     def test_completion_requires_explicit_incarnation(self):
         for store, job in self.stores():
             task = Task(job_id=job.id, role='explore', instruction='private')

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -2463,6 +2463,67 @@ class PuppetmasterTests(unittest.TestCase):
             self.assertEqual(implement_tasks[0].status, TaskStatus.COMPLETE)
             self.assertEqual(implement_tasks[0].attempts, 2)
 
+    def test_worker_exit_reports_durable_startup_traceback(self) -> None:
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("diagnose a failed worker")
+            task_dir = store.job_dir(job.id) / "tasks"
+            (task_dir / "startup_error-worker-explore-4321.log").write_text(
+                "worker failed to start:\nPermissionError: sharing violation",
+                encoding="utf-8",
+            )
+            process = MagicMock(pid=4321, returncode=1)
+
+            error = Orchestrator(store)._worker_exit_error(
+                job.id, "explore", process
+            )
+
+            self.assertIn("worker 'explore' failed with exit code 1", str(error))
+            self.assertIn("PermissionError: sharing violation", str(error))
+
+    def test_worker_main_records_unexpected_system_exit(self) -> None:
+        from puppetmaster.worker_runtime import WorkerRuntime, main as worker_main
+
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("record a silent worker exit")
+            argv = [
+                "--state-dir", str(store.root), "--backend", "file",
+                "--job-id", job.id, "--role", "explore",
+                "--worker-id", "test-worker",
+            ]
+            with patch.object(WorkerRuntime, "run_until_idle", side_effect=SystemExit(1)):
+                with self.assertRaises(SystemExit) as raised:
+                    worker_main(argv)
+
+            self.assertEqual(raised.exception.code, 1)
+            error_file = store.job_dir(job.id) / "tasks" / "startup_error-test-worker.log"
+            self.assertIn("SystemExit: 1", error_file.read_text(encoding="utf-8"))
+            self.assertIn(
+                "worker.startup_failed",
+                [event["event"] for event in store.read_events(job.id)],
+            )
+
+    def test_worker_main_keeps_intentional_crash_exit_unlogged(self) -> None:
+        from puppetmaster.worker_runtime import WorkerRuntime, main as worker_main
+
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("simulate the documented crash")
+            argv = [
+                "--state-dir", str(store.root), "--backend", "file",
+                "--job-id", job.id, "--role", "implement",
+                "--worker-id", "crash-worker", "--crash-after-claim",
+            ]
+            with patch.object(WorkerRuntime, "run_until_idle", side_effect=SystemExit(77)):
+                with self.assertRaises(SystemExit) as raised:
+                    worker_main(argv)
+
+            self.assertEqual(raised.exception.code, 77)
+            self.assertFalse(
+                (store.job_dir(job.id) / "tasks" / "startup_error-crash-worker.log").exists()
+            )
+
     def test_worker_failure_marks_job_failed(self) -> None:
         with TemporaryDirectory() as tmp:
             store = SwarmStore(Path(tmp) / ".puppetmaster")

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -27182,6 +27182,37 @@ class AuditFixTests(unittest.TestCase):
         self.assertTrue(stop.is_set())
         self.assertTrue(runtime._lease_lost.is_set())
 
+    def test_heartbeat_loop_survives_transient_sqlite_writer_contention(self) -> None:
+        import sqlite3
+
+        from puppetmaster.worker_runtime import WorkerRuntime
+
+        store = MagicMock()
+        renewed = MagicMock()
+        runtime = WorkerRuntime(
+            store=store,
+            job_id="job_x",
+            role="coder",
+            worker_id="worker-a",
+            lease_seconds=30,
+            heartbeat_seconds=0.01,
+        )
+        stop = MagicMock()
+        stop.wait.side_effect = [False, False, True]
+
+        with patch.object(
+            runtime,
+            "_heartbeat_run_and_lease",
+            side_effect=[
+                sqlite3.OperationalError("database is locked"),
+                (MagicMock(), renewed),
+            ],
+        ) as heartbeat:
+            runtime._heartbeat_until_stopped(MagicMock(), "task_x", stop)
+
+        self.assertEqual(heartbeat.call_count, 2)
+        self.assertFalse(runtime._lease_lost.is_set())
+
     def test_heartbeat_loop_uses_heartbeat_interval_not_poll_interval(self) -> None:
         from puppetmaster.worker_runtime import WorkerRuntime
 

--- a/tests/test_readonly_performance.py
+++ b/tests/test_readonly_performance.py
@@ -120,6 +120,28 @@ class ReadonlyPerformanceTests(unittest.TestCase):
                     _ = store.incarnation
                 self.assertEqual(opens.call_count, 1)
 
+    def test_incarnation_retries_transient_reader_unavailability(self):
+        from puppetmaster import projections
+
+        with TemporaryDirectory() as root:
+            store = SwarmStore(root)
+            store.create_job('retry worker attach')
+            expected = store.incarnation
+            original = projections.connection
+            calls = [0]
+
+            def open_connection(*args, **kwargs):
+                calls[0] += 1
+                if calls[0] == 1:
+                    raise readonly.ReadUnavailable(
+                        'unable to open database: active reader; sidecars may be missing'
+                    )
+                return original(*args, **kwargs)
+
+            with patch.object(projections, 'connection', side_effect=open_connection):
+                self.assertEqual(store.incarnation, expected)
+            self.assertEqual(calls[0], 2)
+
     def test_cached_helper_refreshes_commits_and_fences_replacement(self):
         for cls in (SwarmStore, SQLiteSwarmStore):
             with self.subTest(backend=cls.backend_name), TemporaryDirectory() as tmp:


### PR DESCRIPTION
Windows release qualification exposed three distinct concurrency failures:

- file-store worker attach surfaced `ReadUnavailable: active reader; sidecars may be missing` because the intended `incarnation` retry branch was unreachable behind an `except sqlite3.OperationalError` clause;
- a SQLite worker heartbeat could exhaust `BEGIN IMMEDIATE` retries and kill its background renewal thread;
- concurrent detached launches replayed SQLite schema preparation for the same root, delaying one launch past the unchanged five-second bound.

This change makes transient file reader states reachable by the bounded attach retry, lets a heartbeat retry only recognized SQLite lock errors, and serializes/coalesces launch preparation per SQLite root while followers validate the current schema and identity. It also preserves unexpected worker `SystemExit` tracebacks against the active backend, includes the worker role and bounded traceback in supervisor errors, and runs the exact crash-recovery regression in the Windows canary. Exit 77 remains reserved for the intentional crash demo.

Validation:
- corrected Windows canary passed the 32-worker store scenario, CLI crash demo, and exact file-store crash-recovery regression before the two additional fixes
- identity, SQLite concurrency, read-only contention, and boundary suites: 79 passed
- exact detached-launch regression: 10/10 repeated passes under its unchanged bound
- `PuppetmasterTests`: 316 passed, 3 skipped during diagnostics; focused heartbeat regression passed after integration
- `git diff --check`
