### PR TITLE
ci: shard Windows unittest into four jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,26 +7,23 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    # All three OSes are required and must stay green. Windows was hardened
-    # (sqlite handle close, non-POSIX path splitting, msvcrt advisory lock,
-    # crash-proof doctor) and now passes as a blocking leg.
+    # Linux and macOS stay unsharded here. Windows is the sharded
+    # test-windows job below and remains a required green leg.
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.12"]
         exclude:
           # Keep the matrix lean: exercise the full OS spread on the current
-          # Python, and the version spread on Linux. (3.9 + macOS/Windows is
-          # covered transitively by 3.12 on those OSes and 3.9 on Linux.)
+          # Python, and the version spread on Linux. (3.9 + macOS is covered
+          # transitively by 3.12 on macOS and 3.9 on Linux.)
           - os: macos-latest
-            python-version: "3.9"
-          - os: windows-latest
             python-version: "3.9"
     defaults:
       run:
-        # GitHub provides bash on every runner (Git Bash on Windows), so the
-        # heredoc-based steps below run identically across all three OSes.
+        # GitHub provides bash on macOS/Linux; Windows shards use Git Bash
+        # in test-windows so heredoc steps stay identical.
         shell: bash
     steps:
       - uses: actions/checkout@v6
@@ -61,6 +58,79 @@ jobs:
           python -m puppetmaster crash-demo
           python -m puppetmaster clean --completed
       - name: Check README links
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import re
+          import sys
+
+          readme = Path("README.md").read_text(encoding="utf-8")
+          missing = []
+          for match in re.finditer(r"\[[^\]]+\]\(([^)]+)\)", readme):
+              target = match.group(1)
+              if target.startswith(("http://", "https://", "#")):
+                  continue
+              if not Path(target).exists():
+                  missing.append(target)
+          if missing:
+              print("missing README links:", ", ".join(missing))
+              sys.exit(1)
+          print("README local links ok")
+          PY
+
+  test-windows:
+    # CI_WINDOWS_RUNNER is an optional hosted-runner swap. Unset, this job
+    # stays on GitHub-hosted windows-latest so CI never queues on a missing
+    # label. Set the repo variable later if a hosted Windows runner is added.
+    runs-on: ${{ vars.CI_WINDOWS_RUNNER || 'windows-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+      - name: Install optional Node dependencies
+        run: npm install --package-lock=false --no-audit
+      - name: Smoke check Cursor runner syntax
+        run: npm run smoke:cursor-runner
+      - name: Run Python tests (shard ${{ matrix.shard }}/4)
+        env:
+          UNITTEST_SHARD: ${{ matrix.shard }}/4
+        run: python -m tests.ci_shard
+      - name: Smoke check CLI metadata
+        if: ${{ matrix.shard == 1 }}
+        run: |
+          python -m puppetmaster --help
+          python -m puppetmaster adapters
+      - name: Run doctor
+        if: ${{ matrix.shard == 1 }}
+        run: python -m puppetmaster doctor
+      - name: Run SQLite demo
+        if: ${{ matrix.shard == 1 }}
+        run: python -m puppetmaster run "CI enterprise workflow" --config examples/enterprise-workflow.json
+      - name: Smoke check memory retrieval
+        if: ${{ matrix.shard == 1 }}
+        run: python -m puppetmaster run "CI memory reuse independent workers" --config examples/memory-reuse.json
+      - name: Smoke check daily-driver CLI
+        if: ${{ matrix.shard == 1 }}
+        run: |
+          python -m puppetmaster last
+          python -m puppetmaster logs
+          python -m puppetmaster diff
+          python -m puppetmaster rerun --config examples/enterprise-workflow.json
+          python -m puppetmaster crash-demo
+          python -m puppetmaster clean --completed
+      - name: Check README links
+        if: ${{ matrix.shard == 1 }}
         run: |
           python - <<'PY'
           from pathlib import Path

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ Puppetmaster keeps a **read-only, local, numbers-only** ledger of what it saved,
 - Tests live under `tests/` (`test_*.py`). New behavior gets a focused hermetic `unittest`; mock subprocess calls for adapter coverage.
 - The `SwarmStore` abstract base is the storage seam — the SQLite implementation lives in `puppetmaster/sqlite_store.py` and overrides hot methods for O(1) cursor reads. Don't break that contract.
 - Don't commit provider keys, `.cursor/mcp.json` user-specific paths, or anything in `.puppetmaster/` runtime state.
-- Run `python -m unittest discover -s tests -v` before suggesting a commit. CI is unittest discover, not pytest.
+- Run `python -m unittest discover -s tests -v` before suggesting a commit. CI is unittest discover, not pytest. Windows CI shards via `UNITTEST_SHARD` and `python -m tests.ci_shard`; the local full suite stays unsharded discover.
 
 ## MCP surface (quick reference)
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,6 +11,8 @@ python -m puppetmaster run "Contributor smoke test" --config examples/enterprise
 python -m puppetmaster crash-demo
 ```
 
+CI Windows shards unittest with `UNITTEST_SHARD` via `python -m tests.ci_shard`; the local full suite stays `python -m unittest discover -s tests -v`.
+
 ## Patch Expectations
 
 - Keep worker outputs structured.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -17,7 +17,7 @@ resume that; every bump now carries semver meaning.
 Use this before sharing Puppetmaster publicly.
 
 - CI passes on the default branch.
-- `python -m unittest discover -s tests -v` passes locally.
+- `python -m unittest discover -s tests -v` passes locally. CI Windows uses `UNITTEST_SHARD` via `python -m tests.ci_shard`; the local full suite stays discover.
 - `python -m puppetmaster doctor` has no unexpected warnings.
 - `python -m puppetmaster crash-demo` completes.
 - Cursor adapter smoke test has been run locally with a real `CURSOR_API_KEY`.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package so Windows CI can run ``python -m tests.ci_shard``."""

--- a/tests/ci_shard.py
+++ b/tests/ci_shard.py
@@ -1,0 +1,72 @@
+"""Stdlib-only unittest sharding for Windows CI.
+
+``UNITTEST_SHARD=2/4`` (1-based) keeps tests whose sorted index satisfies
+``i % total == (idx - 1)``. Empty or invalid specs are a no-op so a local
+``python -m unittest discover -s tests -v`` run is unchanged.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from typing import Iterator, List, Optional, Sequence, Tuple
+
+
+def parse_unittest_shard(spec: Optional[str]) -> Optional[Tuple[int, int]]:
+    """Parse ``2/4`` into a 1-based ``(idx, total)`` pair, or None if unusable."""
+    raw = (spec or "").strip()
+    if not raw:
+        return None
+    parts = raw.split("/")
+    if len(parts) != 2:
+        return None
+    try:
+        idx = int(parts[0])
+        total = int(parts[1])
+    except ValueError:
+        return None
+    if total < 1 or idx < 1 or idx > total:
+        return None
+    return (idx, total)
+
+
+def select_unittest_shard(ids: Sequence[str], spec: Optional[str]) -> List[str]:
+    """Stable-sort ``ids`` and keep the requested shard, or return all as-is."""
+    parsed = parse_unittest_shard(spec)
+    if parsed is None:
+        return list(ids)
+    idx, total = parsed
+    ordered = sorted(ids)
+    keep_slot = idx - 1
+    return [item for i, item in enumerate(ordered) if i % total == keep_slot]
+
+
+def _iter_cases(suite: unittest.TestSuite) -> Iterator[unittest.TestCase]:
+    for item in suite:
+        if isinstance(item, unittest.TestSuite):
+            for child in _iter_cases(item):
+                yield child
+        else:
+            yield item
+
+
+def filter_suite(suite: unittest.TestSuite, spec: Optional[str]) -> unittest.TestSuite:
+    """Keep TestCase entries whose ids fall in ``spec``; walk nested suites."""
+    if parse_unittest_shard(spec) is None:
+        return suite
+    cases = list(_iter_cases(suite))
+    keep = set(select_unittest_shard([case.id() for case in cases], spec))
+    return unittest.TestSuite(case for case in cases if case.id() in keep)
+
+
+def discover_and_run() -> None:
+    spec = os.environ.get("UNITTEST_SHARD")
+    suite = unittest.TestLoader().discover("tests")
+    if spec:
+        suite = filter_suite(suite, spec)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(0 if result.wasSuccessful() else 1)
+
+
+if __name__ == "__main__":
+    discover_and_run()

--- a/tests/test_ci_shard.py
+++ b/tests/test_ci_shard.py
@@ -1,0 +1,102 @@
+"""Pure-function tests for Windows CI unittest sharding.
+
+Uses a fake id list (not live discovery) so UNITTEST_SHARD cannot skip these
+assertions when the helper itself is under a shard filter.
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from tests.ci_shard import (
+    _iter_cases,
+    filter_suite,
+    parse_unittest_shard,
+    select_unittest_shard,
+)
+
+
+# Unsorted on purpose: a valid shard must sort, an invalid spec must not.
+_FAKE_IDS = ("z", "a", "m", "b", "y", "c", "x", "d")
+_SORTED_IDS = ("a", "b", "c", "d", "m", "x", "y", "z")
+
+
+def _named_case(test_id: str) -> unittest.FunctionTestCase:
+    case = unittest.FunctionTestCase(lambda: None)
+    case.id = lambda _test_id=test_id: _test_id
+    return case
+
+
+class ParseUnittestShardTests(unittest.TestCase):
+    def test_empty_and_invalid_are_none(self) -> None:
+        for spec in ("", None, "   ", "nope", "2", "2/4/5", "a/4", "2/b", "0/4", "5/4", "2/0"):
+            self.assertIsNone(parse_unittest_shard(spec), spec)
+
+    def test_valid_one_based_pair(self) -> None:
+        self.assertEqual(parse_unittest_shard("2/4"), (2, 4))
+        self.assertEqual(parse_unittest_shard(" 1/4 "), (1, 4))
+        self.assertEqual(parse_unittest_shard("4/4"), (4, 4))
+
+
+class SelectUnittestShardTests(unittest.TestCase):
+    def test_empty_and_invalid_are_identity(self) -> None:
+        ids = list(_FAKE_IDS)
+        for spec in ("", None, "nope", "0/4", "5/4"):
+            self.assertEqual(select_unittest_shard(ids, spec), ids)
+
+    def test_four_shards_partition(self) -> None:
+        parts = [select_unittest_shard(_FAKE_IDS, "%s/4" % n) for n in (1, 2, 3, 4)]
+        self.assertEqual(parts[0], ["a", "m"])
+        self.assertEqual(parts[1], ["b", "x"])
+        self.assertEqual(parts[2], ["c", "y"])
+        self.assertEqual(parts[3], ["d", "z"])
+        flat = [item for part in parts for item in part]
+        self.assertEqual(len(flat), len(_SORTED_IDS))
+        self.assertEqual(len(set(flat)), len(_SORTED_IDS))
+        self.assertEqual(sorted(flat), list(_SORTED_IDS))
+        for left, right in ((0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)):
+            self.assertFalse(set(parts[left]) & set(parts[right]))
+
+
+class FilterSuiteTests(unittest.TestCase):
+    def _nested_suite(self) -> unittest.TestSuite:
+        inner = unittest.TestSuite([_named_case("c"), _named_case("a")])
+        return unittest.TestSuite(
+            [_named_case("b"), inner, _named_case("d"), _named_case("m")]
+        )
+
+    def test_empty_and_invalid_are_identity(self) -> None:
+        suite = self._nested_suite()
+        original = [case.id() for case in _iter_cases(suite)]
+        for spec in ("", None, "nope", "0/4"):
+            filtered = filter_suite(suite, spec)
+            self.assertIs(filtered, suite)
+            self.assertEqual([case.id() for case in _iter_cases(filtered)], original)
+
+    def test_drops_tests_outside_the_shard(self) -> None:
+        # Nested ids walk to b, c, a, d, m; select sorts to a,b,c,d,m.
+        # Shard 2/4 keeps sorted index 1, 5, ... → b.
+        filtered = filter_suite(self._nested_suite(), "2/4")
+        self.assertEqual([case.id() for case in filtered], ["b"])
+        shard1 = filter_suite(self._nested_suite(), "1/4")
+        self.assertEqual([case.id() for case in shard1], ["a", "m"])
+
+
+class WindowsWorkflowTests(unittest.TestCase):
+    def test_ci_yml_shards_windows_only(self) -> None:
+        text = (
+            Path(__file__).resolve().parents[1]
+            / ".github"
+            / "workflows"
+            / "ci.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("test-windows:", text)
+        self.assertIn("UNITTEST_SHARD", text)
+        self.assertIn("python -m tests.ci_shard", text)
+        self.assertIn("vars.CI_WINDOWS_RUNNER || 'windows-latest'", text)
+        self.assertNotIn("runs-on: blacksmith-", text)
+        self.assertIn("python -m unittest discover -s tests -v", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Split the blocking Windows CI cell from one 23-34 minute `unittest discover` into four `UNITTEST_SHARD=n/4` jobs so wall clock tracks about a quarter of the suite.
- Linux and macOS stay unsharded. Doctor/demo/README smokes run only on Windows shard 1.
- Runner stays `vars.CI_WINDOWS_RUNNER || windows-latest`. Leave the variable unset; Blacksmith is org-only and these repos stay on the professorpalmer user account.

## Test plan
- [x] `python -m unittest tests.test_ci_shard -v` (7 tests)
- [x] 3365 discovered tests partition 842/841/841/841, disjoint, union complete
- [x] `UNITTEST_SHARD=1/4 python -m tests.ci_shard` exits 0 locally
- [ ] GitHub `test-windows` matrix green on this PR (the actual Windows wall-clock proof)