### PR TITLE
v1.27.5: show human goals on the dashboard Runs list

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v1.27.5 — 2026-09-09
+
+**Dashboard Runs list: prefer human goal over Marionette provenance JSON.**
+
+- `renderIndex` used `jobHeadline`, which painted `job.label` (session/dispatch/origin
+  JSON) as the strong title. The list now uses `jobDisplayTitle` — goal first,
+  job id as the secondary line, full goal on hover.
+- Truncated provenance JSON that still starts with `{` and mentions
+  `session_id` / `dispatch_id` / `origin` is treated as provenance even when
+  `JSON.parse` fails.
+
 ## v1.27.4 — 2026-09-09
 
 **Same-job continuous planner: intent before fan-out, typed handoffs, kernel requeue.**

--- a/puppetmaster/__init__.py
+++ b/puppetmaster/__init__.py
@@ -1,5 +1,5 @@
 """Puppetmaster: distributed agent workers with stitched shared memory."""
 
 __all__ = ["__version__"]
-__version__ = "1.27.4"
+__version__ = "1.27.5"
 

--- a/puppetmaster/dashboard.py
+++ b/puppetmaster/dashboard.py
@@ -851,10 +851,6 @@ function phaseStrip(phase) {
     + `<span class="${labelCls}">${esc(p.label || "")}</span></div>`;
 }
 
-function jobHeadline(j) {
-  return j.label || j.title || j.id;
-}
-
 // Header label answering "which project is this board serving?" from an
 // /api/meta payload. Pure by contract: no fetch/document/window/location, no
 // globals at all -- this constant is executed verbatim under node by the test

--- a/puppetmaster/dashboard_assets/dashboard.js
+++ b/puppetmaster/dashboard_assets/dashboard.js
@@ -45,7 +45,8 @@ function isProvenanceLabel(label) {
     const data = JSON.parse(text);
     return !!(data && typeof data === "object" && (data.session_id || data.dispatch_id || data.origin));
   } catch (_err) {
-    return false;
+    // List APIs may truncate mid-JSON; still treat `{` + host keys as provenance.
+    return text.includes("session_id") || text.includes("dispatch_id") || text.includes("origin");
   }
 }
 
@@ -158,7 +159,7 @@ function renderIndex() {
   const query = jobSearch.trim().toLowerCase();
   const shown = latestJobs.filter(job => {
     const statusMatch = jobFilter === "all" || job.status === jobFilter;
-    const text = [jobHeadline(job), job.goal, job.id, job.project].filter(Boolean).join(" ").toLowerCase();
+    const text = [jobDisplayTitle(job), job.goal, job.id, job.project].filter(Boolean).join(" ").toLowerCase();
     return statusMatch && (!query || text.includes(query));
   });
   const activeCount = latestJobs.filter(job => ["running", "queued", "stitching", "in_progress"].includes(job.status)).length;
@@ -177,7 +178,10 @@ function renderIndex() {
     html += '<div class="run-list">';
     for (const job of shown) {
       const href = jobHref(job.id, embedMode);
-      html += `<a class="run-row" href="${href}" aria-label="Open ${esc(jobHeadline(job))}">${statusLabel(job.status)}<span class="run-name"><strong title="${esc(job.goal)}">${esc(jobHeadline(job))}</strong><span>${esc(job.id)}</span></span><span class="run-project">${esc(job.project || projectLabel(meta) || "Local workspace")}</span><time class="run-time" datetime="${esc(job.created_at || "")}">${esc(fmtAgo(job.created_at))}</time></a>`;
+      const title = jobDisplayTitle(job);
+      const goalText = String(job.goal || "").trim();
+      const tooltip = goalText && !isProvenanceLabel(goalText) ? goalText : title;
+      html += `<a class="run-row" href="${href}" aria-label="Open ${esc(title)}">${statusLabel(job.status)}<span class="run-name"><strong title="${esc(tooltip)}">${esc(title)}</strong><span>${esc(job.id)}</span></span><span class="run-project">${esc(job.project || projectLabel(meta) || "Local workspace")}</span><time class="run-time" datetime="${esc(job.created_at || "")}">${esc(fmtAgo(job.created_at))}</time></a>`;
     }
     html += "</div>";
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "puppetmaster-ai"
-version = "1.27.4"
+version = "1.27.5"
 description = "Gunicorn-style agent swarms with Redis-like shared memory and artifact stitching. (Imported as `puppetmaster`; published as `puppetmaster-ai` because the bare PyPI name is held by an abandoned 2019 project, name-reassignment pending.)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_dashboard_embed.py
+++ b/tests/test_dashboard_embed.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import re
+import shutil
+import subprocess
 import unittest
 
 from puppetmaster.dashboard import INDEX_HTML, _PAGE_APP_JS, _PAGE_HEAD
@@ -73,6 +75,64 @@ class DashboardEmbedModeTests(unittest.TestCase):
             "const headline = job.job.label || job.job.title || job.job.id;",
             _PAGE_APP_JS,
         )
+
+    def test_runs_list_uses_display_title_not_undefined_headline(self) -> None:
+        start = _PAGE_APP_JS.index("function renderIndex")
+        end = _PAGE_APP_JS.index("function actualCost")
+        render_index = _PAGE_APP_JS[start:end]
+        self.assertIn("jobDisplayTitle(job)", render_index)
+        self.assertNotIn("jobHeadline", render_index)
+        self.assertNotIn("jobHeadline", _PAGE_APP_JS)
+        self.assertNotIn("function jobHeadline", INDEX_HTML)
+        self.assertNotIn("j.label || j.title || j.id", INDEX_HTML)
+
+    def test_display_title_prefers_goal_over_provenance_json(self) -> None:
+        node = shutil.which("node")
+        if not node:
+            self.skipTest("node not available")
+        start = _PAGE_APP_JS.index("function isProvenanceLabel")
+        end = _PAGE_APP_JS.index("function fmtAgo")
+        prefix = _PAGE_APP_JS[start:end]
+        harness = prefix + r"""
+const assert = require("assert");
+const provenance = '{"session_id":"8cc8a1c2281d","dispatch_id":"call_380675","origin":"marionette"}';
+const truncated = '{"session_id":"8cc8a1c2281d","dispatch_id":"call_380675","origin":"marionette","app';
+assert.equal(isProvenanceLabel(provenance), true);
+assert.equal(isProvenanceLabel(truncated), true);
+assert.equal(isProvenanceLabel("{not-json session_id"), true);
+assert.equal(isProvenanceLabel('{"foo":1}'), false);
+assert.equal(isProvenanceLabel("Audit the catalog"), false);
+assert.equal(
+  jobDisplayTitle({label: provenance, goal: "Audit the offline catalog", id: "job_1"}),
+  "Audit the offline catalog"
+);
+assert.equal(
+  jobDisplayTitle({label: truncated, goal: "Audit the offline catalog", id: "job_1"}),
+  "Audit the offline catalog"
+);
+assert.equal(
+  jobDisplayTitle({label: provenance, goal: provenance, id: "job_1"}),
+  "job_1"
+);
+assert.equal(
+  jobDisplayTitle({label: "Human label", goal: "Ignored goal", id: "job_1"}),
+  "Human label"
+);
+assert.equal(
+  jobDisplayTitle({label: provenance, title: "Derived title", id: "job_1"}),
+  "Derived title"
+);
+assert.equal(
+  jobDisplayTitle({job: {label: provenance, goal: "Host-scoped catalog refresh", id: "job_9"}}),
+  "Host-scoped catalog refresh"
+);
+console.log("display-title-ok");
+"""
+        completed = subprocess.run(
+            [node, "-"], input=harness, capture_output=True, encoding="utf-8", timeout=30
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("display-title-ok", completed.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Runs list cards use `jobDisplayTitle` (human goal) instead of raw provenance JSON / `job.label`.
- Harden truncated JSON provenance detection in the dashboard renderer.
- Stamp `1.27.5`.

## Test plan
- [x] CI green on #165 (ubuntu/mac/windows + windows-store)
- [ ] CI green on this `dev`→`main` PR
- [ ] Tag `v1.27.5` + PyPI after merge
- [ ] Marionette pin `puppetmaster-ai==1.27.5` as 0.9.450