### PR TITLE
Classify Codex spend-cap turn failures for router fallback

### DIFF
--- a/puppetmaster/adapters/codex.py
+++ b/puppetmaster/adapters/codex.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Optional, Union
 
 from puppetmaster.codegraph import enrich_prompt_with_codegraph
-from puppetmaster.failure import classify_codex_failure
+from puppetmaster.failure import UNKNOWN, classify_codex_failure
 from puppetmaster.models import Artifact, ArtifactType, Task
 from puppetmaster.redaction import redact_secrets
 from puppetmaster.usage import selected_token_usage
@@ -347,6 +347,11 @@ class CodexAdapter(CliWorkerAdapter):
 
         parsed_artifacts = cursor_result_artifacts(task, worker_id, last_message, adapter="codex")
         process_failed = completed.returncode != 0 or turn_failed
+        failure = classify_codex_failure(
+            completed.stderr + "\n" + completed.stdout + "\n" + turn_failure_message
+        ) if process_failed else None
+        if turn_failed and failure == UNKNOWN:
+            failure = "codex_turn_failed"
         unstructured = not process_failed and not parsed_artifacts and bool(last_message.strip())
         degraded = unstructured and not write_capable
 
@@ -403,15 +408,7 @@ class CodexAdapter(CliWorkerAdapter):
                 "changed_files": after["changed_files"],
                 "untracked_files": after["untracked_files"],
                 **diff_source_payload(before, after),
-                "failure": (
-                    None
-                    if not process_failed
-                    else "codex_turn_failed"
-                    if turn_failed
-                    else classify_codex_failure(
-                        completed.stderr + "\n" + completed.stdout + "\n" + turn_failure_message
-                    )
-                ),
+                "failure": failure,
             },
         )
         artifacts: list[Artifact] = [verification]

--- a/puppetmaster/failure.py
+++ b/puppetmaster/failure.py
@@ -111,7 +111,9 @@ _ADAPTER_EXTRA_RULES: dict[str, Tuple[Rule, ...]] = {
         (_all("denied", "model"), MODEL_UNAVAILABLE),
         (_any("permission", "not allowed", "denied"), PERMISSION_DENIED),
     ),
-    "codex": (),
+    "codex": (
+        (_any("spend cap"), BILLING_OR_QUOTA),
+    ),
     "hermes": (
         (_all("no such file or directory", "hermes"), MISSING_CLI),
         (_any("no provider", "provider credentials"), NOT_AUTHENTICATED),

--- a/tests/test_puppetmaster.py
+++ b/tests/test_puppetmaster.py
@@ -7397,6 +7397,44 @@ print(json.dumps({"result": "ok", "usage": {"input_tokens": 321, "output_tokens"
         self.assertEqual(verification.payload["failure"], "timeout")
         self.assertEqual(verification.payload["live_log"], "/tmp/codex_exec_live.log")
 
+    def test_codex_adapter_classifies_turn_failed_spend_cap_as_billing_or_quota(self) -> None:
+        message = (
+            "You hit your spend cap set by the owner of your workspace. "
+            "Ask an owner to increase your spend cap to continue."
+        )
+        streamed = StreamedProcess(
+            returncode=1,
+            stdout="\n".join(
+                [
+                    json.dumps({"type": "thread.started", "thread_id": "th_spend_cap"}),
+                    json.dumps({"type": "turn.started"}),
+                    json.dumps({"type": "error", "message": message}),
+                    json.dumps({"type": "turn.failed", "error": {"message": message}}),
+                ]
+            ),
+            stderr="",
+            timed_out=False,
+            live_log_path="/tmp/codex_exec_live.log",
+        )
+        task = Task(
+            id="t-codex-spend-cap",
+            job_id="job-codex-spend-cap",
+            role="codex-review",
+            adapter="codex",
+            instruction="Review the repo.",
+            payload={"cwd": str(Path.cwd()), "sandbox": "read-only", "disable_codegraph": True},
+        )
+        clean = {"sha": "s", "changed_files": [], "untracked_files": [], "diff": ""}
+        with patch("puppetmaster.adapters.resolve_command", return_value="/usr/bin/codex"), patch(
+            "puppetmaster.adapters.git_snapshot", side_effect=[clean, clean]
+        ), patch("puppetmaster.adapters.run_streamed_subprocess", return_value=streamed):
+            artifacts = CodexAdapter().run(task, "goal", "worker")
+
+        verification = artifacts[0]
+        self.assertEqual(verification.payload["result"], "failed")
+        self.assertEqual(verification.payload["failure"], "billing_or_quota")
+        self.assertEqual(verification.payload["turn_failure_message"], message)
+
     def test_codex_adapter_bypassed_read_only_uses_worktree_guard(self) -> None:
         from puppetmaster.adapters import verification_artifact
 


### PR DESCRIPTION
## Summary
- Classify concrete Codex `turn.failed` output before falling back to generic `codex_turn_failed`.
- Map Codex workspace `spend cap` failures to the existing `billing_or_quota` category so the current worker-runtime and router fallback path can recover.
- Keep fallback ownership in the orchestrator; this adds no adapter-local failover, auth handling, or configuration surface.

## Live proof
- Before this change, the captured spend-cap turn produced `codex_turn_failed` and no reroute.
- With this change, live job `job_f1bac6aaab1a` recorded `billing_or_quota`, marked the Codex task failed, emitted `router-fallback`, rerouted to `agentic/openai`, and delivered the grounded `README.txt:1` finding.
- The fallback receipt recorded 3,064 input / 113 output tokens and `$0.006510` API cost. The read-only fixture remained clean.

## Test plan
- [x] Exact captured Codex JSONL fails RED before the change and passes through `CodexAdapter.run` after it.
- [x] Focused classifier, worker-runtime, and router fallback tests: 5 passed.
- [x] Codex streaming, timeout, and spend-cap adapter tests: 3 passed.
- [x] `python -m compileall -q puppetmaster tests/test_puppetmaster.py`
- [x] `git diff --check`
- [ ] CI matrix

## Local suite note
`python -m unittest discover -s tests -v` ran 3,309 tests with 38 skipped and 3 failures. The `CODEX_COMMAND` failure passes when the local override is removed. The two remaining agentic/router failures reproduce unchanged against upstream `8ee0c59`; none touch this diff.
