### PR TITLE
Release Puppetmaster 1.25.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
         run: npm install --package-lock=false --no-audit
       - name: Smoke check Cursor runner syntax
         run: npm run smoke:cursor-runner
+      - name: Windows attach-herd canary
+        if: runner.os == 'Windows'
+        run: python -m unittest tests.test_sqlite_concurrency.SqliteMultiprocessAttachTests.test_supervisor_ensure_then_n_workers_attach_claim_complete -v
       - name: Run Python tests
         run: python -m unittest discover -s tests -v
       - name: Smoke check CLI metadata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,12 @@ jobs:
       - name: Smoke check Cursor runner syntax
         run: npm run smoke:cursor-runner
       - name: Run Python tests
-        run: python -m unittest discover -s tests -v
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            python -m unittest -v tests.test_sqlite_concurrency.SqliteMultiprocessAttachTests.test_supervisor_ensure_then_n_workers_attach_claim_complete
+          else
+            python -m unittest discover -s tests -v
+          fi
       - name: Smoke check CLI metadata
         run: |
           python -m puppetmaster --help

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,7 @@ jobs:
       - name: Smoke check Cursor runner syntax
         run: npm run smoke:cursor-runner
       - name: Run Python tests
-        run: |
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            python -m unittest -v tests.test_sqlite_concurrency.SqliteMultiprocessAttachTests.test_supervisor_ensure_then_n_workers_attach_claim_complete
-          else
-            python -m unittest discover -s tests -v
-          fi
+        run: python -m unittest discover -s tests -v
       - name: Smoke check CLI metadata
         run: |
           python -m puppetmaster --help

--- a/.github/workflows/windows-store.yml
+++ b/.github/workflows/windows-store.yml
@@ -1,0 +1,26 @@
+name: Windows store canary
+
+# Fast Windows signal for the attach herd and crash-demo. Does not replace
+# the required CI matrix (`python -m unittest discover` on all four legs).
+# Do not skip, xfail, or raise timeouts here.
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  windows-store:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Run SQLite attach concurrency tests
+        run: python -m unittest tests.test_sqlite_concurrency -v
+      - name: Run crash-demo
+        if: ${{ !cancelled() }}
+        run: python -m puppetmaster crash-demo

--- a/.github/workflows/windows-store.yml
+++ b/.github/workflows/windows-store.yml
@@ -1,6 +1,6 @@
 name: Windows store canary
 
-# Fast Windows signal for the attach herd and crash-demo. Does not replace
+# Fast Windows signal for store contention, launch binding, and crash-demo. Does not replace
 # the required CI matrix (`python -m unittest discover` on all four legs).
 # Do not skip, xfail, or raise timeouts here.
 
@@ -21,6 +21,8 @@ jobs:
           python-version: "3.12"
       - name: Run SQLite attach concurrency tests
         run: python -m unittest tests.test_sqlite_concurrency -v
+      - name: Run launch stabilization tests
+        run: python -m unittest tests.test_launch_stabilization -v
       - name: Run crash-demo
         if: ${{ !cancelled() }}
         run: python -m puppetmaster crash-demo

--- a/.github/workflows/windows-store.yml
+++ b/.github/workflows/windows-store.yml
@@ -24,3 +24,6 @@ jobs:
       - name: Run crash-demo
         if: ${{ !cancelled() }}
         run: python -m puppetmaster crash-demo
+      - name: Run crash-recovery regression
+        if: ${{ !cancelled() }}
+        run: python -m unittest tests.test_puppetmaster.PuppetmasterTests.test_crash_recovery_demo_reclaims_abandoned_task -v

--- a/puppetmaster/identity.py
+++ b/puppetmaster/identity.py
@@ -1,6 +1,7 @@
 """Store incarnation identity, independent of the path-derived state identity."""
 from __future__ import annotations
 
+import threading
 from uuid import UUID, uuid4
 
 from puppetmaster.models import JobRef
@@ -9,6 +10,10 @@ from puppetmaster.state import state_identity
 
 class StoreIdentityError(ValueError):
     """Missing, corrupt, legacy or replaced identity; never implicitly rebind."""
+
+
+_launch_prepare_lock = threading.Lock()
+_prepared_launch_roots: set[str] = set()
 
 
 def read_identity(c, backend):
@@ -81,10 +86,36 @@ def reference_at(root, job_id, *, expected_incarnation=None, launch_binding=Fals
 def prepare_launch(root, backend, job_ref=None):
     """Supervisor bootstrap before detaching; the child must attach this identity."""
     from puppetmaster.store_factory import create_store
-    store = create_store(backend, root)
-    if job_ref is not None:
-        store.bind_job_ref(job_ref)
-    store.init()
-    # init captured this identity inside the supervisor transaction. Reopening
-    # a metadata reader here races other launchers and their live WAL.
-    return store._incarnation
+
+    def prepare():
+        store = create_store(backend, root)
+        if job_ref is not None:
+            store.bind_job_ref(job_ref)
+        root_key = str(store.root.resolve())
+        if (
+            backend == "sqlite"
+            and root_key in _prepared_launch_roots
+            and store.db_path.exists()
+        ):
+            connection = store._connect_with_lock_retry()
+            try:
+                version = store._assert_schema(connection)
+                if str(version) == str(store.schema_version):
+                    store._incarnation = read_identity(connection, "sqlite")
+                    return store._incarnation
+            finally:
+                connection.close()
+        store.init()
+        if backend == "sqlite":
+            _prepared_launch_roots.add(root_key)
+        # init captured this identity inside the supervisor transaction.
+        # Reopening a metadata reader here races other launchers and their WAL.
+        return store._incarnation
+
+    if backend == "sqlite":
+        # Detach calls can arrive concurrently in one MCP host. Ensure schema
+        # once per root and process (including trigger refresh after upgrades);
+        # followers validate identity without replaying DDL under a writer lock.
+        with _launch_prepare_lock:
+            return prepare()
+    return prepare()

--- a/puppetmaster/orchestrator.py
+++ b/puppetmaster/orchestrator.py
@@ -2411,16 +2411,14 @@ class Orchestrator:
         roles = sorted({task.role for task in tasks})
         record_orchestrator_heartbeat(self.store, job.id)
         processes = [
-            self._spawn_worker(job.id, role, lease_seconds=lease_seconds)
+            (role, self._spawn_worker(job.id, role, lease_seconds=lease_seconds))
             for role in roles
         ]
         try:
-            for process in processes:
+            for role, process in processes:
                 self._wait_for_worker(process, job, tasks)
                 if process.returncode != 0:
-                    raise RuntimeError(
-                        f"worker process failed with exit code {process.returncode}"
-                    )
+                    raise self._worker_exit_error(job.id, role, process)
 
             if self.store.has_incomplete_tasks(job.id):
                 recovered = self.store.recover_stale_tasks(job.id)
@@ -2465,7 +2463,7 @@ class Orchestrator:
                 elif self._should_fail_closed(job, allowed_task_ids):
                     raise RuntimeError("swarm exited with incomplete tasks")
         finally:
-            for process in processes:
+            for _role, process in processes:
                 if process.poll() is None:
                     process.terminate()
                     try:
@@ -2584,21 +2582,21 @@ class Orchestrator:
         roles = sorted({task.role for task in dependencies})
         self._ensure_store_schema()
         processes = [
-            self._spawn_worker(job.id, role, lease_seconds=lease_seconds)
+            (role, self._spawn_worker(job.id, role, lease_seconds=lease_seconds))
             for role in roles
         ]
         try:
-            for process in processes:
+            for role, process in processes:
                 process.wait(timeout=self._worker_wait_timeout(dependencies))
                 if process.returncode != 0:
-                    raise RuntimeError(
-                        f"prerequisite worker failed with exit code {process.returncode}"
+                    raise self._worker_exit_error(
+                        job.id, role, process, phase="prerequisite worker"
                     )
         finally:
             # If a wait timed out or a prerequisite failed mid-batch, don't
             # leave the remaining workers running as orphans — terminate (then
             # kill) any that are still alive so they don't outlive the job.
-            for process in processes:
+            for _role, process in processes:
                 if process.poll() is None:
                     process.terminate()
                     try:
@@ -2656,6 +2654,30 @@ class Orchestrator:
             env["TRACEPARENT"] = self._traceparent
             env["PUPPETMASTER_TRACEPARENT"] = self._traceparent
         return subprocess.Popen(command, env=env)
+
+    def _worker_exit_error(
+        self,
+        job_id: str,
+        role: str,
+        process: subprocess.Popen,
+        *,
+        phase: str = "worker",
+    ) -> RuntimeError:
+        """Include the worker's durable failure traceback when one exists."""
+        message = f"{phase} {role!r} failed with exit code {process.returncode}"
+        expected = f"startup_error-worker-{role}-{process.pid}.log"
+        task_dir = self.store.job_dir(job_id) / "tasks"
+        try:
+            error_file = next(
+                path for path in task_dir.glob("startup_error-*.log")
+                if path.name == expected
+            )
+            detail = error_file.read_text(encoding="utf-8", errors="replace").strip()
+        except (OSError, StopIteration):
+            detail = ""
+        if detail:
+            message += f"\n{detail[-8000:]}"
+        return RuntimeError(message)
 
     @staticmethod
     def _worker_wait_timeout(tasks: list[Task]) -> int:

--- a/puppetmaster/readonly.py
+++ b/puppetmaster/readonly.py
@@ -454,7 +454,8 @@ class ReadConnection:
                     write_race = getattr(exc, 'same_store_write', False)
                     topology_race = attach_binding and getattr(exc, 'launch_topology_change', False)
                     source_open_contention = (
-                        attach_binding and getattr(exc, 'source_open_contention', False)
+                        (attach_binding or launch_binding) and
+                        getattr(exc, 'source_open_contention', False)
                     )
                     locked = _locked(exc)
                     unavailable = isinstance(exc, ReadUnavailable) and any(

--- a/puppetmaster/readonly_worker.py
+++ b/puppetmaster/readonly_worker.py
@@ -236,7 +236,10 @@ def attest_linux_database(before, source_fd):
 def main(path, *, wal_snapshot=False):
     path = Path(path)
     wal_snapshot = bool(wal_snapshot and os.name == 'nt')
-    before = stamps(path)
+    try:
+        before = stamps(path)
+    except OSError as exc:
+        raise _retryable_windows_contention(exc)
     if before[0] is None:
         emit(dict(kind='unavailable', error='unable to open database: source missing'))
         return

--- a/puppetmaster/readonly_worker.py
+++ b/puppetmaster/readonly_worker.py
@@ -158,6 +158,19 @@ def open_windows_source(path):
         raise
 
 
+def _retryable_windows_contention(exc):
+    if os.name == 'nt' and getattr(exc, 'winerror', None) in (5, 32, 33):
+        exc.source_open_contention = True
+    return exc
+
+
+def _stamps_after_open(path):
+    try:
+        return stamps(path)
+    except OSError as exc:
+        raise _retryable_windows_contention(exc)
+
+
 def descriptor_uri(fd):
     """Select a source descriptor URI; Linux additionally attests SQLite's fd."""
     expected = os.fstat(fd)
@@ -307,7 +320,7 @@ def main(path, *, wal_snapshot=False):
             except BlockingIOError:
                 emit(dict(kind='OperationalError', error='database is locked'))
                 return
-        after = stamps(path)
+        after = _stamps_after_open(path)
         if not wal_snapshot and after != before:
             emit(dict(kind='unavailable', error='unable to open database: source changed',
                       launch_topology_change=after[0] == before[0] and after[1:] != before[1:],
@@ -322,7 +335,7 @@ def main(path, *, wal_snapshot=False):
                       error='unable to open database: live sidecars; retry after checkpoint',
                       code=5))
             return
-        after = stamps(path)
+        after = _stamps_after_open(path)
         if not wal_snapshot and after != before:
             emit(dict(kind='unavailable', error='unable to open database: source changed',
                       launch_topology_change=after[0] == before[0] and after[1:] != before[1:]))
@@ -344,7 +357,7 @@ def main(path, *, wal_snapshot=False):
             c.execute('PRAGMA synchronous=NORMAL')
             c.execute('BEGIN')
             c.execute('SELECT rootpage FROM sqlite_master LIMIT 1').fetchone()
-            if not wal_snapshot and stamps(path) != before:
+            if not wal_snapshot and _stamps_after_open(path) != before:
                 emit(dict(kind='unavailable', error='unable to open database: source changed'))
                 return
             def unchanged():

--- a/puppetmaster/sqlite_store.py
+++ b/puppetmaster/sqlite_store.py
@@ -1051,34 +1051,65 @@ class SQLiteSwarmStore(SwarmStore):
         """Persist a run heartbeat and renew the task lease in one transaction."""
         self._ensure_attached()
         updated = replace(run, heartbeat_at=now_iso())
+        with self._writer_scope() as connection:
+            renewed = self._heartbeat_run_and_renew_lease_on_connection(
+                connection, updated, task_id, worker_id, lease_seconds, lease_id
+            )
+        return updated, renewed
+
+    def heartbeat_run_and_renew_lease_opportunistic(
+        self,
+        run: AgentRun,
+        task_id: str,
+        worker_id: str,
+        lease_seconds: int = 60,
+        lease_id: Optional[str] = None,
+    ) -> tuple[AgentRun, Optional[Task]]:
+        """Persist a background heartbeat only when the writer is available."""
+        self._ensure_attached()
+        updated = replace(run, heartbeat_at=now_iso())
+        with self._opportunistic_writer_scope() as connection:
+            renewed = self._heartbeat_run_and_renew_lease_on_connection(
+                connection, updated, task_id, worker_id, lease_seconds, lease_id
+            )
+        return updated, renewed
+
+    def _heartbeat_run_and_renew_lease_on_connection(
+        self,
+        connection: sqlite3.Connection,
+        updated: AgentRun,
+        task_id: str,
+        worker_id: str,
+        lease_seconds: int,
+        lease_id: Optional[str],
+    ) -> Optional[Task]:
         heartbeat_payload = {
             "run_id": updated.id,
             "worker_id": updated.worker_id,
             "task_id": updated.task_id,
         }
         saved_payload = {"run_id": updated.id, "role": updated.role}
-        with self._writer_scope() as connection:
-            row = connection.execute(
-                "SELECT data FROM tasks WHERE id = ?", (task_id,)
-            ).fetchone()
-            renewed: Optional[Task] = None
-            if row is not None:
-                task = task_from_dict(json.loads(row["data"]))
-                if task.status == TaskStatus.RUNNING and self._lease_matches(
-                    task, worker_id, lease_id
-                ):
-                    renewed = self._renew_lease_on_connection(
-                        connection,
-                        task_id,
-                        task,
-                        self._build_renewed_task(task, lease_seconds),
-                        worker_id,
-                        lease_id,
-                    )
-            self._upsert_run_connection(connection, updated)
-            self._emit(connection, updated.job_id, "run.saved", saved_payload)
-            self._emit(connection, updated.job_id, "run.heartbeat", heartbeat_payload)
-        return updated, renewed
+        row = connection.execute(
+            "SELECT data FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        renewed: Optional[Task] = None
+        if row is not None:
+            task = task_from_dict(json.loads(row["data"]))
+            if task.status == TaskStatus.RUNNING and self._lease_matches(
+                task, worker_id, lease_id
+            ):
+                renewed = self._renew_lease_on_connection(
+                    connection,
+                    task_id,
+                    task,
+                    self._build_renewed_task(task, lease_seconds),
+                    worker_id,
+                    lease_id,
+                )
+        self._upsert_run_connection(connection, updated)
+        self._emit(connection, updated.job_id, "run.saved", saved_payload)
+        self._emit(connection, updated.job_id, "run.heartbeat", heartbeat_payload)
+        return renewed
 
     def _upsert_run_connection(
         self, connection: sqlite3.Connection, run: AgentRun
@@ -1264,6 +1295,22 @@ class SQLiteSwarmStore(SwarmStore):
             return
         with self._session() as connection:
             self._reserve_writer(connection)
+            self._completion_connection.connection = connection
+            try:
+                yield connection
+            finally:
+                self._completion_connection.connection = None
+
+    @contextmanager
+    def _opportunistic_writer_scope(self):
+        """Reserve once without SQLite's busy wait for background heartbeats."""
+        active = getattr(self._completion_connection, "connection", None)
+        if active is not None:
+            yield active
+            return
+        with self._session() as connection:
+            connection.execute("PRAGMA busy_timeout = 0")
+            connection.execute("BEGIN IMMEDIATE")
             self._completion_connection.connection = connection
             try:
                 yield connection

--- a/puppetmaster/sqlite_store.py
+++ b/puppetmaster/sqlite_store.py
@@ -267,7 +267,9 @@ class SQLiteSwarmStore(SwarmStore):
                     raise
                 # The helper already exhausted any proven write retry. A fresh
                 # binding must not erase an unproven source-change rejection.
-                if isinstance(exc, ReadUnavailable) and "source changed" in str(exc):
+                if (isinstance(exc, ReadUnavailable)
+                        and "source changed" in str(exc)
+                        and not getattr(exc, "source_open_contention", False)):
                     raise
                 if not locked and not isinstance(exc, ReadUnavailable):
                     raise

--- a/puppetmaster/store.py
+++ b/puppetmaster/store.py
@@ -1470,6 +1470,15 @@ class SwarmStore(StoreContracts):
         # a per-edge file glob / SQLite SELECT on every claim sweep).
         tasks = self.list_tasks(job_id)
         task_map = {task.id: task for task in tasks}
+        if len(tasks) > 1:
+            # Workers otherwise stampede the first queued task, then repeat the
+            # same losing writer reservation for every task already claimed by
+            # a peer. A stable per-worker rotation spreads those first CAS
+            # attempts across the queue without changing eligibility or
+            # allowing a claim outside the store's atomic fence.
+            digest = hashlib.sha256(worker_id.encode("utf-8")).digest()
+            offset = int.from_bytes(digest[:8], "big") % len(tasks)
+            tasks = tasks[offset:] + tasks[:offset]
         for task in tasks:
             if task.status != TaskStatus.QUEUED:
                 continue

--- a/puppetmaster/store.py
+++ b/puppetmaster/store.py
@@ -82,6 +82,10 @@ class LaunchConflictError(ValueError):
     """A launch key was reused for a different normalized request."""
 
 
+class ProjectionWriteAdmissionError(sqlite3.OperationalError):
+    """The file projection writer was unavailable before a source mutation."""
+
+
 class ResetSubgraphResult(list):
     """Task list from ``reset_subgraph`` plus superseded artifact ids.
 
@@ -1409,7 +1413,13 @@ class SwarmStore(StoreContracts):
         worker_id: Optional[str] = None,
     ) -> bool:
         claim_snapshot = self._task_claim_snapshot(task)
-        if not self._save_task_if_matches(task_id, claim_snapshot, claimed):
+        try:
+            if not self._save_task_if_matches(task_id, claim_snapshot, claimed):
+                return False
+        except ProjectionWriteAdmissionError:
+            # The durable task file has not changed. Treat unavailable
+            # projection admission like a lost claim so run_until_idle can
+            # retry from fresh state instead of killing the worker.
             return False
         return True
 
@@ -3629,8 +3639,15 @@ class SwarmStore(StoreContracts):
         if projected:
             self.init()
             marker = str(path) + ":" + new_id("write")
-            with connection(self, write=True) as c:
-                c.execute("INSERT INTO projection_pending VALUES(?)", (marker,))
+            try:
+                with connection(self, write=True) as c:
+                    c.execute("INSERT INTO projection_pending VALUES(?)", (marker,))
+            except sqlite3.OperationalError as exc:
+                from puppetmaster.readonly import _locked
+
+                if not _locked(exc):
+                    raise
+                raise ProjectionWriteAdmissionError(str(exc)) from exc
         if projected and file_kind(path) == 'job':
             from puppetmaster.selected_economics import check_receipt_replacement
             from puppetmaster.contracts import ContractConflict

--- a/puppetmaster/store.py
+++ b/puppetmaster/store.py
@@ -2334,10 +2334,15 @@ class SwarmStore(StoreContracts):
             try:
                 with connection(self, metadata_only=True) as c:
                     return read_identity(c, self.backend_name)
-            except sqlite3.OperationalError as exc:
-                transient = str(exc) == 'database is locked' or (
-                    isinstance(exc, ReadUnavailable) and any(reason in str(exc)
-                    for reason in ('source changed', 'active reader', 'live sidecars')))
+            except (sqlite3.OperationalError, ReadUnavailable) as exc:
+                transient = (
+                    isinstance(exc, sqlite3.OperationalError)
+                    and str(exc) == 'database is locked'
+                ) or (
+                    isinstance(exc, ReadUnavailable)
+                    and any(reason in str(exc)
+                            for reason in ('source changed', 'active reader', 'live sidecars'))
+                )
                 if not transient or time.monotonic() >= deadline:
                     raise
                 time.sleep(.01)

--- a/puppetmaster/worker_runtime.py
+++ b/puppetmaster/worker_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import sqlite3
 import threading
 import time
 from dataclasses import replace
@@ -494,7 +495,17 @@ class WorkerRuntime:
         lease_id: Optional[str] = None,
     ) -> None:
         while not stop.wait(self._heartbeat_interval()):
-            run, renewed = self._heartbeat_run_and_lease(run, task_id, lease_id)
+            try:
+                run, renewed = self._heartbeat_run_and_lease(run, task_id, lease_id)
+            except sqlite3.OperationalError as exc:
+                from puppetmaster.sqlite_store import _is_sqlite_lock_error
+
+                if not _is_sqlite_lock_error(exc):
+                    raise
+                # A failed reservation did not mutate either record. Let the
+                # next heartbeat determine whether the lease still belongs to
+                # this worker instead of killing the background thread.
+                continue
             if renewed is None:
                 self._lease_lost.set()
                 stop.set()

--- a/puppetmaster/worker_runtime.py
+++ b/puppetmaster/worker_runtime.py
@@ -475,8 +475,13 @@ class WorkerRuntime:
         run: AgentRun,
         task_id: str,
         lease_id: Optional[str] = None,
+        opportunistic: bool = False,
     ):
-        coalesced = getattr(type(self.store), "heartbeat_run_and_renew_lease", None)
+        method = ("heartbeat_run_and_renew_lease_opportunistic" if opportunistic
+                  else "heartbeat_run_and_renew_lease")
+        coalesced = getattr(type(self.store), method, None)
+        if opportunistic and not callable(coalesced):
+            coalesced = getattr(type(self.store), "heartbeat_run_and_renew_lease", None)
         if callable(coalesced):
             return coalesced(
                 self.store, run, task_id, self.worker_id, self.lease_seconds, lease_id
@@ -496,7 +501,9 @@ class WorkerRuntime:
     ) -> None:
         while not stop.wait(self._heartbeat_interval()):
             try:
-                run, renewed = self._heartbeat_run_and_lease(run, task_id, lease_id)
+                run, renewed = self._heartbeat_run_and_lease(
+                    run, task_id, lease_id, True
+                )
             except sqlite3.OperationalError as exc:
                 from puppetmaster.sqlite_store import _is_sqlite_lock_error
 

--- a/puppetmaster/worker_runtime.py
+++ b/puppetmaster/worker_runtime.py
@@ -48,7 +48,7 @@ class WorkerRuntime:
     def _heartbeat_interval(self) -> float:
         configured = self.heartbeat_seconds
         if configured is None:
-            configured = 2.0 if self.poll_seconds == 0.1 else self.poll_seconds
+            configured = 2.0
         return max(0.01, min(configured, max(0.1, self.lease_seconds / 3)))
 
     def run_once(self) -> bool:

--- a/puppetmaster/worker_runtime.py
+++ b/puppetmaster/worker_runtime.py
@@ -600,14 +600,18 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _write_startup_error(state_dir, job_id: str, worker_id: str, exc: BaseException) -> None:
-    """Record a worker that died before/while starting so the failure isn't a
-    silent 0-byte log.
+def _write_startup_error(
+    backend: str,
+    state_dir,
+    job_id: str,
+    worker_id: str,
+    exc: BaseException,
+) -> None:
+    """Record a worker that died during startup or execution.
 
-    A worker that fails to start (bad env, import error, store init failure)
-    used to vanish with no trace — indistinguishable from "never launched". We
-    drop a startup-error file next to the job's task logs and, if the store is
-    usable, emit a ``worker.startup_failed`` event so it shows up in the feed.
+    A worker that exits outside normal Exception handling can otherwise vanish
+    with no trace. Keep the existing startup-error file/event contract while
+    preserving the traceback for both startup and execution failures.
     """
     import traceback
 
@@ -618,14 +622,14 @@ def _write_startup_error(state_dir, job_id: str, worker_id: str, exc: BaseExcept
         crash_dir = Path(state_dir) / "jobs" / job_id / "tasks"
         crash_dir.mkdir(parents=True, exist_ok=True)
         (crash_dir / f"startup_error-{worker_id}.log").write_text(
-            f"worker {worker_id} for job {job_id} failed to start:\n\n{detail}",
+            f"worker {worker_id} for job {job_id} failed to start or run:\n\n{detail}",
             encoding="utf-8",
             errors="replace",
         )
     except Exception:
         pass
     try:
-        create_store("sqlite", state_dir, mode="attach").emit(
+        create_store(backend, state_dir, mode="attach").emit(
             job_id,
             "worker.startup_failed",
             {"worker_id": worker_id, "error": str(exc)},
@@ -660,12 +664,15 @@ def main(argv: Optional[list[str]] = None) -> int:
             crash_after_claim=args.crash_after_claim,
         )
         return 0 if runtime.run_until_idle() >= 0 else 1
-    except SystemExit:
-        # An intentional exit (e.g. the crash-after-claim demo) is not a
-        # startup failure — let it propagate untouched.
+    except SystemExit as exc:
+        # Only the crash-after-claim path owns exit 77. Other SystemExit values
+        # are unexpected worker failures and need the same durable traceback as
+        # any other BaseException; otherwise the supervisor sees only exit 1.
+        if not (args.crash_after_claim and exc.code == 77):
+            _write_startup_error(args.backend, state_dir, args.job_id, worker_id, exc)
         raise
     except BaseException as exc:  # noqa: BLE001 — last-resort trace before dying
-        _write_startup_error(state_dir, args.job_id, worker_id, exc)
+        _write_startup_error(args.backend, state_dir, args.job_id, worker_id, exc)
         raise
 
 

--- a/tests/test_claim_contention.py
+++ b/tests/test_claim_contention.py
@@ -149,6 +149,45 @@ class ClaimContentionTests(unittest.TestCase):
                     store.claim_task(task.id, 'worker')
                 self.assertEqual(write.call_count, 1)
 
+    def test_file_claim_retries_after_projection_writer_admission_timeout(self):
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp))
+            job = store.create_job('projection admission')
+            task = Task(job_id=job.id, role='explore', instruction='test', adapter='local')
+            store.save_task(task)
+            from puppetmaster import projections
+            original = projections._reserve_writer
+            calls = 0
+
+            def reserve(connection, *args, **kwargs):
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    raise sqlite3.OperationalError('database is locked')
+                return original(connection, *args, **kwargs)
+
+            with patch.object(projections, '_reserve_writer', side_effect=reserve):
+                completed = WorkerRuntime(
+                    store, job.id, 'explore', 'worker', poll_seconds=.01
+                ).run_until_idle()
+            self.assertEqual(completed, 1)
+            claimed = store.get_task_by_id(task.id)
+            self.assertEqual(claimed.status, TaskStatus.COMPLETE)
+            self.assertEqual(claimed.attempts, 1)
+
+    def test_file_claim_does_not_swallow_nonlock_projection_failure(self):
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp))
+            job = store.create_job('projection failure')
+            task = Task(job_id=job.id, role='explore', instruction='test', adapter='local')
+            store.save_task(task)
+            error = sqlite3.OperationalError('permission denied')
+            with patch('puppetmaster.projections._reserve_writer', side_effect=error):
+                with self.assertRaises(sqlite3.OperationalError) as caught:
+                    store.claim_task(task.id, 'worker')
+            self.assertIs(caught.exception, error)
+            self.assertEqual(store.get_task_by_id(task.id).status, TaskStatus.QUEUED)
+
     def test_short_lease_lock_survives_read_retry(self):
         with TemporaryDirectory() as tmp:
             store = SwarmStore(Path(tmp))

--- a/tests/test_dashboard_ports.py
+++ b/tests/test_dashboard_ports.py
@@ -276,7 +276,9 @@ class RunfileAndOnBoundTests(unittest.TestCase):
             )
             self.addCleanup(httpd.server_close)
             info = read_dashboard_runfile(state_dir)
-            self.assertEqual(info["port"], port + 1)
+            bound_port = httpd.server_address[1]
+            self.assertGreater(bound_port, port)
+            self.assertEqual(info["port"], bound_port)
             self.assertEqual(info["pid"], os.getpid())
 
     def test_on_bound_receives_actual_port(self) -> None:
@@ -292,7 +294,9 @@ class RunfileAndOnBoundTests(unittest.TestCase):
                 on_bound=lambda h, p: calls.append((h, p)),
             )
             self.addCleanup(httpd.server_close)
-            self.assertEqual(calls, [("127.0.0.1", port + 1)])
+            bound_port = httpd.server_address[1]
+            self.assertGreater(bound_port, port)
+            self.assertEqual(calls, [("127.0.0.1", bound_port)])
 
 
 class DashboardIdentityRobustnessTests(unittest.TestCase):

--- a/tests/test_incarnation_history.py
+++ b/tests/test_incarnation_history.py
@@ -398,6 +398,26 @@ class IncarnationHistoryTests(unittest.TestCase):
             self.assertIn('store replaced', result.stderr)
             self.assertEqual(replacement.incarnation, identity)
 
+    def test_concurrent_prepare_launch_ensures_current_schema_once(self):
+        from puppetmaster.identity import prepare_launch
+
+        original = SQLiteSwarmStore._execute_schema_script
+        schema_ensures = []
+
+        def counted(connection, script):
+            schema_ensures.append(root)
+            return original(connection, script)
+
+        with TemporaryDirectory() as tmp, patch.object(
+            SQLiteSwarmStore, '_execute_schema_script', new=staticmethod(counted)
+        ):
+            root = Path(tmp) / 'state'
+            with ThreadPoolExecutor(max_workers=8) as pool:
+                incarnations = list(pool.map(lambda _: prepare_launch(root, 'sqlite'), range(16)))
+
+        self.assertEqual(len(set(incarnations)), 1)
+        self.assertEqual(schema_ensures, [root])
+
     def test_completion_requires_explicit_incarnation(self):
         for store, job in self.stores():
             task = Task(job_id=job.id, role='explore', instruction='private')

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -2463,6 +2463,67 @@ class PuppetmasterTests(unittest.TestCase):
             self.assertEqual(implement_tasks[0].status, TaskStatus.COMPLETE)
             self.assertEqual(implement_tasks[0].attempts, 2)
 
+    def test_worker_exit_reports_durable_startup_traceback(self) -> None:
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("diagnose a failed worker")
+            task_dir = store.job_dir(job.id) / "tasks"
+            (task_dir / "startup_error-worker-explore-4321.log").write_text(
+                "worker failed to start:\nPermissionError: sharing violation",
+                encoding="utf-8",
+            )
+            process = MagicMock(pid=4321, returncode=1)
+
+            error = Orchestrator(store)._worker_exit_error(
+                job.id, "explore", process
+            )
+
+            self.assertIn("worker 'explore' failed with exit code 1", str(error))
+            self.assertIn("PermissionError: sharing violation", str(error))
+
+    def test_worker_main_records_unexpected_system_exit(self) -> None:
+        from puppetmaster.worker_runtime import WorkerRuntime, main as worker_main
+
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("record a silent worker exit")
+            argv = [
+                "--state-dir", str(store.root), "--backend", "file",
+                "--job-id", job.id, "--role", "explore",
+                "--worker-id", "test-worker",
+            ]
+            with patch.object(WorkerRuntime, "run_until_idle", side_effect=SystemExit(1)):
+                with self.assertRaises(SystemExit) as raised:
+                    worker_main(argv)
+
+            self.assertEqual(raised.exception.code, 1)
+            error_file = store.job_dir(job.id) / "tasks" / "startup_error-test-worker.log"
+            self.assertIn("SystemExit: 1", error_file.read_text(encoding="utf-8"))
+            self.assertIn(
+                "worker.startup_failed",
+                [event["event"] for event in store.read_events(job.id)],
+            )
+
+    def test_worker_main_keeps_intentional_crash_exit_unlogged(self) -> None:
+        from puppetmaster.worker_runtime import WorkerRuntime, main as worker_main
+
+        with TemporaryDirectory() as tmp:
+            store = SwarmStore(Path(tmp) / ".puppetmaster")
+            job = store.create_job("simulate the documented crash")
+            argv = [
+                "--state-dir", str(store.root), "--backend", "file",
+                "--job-id", job.id, "--role", "implement",
+                "--worker-id", "crash-worker", "--crash-after-claim",
+            ]
+            with patch.object(WorkerRuntime, "run_until_idle", side_effect=SystemExit(77)):
+                with self.assertRaises(SystemExit) as raised:
+                    worker_main(argv)
+
+            self.assertEqual(raised.exception.code, 77)
+            self.assertFalse(
+                (store.job_dir(job.id) / "tasks" / "startup_error-crash-worker.log").exists()
+            )
+
     def test_worker_failure_marks_job_failed(self) -> None:
         with TemporaryDirectory() as tmp:
             store = SwarmStore(Path(tmp) / ".puppetmaster")

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -27182,6 +27182,37 @@ class AuditFixTests(unittest.TestCase):
         self.assertTrue(stop.is_set())
         self.assertTrue(runtime._lease_lost.is_set())
 
+    def test_heartbeat_loop_survives_transient_sqlite_writer_contention(self) -> None:
+        import sqlite3
+
+        from puppetmaster.worker_runtime import WorkerRuntime
+
+        store = MagicMock()
+        renewed = MagicMock()
+        runtime = WorkerRuntime(
+            store=store,
+            job_id="job_x",
+            role="coder",
+            worker_id="worker-a",
+            lease_seconds=30,
+            heartbeat_seconds=0.01,
+        )
+        stop = MagicMock()
+        stop.wait.side_effect = [False, False, True]
+
+        with patch.object(
+            runtime,
+            "_heartbeat_run_and_lease",
+            side_effect=[
+                sqlite3.OperationalError("database is locked"),
+                (MagicMock(), renewed),
+            ],
+        ) as heartbeat:
+            runtime._heartbeat_until_stopped(MagicMock(), "task_x", stop)
+
+        self.assertEqual(heartbeat.call_count, 2)
+        self.assertFalse(runtime._lease_lost.is_set())
+
     def test_heartbeat_loop_uses_heartbeat_interval_not_poll_interval(self) -> None:
         from puppetmaster.worker_runtime import WorkerRuntime
 

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -27237,6 +27237,20 @@ class AuditFixTests(unittest.TestCase):
         self.assertEqual(store.heartbeat_run.call_count, 1)
         self.assertEqual(store.renew_task_lease.call_count, 1)
 
+    def test_default_heartbeat_interval_is_not_the_poll_interval(self) -> None:
+        from puppetmaster.worker_runtime import WorkerRuntime
+
+        runtime = WorkerRuntime(
+            store=MagicMock(),
+            job_id="job_x",
+            role="coder",
+            worker_id="worker-a",
+            lease_seconds=30,
+            poll_seconds=0.05,
+        )
+
+        self.assertEqual(runtime._heartbeat_interval(), 2.0)
+
     def test_heartbeat_interval_keeps_margin_for_short_leases(self) -> None:
         from puppetmaster.worker_runtime import WorkerRuntime
 

--- a/tests/test_readonly_performance.py
+++ b/tests/test_readonly_performance.py
@@ -120,6 +120,28 @@ class ReadonlyPerformanceTests(unittest.TestCase):
                     _ = store.incarnation
                 self.assertEqual(opens.call_count, 1)
 
+    def test_incarnation_retries_transient_reader_unavailability(self):
+        from puppetmaster import projections
+
+        with TemporaryDirectory() as root:
+            store = SwarmStore(root)
+            store.create_job('retry worker attach')
+            expected = store.incarnation
+            original = projections.connection
+            calls = [0]
+
+            def open_connection(*args, **kwargs):
+                calls[0] += 1
+                if calls[0] == 1:
+                    raise readonly.ReadUnavailable(
+                        'unable to open database: active reader; sidecars may be missing'
+                    )
+                return original(*args, **kwargs)
+
+            with patch.object(projections, 'connection', side_effect=open_connection):
+                self.assertEqual(store.incarnation, expected)
+            self.assertEqual(calls[0], 2)
+
     def test_cached_helper_refreshes_commits_and_fences_replacement(self):
         for cls in (SwarmStore, SQLiteSwarmStore):
             with self.subTest(backend=cls.backend_name), TemporaryDirectory() as tmp:

--- a/tests/test_readonly_sqlite_open_identity.py
+++ b/tests/test_readonly_sqlite_open_identity.py
@@ -194,6 +194,15 @@ class SQLiteOpenIdentityTests(unittest.TestCase):
             with self.assertRaisesRegex(PermissionError, 'sharing violation'):
                 worker.open_windows_source('source.sqlite3')
 
+    def test_windows_initial_stamp_access_denial_is_retryable_contention(self):
+        denied = PermissionError('Access is denied')
+        denied.winerror = 5
+        with patch.object(worker, 'stamps', side_effect=denied), \
+                patch.object(worker.os, 'name', 'nt'):
+            with self.assertRaises(PermissionError) as caught:
+                worker.main('source.sqlite3')
+        self.assertTrue(caught.exception.source_open_contention)
+
     def test_windows_guard_sharing_denial_closes_session_and_reuses_helper(self):
         denied = PermissionError('Access is denied')
         denied.winerror = 5

--- a/tests/test_readonly_sqlite_open_identity.py
+++ b/tests/test_readonly_sqlite_open_identity.py
@@ -224,6 +224,108 @@ class SQLiteOpenIdentityTests(unittest.TestCase):
                 worker.main('source.sqlite3')
         self.assertTrue(caught.exception.source_open_contention)
 
+    def test_windows_snapshot_sharing_denial_is_session_closed_and_retried(self):
+        before = [(1, 2, 3, 4, 5), None, None, None]
+        responses = []
+
+        class Source:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def fileno(self):
+                return 11
+
+            def read(self, size):
+                return b'\x00' * size
+
+        calls = {'count': 0}
+        native_path = type(Path())
+        run = worker.main
+
+        def stamps(_path):
+            calls['count'] += 1
+            if calls['count'] == 1:
+                return before
+            denied = PermissionError('Access is denied')
+            denied.winerror = 5
+            raise denied
+
+        def main(path, *, wal_snapshot=False):
+            if calls['count']:
+                return True
+            return run(path, wal_snapshot=wal_snapshot)
+
+        with patch.object(worker, 'stamps', side_effect=stamps), \
+                patch.object(worker, 'main', side_effect=main) as main_mock, \
+                patch.object(worker, 'open_windows_source', return_value=Source()), \
+                patch.object(worker, 'source_stamp', return_value=before[0]), \
+                patch.object(worker, 'emit', side_effect=responses.append), \
+                patch.object(worker, 'Path', native_path), \
+                patch.object(worker.os, 'name', 'nt'), \
+                patch.object(ctypes, 'WinDLL', return_value=SimpleNamespace(
+                    LockFileEx=lambda *args: True), create=True), \
+                patch.dict(sys.modules, msvcrt=SimpleNamespace(
+                    open_osfhandle=lambda handle, flags: handle,
+                    get_osfhandle=lambda fd: fd)), \
+                patch.object(worker.sys, 'stdin', io.StringIO(
+                    '{"open":"source.sqlite3"}\n')):
+            worker.serve('source.sqlite3')
+        self.assertEqual(main_mock.call_count, 2)
+        self.assertEqual(len(responses), 2)
+        self.assertTrue(responses[0]['source_open_contention'])
+        self.assertTrue(responses[0]['session_closed'])
+        self.assertIn('Access is denied', responses[0]['error'])
+        self.assertEqual(responses[1], {'rows': [], 'names': []})
+
+    def test_windows_snapshot_identity_failure_is_terminal(self):
+        failure = OSError('SQLite fd attestation: existing descriptors changed')
+        responses = []
+
+        class Source:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def fileno(self):
+                return 11
+
+            def read(self, size):
+                return b'\x00' * size
+
+        calls = {'count': 0}
+        native_path = type(Path())
+
+        def stamps(_path):
+            calls['count'] += 1
+            if calls['count'] == 1:
+                return [(1, 2, 3, 4, 5), None, None, None]
+            raise failure
+
+        with patch.object(worker, 'stamps', side_effect=stamps), \
+                patch.object(worker, 'main', wraps=worker.main) as main, \
+                patch.object(worker, 'open_windows_source', return_value=Source()), \
+                patch.object(worker, 'source_stamp', return_value=(1, 2, 3, 4, 5)), \
+                patch.object(worker, 'emit', side_effect=responses.append), \
+                patch.object(worker, 'Path', native_path), \
+                patch.object(worker.os, 'name', 'nt'), \
+                patch.object(ctypes, 'WinDLL', return_value=SimpleNamespace(
+                    LockFileEx=lambda *args: True), create=True), \
+                patch.dict(sys.modules, msvcrt=SimpleNamespace(
+                    open_osfhandle=lambda handle, flags: handle,
+                    get_osfhandle=lambda fd: fd)), \
+                patch.object(worker.sys, 'stdin', io.StringIO(
+                    '{"open":"source.sqlite3"}\n')):
+            worker.serve('source.sqlite3')
+        self.assertEqual(main.call_count, 1)
+        self.assertEqual(len(responses), 1)
+        self.assertNotIn('session_closed', responses[0])
+        self.assertIn('existing descriptors changed', responses[0]['error'])
+
     def test_windows_guard_closes_handle_if_crt_transfer_fails(self):
         closed = []
         def create(*args):

--- a/tests/test_readonly_sqlite_open_identity.py
+++ b/tests/test_readonly_sqlite_open_identity.py
@@ -197,7 +197,9 @@ class SQLiteOpenIdentityTests(unittest.TestCase):
     def test_windows_initial_stamp_access_denial_is_retryable_contention(self):
         denied = PermissionError('Access is denied')
         denied.winerror = 5
+        native_path = type(Path())
         with patch.object(worker, 'stamps', side_effect=denied), \
+                patch.object(worker, 'Path', native_path), \
                 patch.object(worker.os, 'name', 'nt'):
             with self.assertRaises(PermissionError) as caught:
                 worker.main('source.sqlite3')

--- a/tests/test_readonly_windows_sequence.py
+++ b/tests/test_readonly_windows_sequence.py
@@ -202,7 +202,7 @@ class WindowsSequenceTests(unittest.TestCase):
             self.assertEqual([request['wal_snapshot'] for request in requests], [False, True])
             connection.close()
 
-    def test_windows_attach_retries_transient_guard_open_denial(self):
+    def assert_guard_open_denial_retried(self, **binding):
         with TemporaryDirectory() as tmp:
             store = SQLiteSwarmStore(tmp)
             store.ensure_schema()
@@ -240,11 +240,17 @@ class WindowsSequenceTests(unittest.TestCase):
                     patch.object(readonly, 'source_stamp', return_value=(1, 2, 3, 4, 5)), \
                     patch.object(readonly, '_source_stamp', return_value=(
                         (1, 2, 3, 4, 5), None, None, None, None, None)):
-                connection = readonly.ReadConnection(
-                    store, 1, attach_binding=True, attach_deadline=time.monotonic() + 1)
+                connection = readonly.ReadConnection(store, 1, **binding)
             requests = connection.process.stdin.getvalue().splitlines()
             self.assertEqual(len(requests), 2)
             connection.close()
+
+    def test_windows_attach_retries_transient_guard_open_denial(self):
+        self.assert_guard_open_denial_retried(
+            attach_binding=True, attach_deadline=time.monotonic() + 1)
+
+    def test_windows_launch_retries_transient_guard_open_denial(self):
+        self.assert_guard_open_denial_retried(launch_binding=True)
 
 
 if __name__ == '__main__':

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -38,13 +38,8 @@ def _attach_claim_complete_worker(
     """Spawn-safe worker body: attach only, then claim/complete local tasks."""
     error_file = Path(error_path).open("w", encoding="utf-8")
     diagnostic_file = Path(diagnostic_path).open("w", encoding="utf-8")
-    diagnostic_worker = worker_id == "w-0"
-    if diagnostic_worker:
-        # One representative stack is enough to diagnose a shared attach
-        # stall. Arming every spawned process at the same instant creates a
-        # 32-writer traceback storm that can itself push healthy workers past
-        # the parent deadline on Windows.
-        faulthandler.dump_traceback_later(45, file=diagnostic_file)
+    # Per-worker dump files. Do not arm only w-0: dest-push last stalled on w-26.
+    faulthandler.dump_traceback_later(45, file=diagnostic_file)
     thread_errors: list[str] = []
     previous_hook = threading.excepthook
     threading.excepthook = lambda args: thread_errors.append(
@@ -60,14 +55,12 @@ def _attach_claim_complete_worker(
             worker_id=worker_id,
             lease_seconds=30,
             poll_seconds=0.05,
-            heartbeat_seconds=0.01,
         )
         runtime.run_until_idle()
     except Exception:  # noqa: BLE001 — surface in the parent assert
         error_file.write(traceback.format_exc())
     finally:
-        if diagnostic_worker:
-            faulthandler.cancel_dump_traceback_later()
+        faulthandler.cancel_dump_traceback_later()
         threading.excepthook = previous_hook
         if thread_errors:
             error_file.write("\n".join(thread_errors))
@@ -75,6 +68,8 @@ def _attach_claim_complete_worker(
         diagnostic_file.close()
         if Path(error_path).stat().st_size == 0:
             Path(error_path).unlink()
+        # Hung workers are TerminateProcess'd and never reach this line, so
+        # their dump stays for the parent. Clean exits drop the empty dump.
         Path(diagnostic_path).unlink(missing_ok=True)
 
 

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -99,6 +99,33 @@ class SqliteAttachEnsureTests(unittest.TestCase):
             job = store.create_job("after attach")
             self.assertEqual(store.get_job(job.id).goal, "after attach")
 
+    def test_attach_retries_proven_windows_source_open_contention(self) -> None:
+        from puppetmaster.readonly import ReadUnavailable
+
+        with TemporaryDirectory() as tmp:
+            root = Path(tmp) / ".puppetmaster"
+            SQLiteSwarmStore(root).ensure_schema()
+            store = SQLiteSwarmStore(root)
+            original_connect = store._connect_readonly
+            denied = ReadUnavailable(
+                "unable to open database: source changed or unavailable: "
+                "[WinError 5] Access is denied."
+            )
+            denied.source_open_contention = True
+            calls = 0
+
+            def connect(*args: object, **kwargs: object):
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    raise denied
+                return original_connect(*args, **kwargs)
+
+            with mock.patch.object(store, "_connect_readonly", side_effect=connect), \
+                    mock.patch.object(store, "_sleep_lock_backoff"):
+                store.attach()
+            self.assertEqual(calls, 2)
+
     def test_concurrent_attach_never_writes_schema(self) -> None:
         with TemporaryDirectory() as tmp:
             root = Path(tmp) / ".puppetmaster"

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -148,7 +148,8 @@ class SqliteAttachEnsureTests(unittest.TestCase):
                 for thread in threads:
                     thread.join()
 
-            self.assertEqual(errors, [])
+            if errors:
+                self.fail("\n\n".join(errors[:2]))
             self.assertEqual(scripts, [])
             self.assertEqual(metadata_inserts, [])
 

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -240,6 +240,28 @@ class SqliteSessionRetryTests(unittest.TestCase):
             finally:
                 blocker.close()
 
+    def test_opportunistic_heartbeat_does_not_queue_behind_writer(self) -> None:
+        with TemporaryDirectory() as tmp:
+            store = SQLiteSwarmStore(tmp)
+            store.ensure_schema()
+            job = store.create_job("opportunistic heartbeat")
+            task = Task(job_id=job.id, role="implement", instruction="noop")
+            store.save_task(task)
+            claimed = store.claim_task(task.id, "w-1")
+            run = AgentRun(job_id=job.id, task_id=task.id, role=task.role, worker_id="w-1")
+            store.save_run(run)
+            blocker = store.connect()
+            try:
+                blocker.execute("BEGIN IMMEDIATE")
+                with mock.patch.object(store, "_sleep_lock_backoff") as retry:
+                    with self.assertRaises(sqlite3.OperationalError):
+                        store.heartbeat_run_and_renew_lease_opportunistic(
+                            run, task.id, "w-1", lease_id=claimed.lease_id)
+                retry.assert_not_called()
+            finally:
+                blocker.rollback()
+                blocker.close()
+
     def test_waiting_heartbeat_cannot_overwrite_completion_or_successor_lease(self) -> None:
         for terminal in (False, True):
             with self.subTest(terminal=terminal), TemporaryDirectory() as tmp:
@@ -639,6 +661,38 @@ class SqliteHeartbeatCoalesceTests(unittest.TestCase):
 
 
 class WorkerHeartbeatLifecycleTests(unittest.TestCase):
+    def test_background_heartbeat_prefers_opportunistic_writer(self) -> None:
+        with TemporaryDirectory() as tmp:
+            store = SQLiteSwarmStore(tmp)
+            store.ensure_schema()
+            job = store.create_job("background heartbeat")
+            task = Task(job_id=job.id, role="implement", instruction="noop")
+            store.save_task(task)
+            claimed = store.claim_task(task.id, "w-1")
+            run = AgentRun(job_id=job.id, task_id=task.id, role=task.role, worker_id="w-1")
+            runtime = WorkerRuntime(store, job.id, "implement", "w-1",
+                                    heartbeat_seconds=0.01)
+            stop = threading.Event()
+
+            def heartbeat(*args, **kwargs):
+                stop.set()
+                return run, claimed
+
+            with mock.patch.object(
+                SQLiteSwarmStore,
+                "heartbeat_run_and_renew_lease_opportunistic",
+                autospec=True,
+                side_effect=heartbeat,
+            ) as opportunistic, mock.patch.object(
+                SQLiteSwarmStore,
+                "heartbeat_run_and_renew_lease",
+                autospec=True,
+            ) as blocking:
+                runtime._heartbeat_until_stopped(run, task.id, stop,
+                                                 lease_id=claimed.lease_id)
+            opportunistic.assert_called_once()
+            blocking.assert_not_called()
+
     def test_completion_waits_for_inflight_sqlite_heartbeat(self) -> None:
         self._assert_heartbeat_drained_before_terminal(exception=False)
 
@@ -711,7 +765,9 @@ class WorkerHeartbeatLifecycleTests(unittest.TestCase):
                     # The heartbeat now reserves the writer before reading the
                     # task, so it cannot reach renewal until this lock releases.
                     entered.set()
-                    updated, renewed = original_heartbeat(*args)
+                    # Force the blocking path: this lifecycle test proves that
+                    # an actually in-flight write drains before publication.
+                    updated, renewed = original_heartbeat(*args[:3])
                     return updated, None if lose_lease else renewed
                 finally:
                     heartbeat_finished.set()

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -156,7 +156,7 @@ class SqliteAttachEnsureTests(unittest.TestCase):
                     thread.join()
 
             if errors:
-                self.fail("\n\n".join(errors[:2]))
+                self.fail("\n\n".join(str(error) for error in errors[:2]))
             self.assertEqual(scripts, [])
             self.assertEqual(metadata_inserts, [])
 

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -38,7 +38,13 @@ def _attach_claim_complete_worker(
     """Spawn-safe worker body: attach only, then claim/complete local tasks."""
     error_file = Path(error_path).open("w", encoding="utf-8")
     diagnostic_file = Path(diagnostic_path).open("w", encoding="utf-8")
-    faulthandler.dump_traceback_later(45, file=diagnostic_file)
+    diagnostic_worker = worker_id == "w-0"
+    if diagnostic_worker:
+        # One representative stack is enough to diagnose a shared attach
+        # stall. Arming every spawned process at the same instant creates a
+        # 32-writer traceback storm that can itself push healthy workers past
+        # the parent deadline on Windows.
+        faulthandler.dump_traceback_later(45, file=diagnostic_file)
     thread_errors: list[str] = []
     previous_hook = threading.excepthook
     threading.excepthook = lambda args: thread_errors.append(
@@ -60,7 +66,8 @@ def _attach_claim_complete_worker(
     except Exception:  # noqa: BLE001 — surface in the parent assert
         error_file.write(traceback.format_exc())
     finally:
-        faulthandler.cancel_dump_traceback_later()
+        if diagnostic_worker:
+            faulthandler.cancel_dump_traceback_later()
         threading.excepthook = previous_hook
         if thread_errors:
             error_file.write("\n".join(thread_errors))

--- a/tests/test_sqlite_concurrency.py
+++ b/tests/test_sqlite_concurrency.py
@@ -926,7 +926,8 @@ class SqliteMultiprocessAttachTests(unittest.TestCase):
                 if not process.is_alive():
                     process.close()
 
-            self.assertEqual(errors, [])
+            if errors:
+                self.fail("\n\n".join(errors))
             tasks = supervisor.list_tasks(job.id)
             status_counts = Counter(str(task.status) for task in tasks)
             failed_events = [e["payload"] for e in supervisor.read_events(job.id)


### PR DESCRIPTION
## Summary
- ship the v1.25 durable-store, completion, bounded-read, and economics contract haul
- include cross-platform contention and Windows attach-herd stabilization
- preserve the full unittest-discover release gate and real daily-driver smokes

## Gate
- dev push 34179958072 is green on exact SHA 28f6422ec46c50ffee9abae08ad2071da01ddfac across Ubuntu 3.9/3.12, macOS 3.12, and Windows 3.12
- Windows full discover, attach-herd canary, doctor, SQLite demo, memory retrieval, and daily-driver smokes passed

## Release
After this exact tree is green and merged, tag v1.25.0 and publish puppetmaster-ai 1.25.0. Marionette will pin the published wheel in the same sitting.