### PR TITLE
v1.27.3: Codex spend-cap classification (#161)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v1.27.3 — 2026-09-09
+
+**Classify Codex spend-cap turn failures as billing_or_quota (#161).**
+
+- Map workspace `spend cap` Codex `turn.failed` output to `billing_or_quota` so
+  the existing worker-runtime / router fallback path can recover (instead of
+  stuck `codex_turn_failed`).
+- Credit @kbentonferguson.
+
 ## v1.27.2 — 2026-09-09
 
 **Dashboard: never paint Marionette provenance JSON as the job title.**

--- a/puppetmaster/__init__.py
+++ b/puppetmaster/__init__.py
@@ -1,5 +1,5 @@
 """Puppetmaster: distributed agent workers with stitched shared memory."""
 
 __all__ = ["__version__"]
-__version__ = "1.27.2"
+__version__ = "1.27.3"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "puppetmaster-ai"
-version = "1.27.2"
+version = "1.27.3"
 description = "Gunicorn-style agent swarms with Redis-like shared memory and artifact stitching. (Imported as `puppetmaster`; published as `puppetmaster-ai` because the bare PyPI name is held by an abandoned 2019 project, name-reassignment pending.)"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
- Version stamp for merged #161 (Codex spend-cap → `billing_or_quota` for router fallback).
- Changelog entry; credit @kbentonferguson.

## Test plan
- [ ] CI green
- [ ] merge → tag `v1.27.3` → PyPI → Marionette pin