### PR TITLE
Fix Windows attach herd stalls

### DIFF
--- a/puppetmaster/readonly_worker.py
+++ b/puppetmaster/readonly_worker.py
@@ -236,7 +236,10 @@ def attest_linux_database(before, source_fd):
 def main(path, *, wal_snapshot=False):
     path = Path(path)
     wal_snapshot = bool(wal_snapshot and os.name == 'nt')
-    before = stamps(path)
+    try:
+        before = stamps(path)
+    except OSError as exc:
+        raise _retryable_windows_contention(exc)
     if before[0] is None:
         emit(dict(kind='unavailable', error='unable to open database: source missing'))
         return

--- a/puppetmaster/sqlite_store.py
+++ b/puppetmaster/sqlite_store.py
@@ -1051,34 +1051,65 @@ class SQLiteSwarmStore(SwarmStore):
         """Persist a run heartbeat and renew the task lease in one transaction."""
         self._ensure_attached()
         updated = replace(run, heartbeat_at=now_iso())
+        with self._writer_scope() as connection:
+            renewed = self._heartbeat_run_and_renew_lease_on_connection(
+                connection, updated, task_id, worker_id, lease_seconds, lease_id
+            )
+        return updated, renewed
+
+    def heartbeat_run_and_renew_lease_opportunistic(
+        self,
+        run: AgentRun,
+        task_id: str,
+        worker_id: str,
+        lease_seconds: int = 60,
+        lease_id: Optional[str] = None,
+    ) -> tuple[AgentRun, Optional[Task]]:
+        """Persist a background heartbeat only when the writer is available."""
+        self._ensure_attached()
+        updated = replace(run, heartbeat_at=now_iso())
+        with self._opportunistic_writer_scope() as connection:
+            renewed = self._heartbeat_run_and_renew_lease_on_connection(
+                connection, updated, task_id, worker_id, lease_seconds, lease_id
+            )
+        return updated, renewed
+
+    def _heartbeat_run_and_renew_lease_on_connection(
+        self,
+        connection: sqlite3.Connection,
+        updated: AgentRun,
+        task_id: str,
+        worker_id: str,
+        lease_seconds: int,
+        lease_id: Optional[str],
+    ) -> Optional[Task]:
         heartbeat_payload = {
             "run_id": updated.id,
             "worker_id": updated.worker_id,
             "task_id": updated.task_id,
         }
         saved_payload = {"run_id": updated.id, "role": updated.role}
-        with self._writer_scope() as connection:
-            row = connection.execute(
-                "SELECT data FROM tasks WHERE id = ?", (task_id,)
-            ).fetchone()
-            renewed: Optional[Task] = None
-            if row is not None:
-                task = task_from_dict(json.loads(row["data"]))
-                if task.status == TaskStatus.RUNNING and self._lease_matches(
-                    task, worker_id, lease_id
-                ):
-                    renewed = self._renew_lease_on_connection(
-                        connection,
-                        task_id,
-                        task,
-                        self._build_renewed_task(task, lease_seconds),
-                        worker_id,
-                        lease_id,
-                    )
-            self._upsert_run_connection(connection, updated)
-            self._emit(connection, updated.job_id, "run.saved", saved_payload)
-            self._emit(connection, updated.job_id, "run.heartbeat", heartbeat_payload)
-        return updated, renewed
+        row = connection.execute(
+            "SELECT data FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        renewed: Optional[Task] = None
+        if row is not None:
+            task = task_from_dict(json.loads(row["data"]))
+            if task.status == TaskStatus.RUNNING and self._lease_matches(
+                task, worker_id, lease_id
+            ):
+                renewed = self._renew_lease_on_connection(
+                    connection,
+                    task_id,
+                    task,
+                    self._build_renewed_task(task, lease_seconds),
+                    worker_id,
+                    lease_id,
+                )
+        self._upsert_run_connection(connection, updated)
+        self._emit(connection, updated.job_id, "run.saved", saved_payload)
+        self._emit(connection, updated.job_id, "run.heartbeat", heartbeat_payload)
+        return renewed
 
     def _upsert_run_connection(
         self, connection: sqlite3.Connection, run: AgentRun
@@ -1264,6 +1295,22 @@ class SQLiteSwarmStore(SwarmStore):
             return
         with self._session() as connection:
             self._reserve_writer(connection)
+            self._completion_connection.connection = connection
+            try:
+                yield connection
+            finally:
+                self._completion_connection.connection = None
+
+    @contextmanager
+    def _opportunistic_writer_scope(self):
+        """Reserve once without SQLite's busy wait for background heartbeats."""
+        active = getattr(self._completion_connection, "connection", None)
+        if active is not None:
+            yield active
+            return
+        with self._session() as connection:
+            connection.execute("PRAGMA busy_timeout = 0")
+            connection.execute("BEGIN IMMEDIATE")
             self._completion_connection.connection = connection
             try:
                 yield connection

--- a/puppetmaster/sqlite_store.py
+++ b/puppetmaster/sqlite_store.py
@@ -267,7 +267,9 @@ class SQLiteSwarmStore(SwarmStore):
                     raise
                 # The helper already exhausted any proven write retry. A fresh
                 # binding must not erase an unproven source-change rejection.
-                if isinstance(exc, ReadUnavailable) and "source changed" in str(exc):
+                if (isinstance(exc, ReadUnavailable)
+                        and "source changed" in str(exc)
+                        and not getattr(exc, "source_open_contention", False)):
                     raise
                 if not locked and not isinstance(exc, ReadUnavailable):
                     raise

--- a/puppetmaster/worker_runtime.py
+++ b/puppetmaster/worker_runtime.py
@@ -475,8 +475,13 @@ class WorkerRuntime:
         run: AgentRun,
         task_id: str,
         lease_id: Optional[str] = None,
+        opportunistic: bool = False,
     ):
-        coalesced = getattr(type(self.store), "heartbeat_run_and_renew_lease", None)
+        method = ("heartbeat_run_and_renew_lease_opportunistic" if opportunistic
+                  else "heartbeat_run_and_renew_lease")
+        coalesced = getattr(type(self.store), method, None)
+        if opportunistic and not callable(coalesced):
+            coalesced = getattr(type(self.store), "heartbeat_run_and_renew_lease", None)
         if callable(coalesced):
             return coalesced(
                 self.store, run, task_id, self.worker_id, self.lease_seconds, lease_id
@@ -496,7 +501,9 @@ class WorkerRuntime:
     ) -> None:
         while not stop.wait(self._heartbeat_interval()):
             try:
-                run, renewed = self._heartbeat_run_and_lease(run, task_id, lease_id)
+                run, renewed = self._heartbeat_run_and_lease(
+                    run, task_id, lease_id, True
+                )
             except sqlite3.OperationalError as exc:
                 from puppetmaster.sqlite_store import _is_sqlite_lock_error
 

--- a/tests/test_readonly_sqlite_open_identity.py
+++ b/tests/test_readonly_sqlite_open_identity.py
@@ -194,6 +194,15 @@ class SQLiteOpenIdentityTests(unittest.TestCase):
             with self.assertRaisesRegex(PermissionError, 'sharing violation'):
                 worker.open_windows_source('source.sqlite3')
 
+    def test_windows_initial_stamp_access_denial_is_retryable_contention(self):
+        denied = PermissionError('Access is denied')
+        denied.winerror = 5
+        with patch.object(worker, 'stamps', side_effect=denied), \
+                patch.object(worker.os, 'name', 'nt'):
+            with self.assertRaises(PermissionError) as caught:
+                worker.main('source.sqlite3')
+        self.assertTrue(caught.exception.source_open_contention)
+
     def test_windows_guard_sharing_denial_closes_session_and_reuses_helper(self):
         denied = PermissionError('Access is denied')
         denied.winerror = 5

--- a/tests/test_readonly_sqlite_open_identity.py
+++ b/tests/test_readonly_sqlite_open_identity.py
@@ -197,7 +197,9 @@ class SQLiteOpenIdentityTests(unittest.TestCase):
     def test_windows_initial_stamp_access_denial_is_retryable_contention(self):
         denied = PermissionError('Access is denied')
         denied.winerror = 5
+        native_path = type(Path())
         with patch.object(worker, 'stamps', side_effect=denied), \
+                patch.object(worker, 'Path', native_path), \
                 patch.object(worker.os, 'name', 'nt'):
             with self.assertRaises(PermissionError) as caught:
                 worker.main('source.sqlite3')

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -99,6 +99,33 @@ class SqliteAttachEnsureTests(unittest.TestCase):
             job = store.create_job("after attach")
             self.assertEqual(store.get_job(job.id).goal, "after attach")
 
+    def test_attach_retries_proven_windows_source_open_contention(self) -> None:
+        from puppetmaster.readonly import ReadUnavailable
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".puppetmaster"
+            SQLiteSwarmStore(root).ensure_schema()
+            store = SQLiteSwarmStore(root)
+            original_connect = store._connect_readonly
+            denied = ReadUnavailable(
+                "unable to open database: source changed or unavailable: "
+                "[WinError 5] Access is denied."
+            )
+            denied.source_open_contention = True
+            calls = 0
+
+            def connect(*args: object, **kwargs: object):
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    raise denied
+                return original_connect(*args, **kwargs)
+
+            with mock.patch.object(store, "_connect_readonly", side_effect=connect), \
+                    mock.patch.object(store, "_sleep_lock_backoff"):
+                store.attach()
+            self.assertEqual(calls, 2)
+
     def test_concurrent_attach_never_writes_schema(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp) / ".puppetmaster"

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -240,6 +240,28 @@ class SqliteSessionRetryTests(unittest.TestCase):
             finally:
                 blocker.close()
 
+    def test_opportunistic_heartbeat_does_not_queue_behind_writer(self) -> None:
+        with TemporaryDirectory() as tmp:
+            store = SQLiteSwarmStore(tmp)
+            store.ensure_schema()
+            job = store.create_job("opportunistic heartbeat")
+            task = Task(job_id=job.id, role="implement", instruction="noop")
+            store.save_task(task)
+            claimed = store.claim_task(task.id, "w-1")
+            run = AgentRun(job_id=job.id, task_id=task.id, role=task.role, worker_id="w-1")
+            store.save_run(run)
+            blocker = store.connect()
+            try:
+                blocker.execute("BEGIN IMMEDIATE")
+                with mock.patch.object(store, "_sleep_lock_backoff") as retry:
+                    with self.assertRaises(sqlite3.OperationalError):
+                        store.heartbeat_run_and_renew_lease_opportunistic(
+                            run, task.id, "w-1", lease_id=claimed.lease_id)
+                retry.assert_not_called()
+            finally:
+                blocker.rollback()
+                blocker.close()
+
     def test_waiting_heartbeat_cannot_overwrite_completion_or_successor_lease(self) -> None:
         for terminal in (False, True):
             with self.subTest(terminal=terminal), TemporaryDirectory() as tmp:
@@ -639,6 +661,38 @@ class SqliteHeartbeatCoalesceTests(unittest.TestCase):
 
 
 class WorkerHeartbeatLifecycleTests(unittest.TestCase):
+    def test_background_heartbeat_prefers_opportunistic_writer(self) -> None:
+        with TemporaryDirectory() as tmp:
+            store = SQLiteSwarmStore(tmp)
+            store.ensure_schema()
+            job = store.create_job("background heartbeat")
+            task = Task(job_id=job.id, role="implement", instruction="noop")
+            store.save_task(task)
+            claimed = store.claim_task(task.id, "w-1")
+            run = AgentRun(job_id=job.id, task_id=task.id, role=task.role, worker_id="w-1")
+            runtime = WorkerRuntime(store, job.id, "implement", "w-1",
+                                    heartbeat_seconds=0.01)
+            stop = threading.Event()
+
+            def heartbeat(*args, **kwargs):
+                stop.set()
+                return run, claimed
+
+            with mock.patch.object(
+                SQLiteSwarmStore,
+                "heartbeat_run_and_renew_lease_opportunistic",
+                autospec=True,
+                side_effect=heartbeat,
+            ) as opportunistic, mock.patch.object(
+                SQLiteSwarmStore,
+                "heartbeat_run_and_renew_lease",
+                autospec=True,
+            ) as blocking:
+                runtime._heartbeat_until_stopped(run, task.id, stop,
+                                                 lease_id=claimed.lease_id)
+            opportunistic.assert_called_once()
+            blocking.assert_not_called()
+
     def test_completion_waits_for_inflight_sqlite_heartbeat(self) -> None:
         self._assert_heartbeat_drained_before_terminal(exception=False)
 
@@ -711,7 +765,9 @@ class WorkerHeartbeatLifecycleTests(unittest.TestCase):
                     # The heartbeat now reserves the writer before reading the
                     # task, so it cannot reach renewal until this lock releases.
                     entered.set()
-                    updated, renewed = original_heartbeat(*args)
+                    # Force the blocking path: this lifecycle test proves that
+                    # an actually in-flight write drains before publication.
+                    updated, renewed = original_heartbeat(*args[:3])
                     return updated, None if lose_lease else renewed
                 finally:
                     heartbeat_finished.set()


### PR DESCRIPTION
Windows worker cohorts could stall while terminal cleanup waited for background heartbeat threads queued behind SQLite's five-second writer reservation. Worker attach could also fail when transient WinError 5 denials escaped the bounded read-helper retry path.

This makes background heartbeats opportunistic while preserving the blocking heartbeat API and terminal lease fencing, and classifies initial Windows source-stamp denials as bounded attach contention. No timeout, skip, or xfail changes.

Validation:
- Windows store canary green three consecutive times on the production fixes, including 32-worker attach/claim/complete, crash-demo, and crash recovery
- 3,258 local tests green on Python 3.12
- focused regression green on Python 3.9 and Python 3.12
