### PR TITLE
Fix Windows launch-binding guard contention

### DIFF
--- a/.github/workflows/windows-store.yml
+++ b/.github/workflows/windows-store.yml
@@ -1,6 +1,6 @@
 name: Windows store canary
 
-# Fast Windows signal for the attach herd and crash-demo. Does not replace
+# Fast Windows signal for store contention, launch binding, and crash-demo. Does not replace
 # the required CI matrix (`python -m unittest discover` on all four legs).
 # Do not skip, xfail, or raise timeouts here.
 
@@ -21,6 +21,8 @@ jobs:
           python-version: "3.12"
       - name: Run SQLite attach concurrency tests
         run: python -m unittest tests.test_sqlite_concurrency -v
+      - name: Run launch stabilization tests
+        run: python -m unittest tests.test_launch_stabilization -v
       - name: Run crash-demo
         if: ${{ !cancelled() }}
         run: python -m puppetmaster crash-demo

--- a/puppetmaster/readonly.py
+++ b/puppetmaster/readonly.py
@@ -454,7 +454,8 @@ class ReadConnection:
                     write_race = getattr(exc, 'same_store_write', False)
                     topology_race = attach_binding and getattr(exc, 'launch_topology_change', False)
                     source_open_contention = (
-                        attach_binding and getattr(exc, 'source_open_contention', False)
+                        (attach_binding or launch_binding) and
+                        getattr(exc, 'source_open_contention', False)
                     )
                     locked = _locked(exc)
                     unavailable = isinstance(exc, ReadUnavailable) and any(

--- a/tests/test_readonly_windows_sequence.py
+++ b/tests/test_readonly_windows_sequence.py
@@ -202,7 +202,7 @@ class WindowsSequenceTests(unittest.TestCase):
             self.assertEqual([request['wal_snapshot'] for request in requests], [False, True])
             connection.close()
 
-    def test_windows_attach_retries_transient_guard_open_denial(self):
+    def assert_guard_open_denial_retried(self, **binding):
         with TemporaryDirectory() as tmp:
             store = SQLiteSwarmStore(tmp)
             store.ensure_schema()
@@ -240,11 +240,17 @@ class WindowsSequenceTests(unittest.TestCase):
                     patch.object(readonly, 'source_stamp', return_value=(1, 2, 3, 4, 5)), \
                     patch.object(readonly, '_source_stamp', return_value=(
                         (1, 2, 3, 4, 5), None, None, None, None, None)):
-                connection = readonly.ReadConnection(
-                    store, 1, attach_binding=True, attach_deadline=time.monotonic() + 1)
+                connection = readonly.ReadConnection(store, 1, **binding)
             requests = connection.process.stdin.getvalue().splitlines()
             self.assertEqual(len(requests), 2)
             connection.close()
+
+    def test_windows_attach_retries_transient_guard_open_denial(self):
+        self.assert_guard_open_denial_retried(
+            attach_binding=True, attach_deadline=time.monotonic() + 1)
+
+    def test_windows_launch_retries_transient_guard_open_denial(self):
+        self.assert_guard_open_denial_retried(launch_binding=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Failure
Dev push 34181599524 failed only on Windows in test_real_writer_and_missing_sidecars_stabilize: launch binding treated a transient native sharing denial as terminal, then fixture cleanup cascaded.

## Fix
- classify source-open contention as retryable for launch binding as well as attach binding
- retain the existing bounded launch deadline and helper-session reuse
- add the missing launch-binding regression beside the attach-binding case

No timeout increase, skip, xfail, schema change, or lock retry was added.

## Local gate
python -m unittest tests.test_readonly_windows_sequence tests.test_readonly_sqlite_open_identity tests.test_launch_stabilization -q — 35 tests green, 1 native-Windows-only skip.