### PR TITLE
Harden release-gate contention paths

### DIFF
--- a/puppetmaster/store.py
+++ b/puppetmaster/store.py
@@ -82,6 +82,10 @@ class LaunchConflictError(ValueError):
     """A launch key was reused for a different normalized request."""
 
 
+class ProjectionWriteAdmissionError(sqlite3.OperationalError):
+    """The file projection writer was unavailable before a source mutation."""
+
+
 class ResetSubgraphResult(list):
     """Task list from ``reset_subgraph`` plus superseded artifact ids.
 
@@ -1409,7 +1413,13 @@ class SwarmStore(StoreContracts):
         worker_id: Optional[str] = None,
     ) -> bool:
         claim_snapshot = self._task_claim_snapshot(task)
-        if not self._save_task_if_matches(task_id, claim_snapshot, claimed):
+        try:
+            if not self._save_task_if_matches(task_id, claim_snapshot, claimed):
+                return False
+        except ProjectionWriteAdmissionError:
+            # The durable task file has not changed. Treat unavailable
+            # projection admission like a lost claim so run_until_idle can
+            # retry from fresh state instead of killing the worker.
             return False
         return True
 
@@ -3629,8 +3639,15 @@ class SwarmStore(StoreContracts):
         if projected:
             self.init()
             marker = str(path) + ":" + new_id("write")
-            with connection(self, write=True) as c:
-                c.execute("INSERT INTO projection_pending VALUES(?)", (marker,))
+            try:
+                with connection(self, write=True) as c:
+                    c.execute("INSERT INTO projection_pending VALUES(?)", (marker,))
+            except sqlite3.OperationalError as exc:
+                from puppetmaster.readonly import _locked
+
+                if not _locked(exc):
+                    raise
+                raise ProjectionWriteAdmissionError(str(exc)) from exc
         if projected and file_kind(path) == 'job':
             from puppetmaster.selected_economics import check_receipt_replacement
             from puppetmaster.contracts import ContractConflict

--- a/tests/test_claim_contention.py
+++ b/tests/test_claim_contention.py
@@ -149,6 +149,45 @@ class ClaimContentionTests(unittest.TestCase):
                     store.claim_task(task.id, 'worker')
                 self.assertEqual(write.call_count, 1)
 
+    def test_file_claim_retries_after_projection_writer_admission_timeout(self):
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp))
+            job = store.create_job('projection admission')
+            task = Task(job_id=job.id, role='explore', instruction='test', adapter='local')
+            store.save_task(task)
+            from puppetmaster import projections
+            original = projections._reserve_writer
+            calls = 0
+
+            def reserve(connection, *args, **kwargs):
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    raise sqlite3.OperationalError('database is locked')
+                return original(connection, *args, **kwargs)
+
+            with patch.object(projections, '_reserve_writer', side_effect=reserve):
+                completed = WorkerRuntime(
+                    store, job.id, 'explore', 'worker', poll_seconds=.01
+                ).run_until_idle()
+            self.assertEqual(completed, 1)
+            claimed = store.get_task_by_id(task.id)
+            self.assertEqual(claimed.status, TaskStatus.COMPLETE)
+            self.assertEqual(claimed.attempts, 1)
+
+    def test_file_claim_does_not_swallow_nonlock_projection_failure(self):
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp))
+            job = store.create_job('projection failure')
+            task = Task(job_id=job.id, role='explore', instruction='test', adapter='local')
+            store.save_task(task)
+            error = sqlite3.OperationalError('permission denied')
+            with patch('puppetmaster.projections._reserve_writer', side_effect=error):
+                with self.assertRaises(sqlite3.OperationalError) as caught:
+                    store.claim_task(task.id, 'worker')
+            self.assertIs(caught.exception, error)
+            self.assertEqual(store.get_task_by_id(task.id).status, TaskStatus.QUEUED)
+
     def test_short_lease_lock_survives_read_retry(self):
         with TemporaryDirectory() as tmp:
             store = SwarmStore(Path(tmp))

--- a/tests/test_dashboard_ports.py
+++ b/tests/test_dashboard_ports.py
@@ -276,7 +276,9 @@ class RunfileAndOnBoundTests(unittest.TestCase):
             )
             self.addCleanup(httpd.server_close)
             info = read_dashboard_runfile(state_dir)
-            self.assertEqual(info["port"], port + 1)
+            bound_port = httpd.server_address[1]
+            self.assertGreater(bound_port, port)
+            self.assertEqual(info["port"], bound_port)
             self.assertEqual(info["pid"], os.getpid())
 
     def test_on_bound_receives_actual_port(self) -> None:
@@ -292,7 +294,9 @@ class RunfileAndOnBoundTests(unittest.TestCase):
                 on_bound=lambda h, p: calls.append((h, p)),
             )
             self.addCleanup(httpd.server_close)
-            self.assertEqual(calls, [("127.0.0.1", port + 1)])
+            bound_port = httpd.server_address[1]
+            self.assertGreater(bound_port, port)
+            self.assertEqual(calls, [("127.0.0.1", bound_port)])
 
 
 class DashboardIdentityRobustnessTests(unittest.TestCase):


### PR DESCRIPTION
The post-merge matrix exposed two independent contention assumptions.

- Ubuntu found another process holding the first fallback dashboard port. Assert runfile and callback values against `httpd.server_address[1]`; retain the dedicated exact-next-port test for the case where `requested + 1` is available.
- Windows exhausted file-projection writer admission before a task claim mutated source state. Classify only that pre-mutation boundary and return an unclaimed result so `WorkerRuntime.run_until_idle()` retries from fresh state. Later or non-lock write failures still propagate, and mutation bodies are never replayed.

Validation:
- 16 focused claim/port tests passed.
- Crash recovery and worker-exit diagnostics passed.
- The crash-recovery regression passed 20/20 repetitions.
- The port regression passed 100/100 repetitions.
