### PR TITLE
Stop the Windows attach-herd heartbeat stampede

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
         run: npm install --package-lock=false --no-audit
       - name: Smoke check Cursor runner syntax
         run: npm run smoke:cursor-runner
+      - name: Windows attach-herd canary
+        if: runner.os == 'Windows'
+        run: python -m unittest tests.test_sqlite_concurrency.SqliteMultiprocessAttachTests.test_supervisor_ensure_then_n_workers_attach_claim_complete -v
       - name: Run Python tests
         run: python -m unittest discover -s tests -v
       - name: Smoke check CLI metadata

--- a/puppetmaster/worker_runtime.py
+++ b/puppetmaster/worker_runtime.py
@@ -48,7 +48,7 @@ class WorkerRuntime:
     def _heartbeat_interval(self) -> float:
         configured = self.heartbeat_seconds
         if configured is None:
-            configured = 2.0 if self.poll_seconds == 0.1 else self.poll_seconds
+            configured = 2.0
         return max(0.01, min(configured, max(0.1, self.lease_seconds / 3)))
 
     def run_once(self) -> bool:

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -27237,6 +27237,20 @@ class AuditFixTests(unittest.TestCase):
         self.assertEqual(store.heartbeat_run.call_count, 1)
         self.assertEqual(store.renew_task_lease.call_count, 1)
 
+    def test_default_heartbeat_interval_is_not_the_poll_interval(self) -> None:
+        from puppetmaster.worker_runtime import WorkerRuntime
+
+        runtime = WorkerRuntime(
+            store=MagicMock(),
+            job_id="job_x",
+            role="coder",
+            worker_id="worker-a",
+            lease_seconds=30,
+            poll_seconds=0.05,
+        )
+
+        self.assertEqual(runtime._heartbeat_interval(), 2.0)
+
     def test_heartbeat_interval_keeps_margin_for_short_leases(self) -> None:
         from puppetmaster.worker_runtime import WorkerRuntime
 

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -38,13 +38,8 @@ def _attach_claim_complete_worker(
     """Spawn-safe worker body: attach only, then claim/complete local tasks."""
     error_file = Path(error_path).open("w", encoding="utf-8")
     diagnostic_file = Path(diagnostic_path).open("w", encoding="utf-8")
-    diagnostic_worker = worker_id == "w-0"
-    if diagnostic_worker:
-        # One representative stack is enough to diagnose a shared attach
-        # stall. Arming every spawned process at the same instant creates a
-        # 32-writer traceback storm that can itself push healthy workers past
-        # the parent deadline on Windows.
-        faulthandler.dump_traceback_later(45, file=diagnostic_file)
+    # Per-worker dump files. Do not arm only w-0: dest-push last stalled on w-26.
+    faulthandler.dump_traceback_later(45, file=diagnostic_file)
     thread_errors: list[str] = []
     previous_hook = threading.excepthook
     threading.excepthook = lambda args: thread_errors.append(
@@ -60,14 +55,12 @@ def _attach_claim_complete_worker(
             worker_id=worker_id,
             lease_seconds=30,
             poll_seconds=0.05,
-            heartbeat_seconds=0.01,
         )
         runtime.run_until_idle()
     except Exception:  # noqa: BLE001 — surface in the parent assert
         error_file.write(traceback.format_exc())
     finally:
-        if diagnostic_worker:
-            faulthandler.cancel_dump_traceback_later()
+        faulthandler.cancel_dump_traceback_later()
         threading.excepthook = previous_hook
         if thread_errors:
             error_file.write("\n".join(thread_errors))
@@ -75,6 +68,8 @@ def _attach_claim_complete_worker(
         diagnostic_file.close()
         if Path(error_path).stat().st_size == 0:
             Path(error_path).unlink()
+        # Hung workers are TerminateProcess'd and never reach this line, so
+        # their dump stays for the parent. Clean exits drop the empty dump.
         Path(diagnostic_path).unlink(missing_ok=True)
 
 

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -926,7 +926,8 @@ class SqliteMultiprocessAttachTests(unittest.TestCase):
                 if not process.is_alive():
                     process.close()
 
-            self.assertEqual(errors, [])
+            if errors:
+                self.fail("\n\n".join(errors))
             tasks = supervisor.list_tasks(job.id)
             status_counts = Counter(str(task.status) for task in tasks)
             failed_events = [e["payload"] for e in supervisor.read_events(job.id)


### PR DESCRIPTION
## Summary
- dest-push Windows is one test: `test_supervisor_ensure_then_n_workers_attach_claim_complete`. #148 set `heartbeat_seconds=0.01` on 32 spawn workers and armed dumps only for `w-0`. That is a 100Hz SQLite WAL write stampede. One worker starves (last time `w-26`).
- Removes the 10ms heartbeat override, dumps every worker, and runs that one test first on Windows so the next miss is ~90s not 26 minutes. Discover still runs the full suite.

## Test plan
- [x] herd test on macOS (2.9s, ok)
- [ ] Windows attach-herd canary on this PR
- [ ] Full Windows discover on this PR
- [ ] dest-push after merge
