### PR TITLE
Retry Windows source-stamp Access Denied on attach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,6 @@ jobs:
         run: npm install --package-lock=false --no-audit
       - name: Smoke check Cursor runner syntax
         run: npm run smoke:cursor-runner
-      - name: Windows attach-herd canary
-        if: runner.os == 'Windows'
-        run: python -m unittest tests.test_sqlite_concurrency.SqliteMultiprocessAttachTests.test_supervisor_ensure_then_n_workers_attach_claim_complete -v
       - name: Run Python tests
         run: python -m unittest discover -s tests -v
       - name: Smoke check CLI metadata

--- a/puppetmaster/readonly.py
+++ b/puppetmaster/readonly.py
@@ -705,6 +705,13 @@ def _launch_transient(exc):
          getattr(exc, 'launch_topology_change', False))))
 
 
+def _source_open_contention(exc):
+    return bool(
+        getattr(exc, 'source_open_contention', False)
+        or getattr(exc, 'winerror', None) in (5, 32, 33)
+    )
+
+
 def _metadata_fence(before, after):
     from puppetmaster.identity import StoreIdentityError
     if (before is not None and after is not None and
@@ -731,18 +738,19 @@ def connect(store, *, timeout=5, reuse=False, launch_binding=False, attach_bindi
     retry_deadline = None
     refresh_stamp = None
     refresh_error = None
-    launch_source = _source_stamp(store)[1] if launch_binding else None
+    launch_source = None
     while True:
         if launch_binding and selection(store) != store._read_selection:
             raise StoreIdentityError('store removed or replaced since selection; explicitly reopen')
-        if launch_source is not None:
-            current_source = _source_stamp(store)[1]
-            # Reject observed metadata-only drift; ctime is not an operation counter.
-            _metadata_fence(launch_source, current_source)
-            launch_source = current_source
-        if refresh_stamp is not None and _source_stamp(store) != refresh_stamp:
-            raise ReadUnavailable('unable to open database: source changed')
         try:
+            if launch_binding:
+                current_source = _source_stamp(store)[1]
+                if launch_source is not None:
+                    # Reject observed metadata-only drift; ctime is not an operation counter.
+                    _metadata_fence(launch_source, current_source)
+                launch_source = current_source
+            if refresh_stamp is not None and _source_stamp(store) != refresh_stamp:
+                raise ReadUnavailable('unable to open database: source changed')
             remaining = min(timeout, (deadline if retry_deadline is None else retry_deadline) - time.monotonic())
             if timeout > 0 and remaining <= 0:
                 raise ReadTimeout('unable to open database: reader timed out')
@@ -755,6 +763,25 @@ def connect(store, *, timeout=5, reuse=False, launch_binding=False, attach_bindi
                 connection._abort()
                 raise ReadUnavailable('unable to open database: source changed')
             return connection
+        except OSError as exc:
+            if (
+                isinstance(exc, FileNotFoundError)
+                or not (attach_binding or launch_binding)
+                or not _source_open_contention(exc)
+            ):
+                raise
+            if contention_window[0] is None:
+                contention_window[0] = min(deadline, time.monotonic() + (0.1 if reuse else 1.0))
+            next_deadline = (
+                attach_deadline if attach_binding and attach_deadline is not None
+                else deadline
+            )
+            retry_deadline = next_deadline if retry_deadline is None else min(retry_deadline, next_deadline)
+            if time.monotonic() >= retry_deadline:
+                raise
+            time.sleep(min(.05, max(0, retry_deadline - time.monotonic())))
+            if time.monotonic() >= retry_deadline:
+                raise
         except sqlite3.OperationalError as exc:
             if isinstance(exc, ReadTimeout) and refresh_error is not None and not (attach_binding or launch_binding):
                 raise refresh_error

--- a/puppetmaster/readonly_worker.py
+++ b/puppetmaster/readonly_worker.py
@@ -43,7 +43,7 @@ def source_stamp(path=None, *, fd=None):
         # Attributes only, shared read/write/delete, including directories.
         handle = create(str(path), 0x80, 7, None, 3, 0x02000000, None)
         if handle == wintypes.HANDLE(-1).value:
-            raise ctypes.WinError(ctypes.get_last_error())
+            raise _retryable_windows_contention(ctypes.WinError(ctypes.get_last_error()))
         try:
             fd = msvcrt.open_osfhandle(handle, os.O_RDONLY)
         except BaseException:
@@ -60,10 +60,10 @@ def source_stamp(path=None, *, fd=None):
         for _ in range(8):
             first, last = BasicInfo(), BasicInfo()
             if not query(msvcrt.get_osfhandle(fd), 0, ctypes.byref(first), ctypes.sizeof(first)):
-                raise ctypes.WinError(ctypes.get_last_error())
+                raise _retryable_windows_contention(ctypes.WinError(ctypes.get_last_error()))
             st = os.fstat(fd)
             if not query(msvcrt.get_osfhandle(fd), 0, ctypes.byref(last), ctypes.sizeof(last)):
-                raise ctypes.WinError(ctypes.get_last_error())
+                raise _retryable_windows_contention(ctypes.WinError(ctypes.get_last_error()))
             write = (last.write - epoch) * 100
             if (first.write, first.change) == (last.write, last.change) and st.st_mtime_ns == write:
                 return (st.st_dev, st.st_ino, st.st_size, write, (last.change - epoch) * 100)

--- a/tests/test_readonly_sqlite_open_identity.py
+++ b/tests/test_readonly_sqlite_open_identity.py
@@ -13,7 +13,9 @@ from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent))
 import hermetic_env  # noqa: F401
+from puppetmaster import readonly
 from puppetmaster import readonly_worker as worker
+from puppetmaster.sqlite_store import SQLiteSwarmStore
 
 
 class SQLiteOpenIdentityTests(unittest.TestCase):
@@ -204,6 +206,46 @@ class SQLiteOpenIdentityTests(unittest.TestCase):
             with self.assertRaises(PermissionError) as caught:
                 worker.main('source.sqlite3')
         self.assertTrue(caught.exception.source_open_contention)
+
+    def test_source_stamp_createfile_access_denial_is_retryable_contention(self):
+        from ctypes import wintypes
+
+        denied = PermissionError('Access is denied')
+        denied.winerror = 5
+        kernel = SimpleNamespace(
+            CreateFileW=lambda *args: wintypes.HANDLE(-1).value,
+            GetFileInformationByHandleEx=SimpleNamespace(),
+        )
+        with patch.object(worker.os, 'name', 'nt'), \
+                patch.object(ctypes, 'WinDLL', return_value=kernel, create=True), \
+                patch.object(ctypes, 'get_last_error', return_value=5, create=True), \
+                patch.object(ctypes, 'WinError', return_value=denied, create=True), \
+                patch.dict(sys.modules, msvcrt=SimpleNamespace()):
+            with self.assertRaises(PermissionError) as caught:
+                worker.source_stamp('source.sqlite3')
+        self.assertTrue(caught.exception.source_open_contention)
+
+    def test_connect_retries_parent_source_stamp_access_denied(self):
+        denied = PermissionError('Access is denied')
+        denied.winerror = 5
+        denied.source_open_contention = True
+        calls = {'n': 0}
+        real = readonly.source_stamp
+
+        def flaky(path=None, *, fd=None):
+            calls['n'] += 1
+            if calls['n'] == 1:
+                raise denied
+            return real(path, fd=fd)
+
+        with TemporaryDirectory() as directory:
+            store = SQLiteSwarmStore(directory)
+            store.ensure_schema()
+            store.attach()
+            with patch.object(readonly, 'source_stamp', flaky):
+                with readonly.connect(store, attach_binding=True, timeout=2) as connection:
+                    self.assertEqual(connection.execute('SELECT 42').fetchone()[0], 42)
+        self.assertGreaterEqual(calls['n'], 2)
 
     def test_windows_guard_sharing_denial_closes_session_and_reuses_helper(self):
         denied = PermissionError('Access is denied')


### PR DESCRIPTION
## Summary
- Parent-side `source_stamp()` CreateFileW WinError 5 was a raw `PermissionError`, so `connect()` never retried it (only `sqlite3.OperationalError`). Worker attach in CI then died in `test_run_creates_artifacts_summary_and_memory` / `test_crash_demo_cli_forwards_scope` on `e55f368`.
- Mark those CreateFileW / `GetFileInformationByHandleEx` failures as `source_open_contention` and retry them on `attach_binding` / `launch_binding` inside the existing deadline.
- Remove the duplicate in-workflow attach-herd canary. `.github/workflows/windows-store.yml` already runs `tests.test_sqlite_concurrency`; CI discover still runs the test.

This does not change `v1.26.0` on PyPI. It makes the next `dev` tip an honest Windows-green SHA so users stop reading the #152 merge X as a bad release.

## Test plan
- [x] `python -m unittest tests.test_readonly_sqlite_open_identity tests.test_readonly_launch_retry tests.test_readonly_retry_deadline tests.test_readonly_admission -q` (68 tests, 1 skip)
- [ ] CI Windows + Windows store canary on this PR
- [ ] Confirm `test_supervisor_ensure_then_n_workers_attach_claim_complete` still runs via discover / windows-store.yml