### PR TITLE
fix: read verify-first-run wire identity from the persisted pin

### DIFF
--- a/puppetmaster/setup_verification.py
+++ b/puppetmaster/setup_verification.py
@@ -80,7 +80,7 @@ def _validate(store, model: str, nonce: str, fixture: Path) -> str:
         return "Expected exactly one task; disable retries and reuse."
     task = tasks[0]
     payload = task.payload
-    wire = model.removeprefix("codex/")
+    wire = str(payload.get("pinned_adapter_model_name") or "")
     identity = {"model": wire, "pinned_model": model,
                 "pinned_adapter_model_name": wire, "router_model_id": model,
                 "auto_route": False, "allowed_model_ids": [model]}

--- a/tests/test_setup_verification.py
+++ b/tests/test_setup_verification.py
@@ -24,6 +24,8 @@ from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
 MODEL = 'codex/test-model'
 FIXTURE = Path('/fixture/verification.txt')
 NONCE = 'a' * 64
+PIN = 'codex/gpt-5-6-sol'
+WIRE = 'gpt-5.6-sol'
 
 
 def require_process_discovery(test):
@@ -58,6 +60,37 @@ class ProbeStore:
     def list_usage_observations(self, job, attempt_id): return self.usage
     def list_artifacts(self, job): return self.artifacts
     def status_snapshot(self, job, compact): return {'delivery': self.delivery}
+
+
+def registry_wire_store():
+    """A probe store whose pin has a dashed registry id and dotted wire name."""
+    store = ProbeStore()
+    task = replace(store.task, payload={
+        'model': WIRE, 'pinned_model': PIN,
+        'pinned_adapter_model_name': WIRE, 'router_model_id': PIN,
+        'auto_route': False, 'allowed_model_ids': [PIN]})
+    store.task = task
+    store.tasks = [task]
+    store.attempts = [replace(store.attempts[0], model=WIRE)]
+    store.artifacts = [
+        store.artifacts[0],
+        replace(store.artifacts[1], payload={**store.artifacts[1].payload, 'model': WIRE}),
+    ]
+    return store
+
+
+class RegistryWireIdentityTests(unittest.TestCase):
+    """The pinned wire identity is the persisted pin, not the id string."""
+
+    def test_dashed_registry_id_validates_against_its_dotted_wire_name(self):
+        self.assertEqual(verification._validate(registry_wire_store(), PIN, NONCE, FIXTURE), '')
+
+    def test_another_models_wire_name_is_still_rejected(self):
+        store = registry_wire_store()
+        store.attempts = [replace(store.attempts[0], model='gpt-5.5')]
+        self.assertEqual(
+            verification._validate(store, PIN, NONCE, FIXTURE),
+            'Execution ledger does not prove one fresh attempt on the requested model.')
 
 
 class SuccessPredicateTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- `setup --verify-first-run codex/<model>` always failed with "Persisted model identity differs from the exact requested pin". The probe derived the expected wire name by stripping the `codex/` prefix from the registry id (`codex/gpt-5-6-sol` -> `gpt-5-6-sol`), but the run persists the adapter's wire name (`gpt-5.6-sol`). Registry ids are dashed aliases; `adapter_model_name` is the literal the adapter passes.
- Read the expected wire from the payload's own `pinned_adapter_model_name`. It feeds the identity, attempt-ledger, and verification-artifact comparisons, so the block is fixed at its source.
- No new dependency on the live registry: `routing_authority.py` stays the owner of registry id -> wire truth at launch, and a registry edit between a run and its validation cannot change the verdict.
- The existing fixture could not catch this because its pin (`codex/test-model`) has a wire name equal to its id suffix.

## Test plan
- [x] `python -m unittest discover -s tests -p 'test_setup_verification.py'` - RED on unpatched source (`FAILED (failures=2)`, reporting the exact live message), `Ran 28 tests ... OK` with the fix.
- [x] Full local `python -m unittest discover -s tests` on macOS: 3,374 tests, 3 failures, none in this module. One is a local `CODEX_COMMAND` shim (`test_claude_and_codex_gate_on_resolvable_binary`, passes with it unset); two are pre-existing baseline failures (`test_implement_verify_bounces_failure_then_accepts_on_pass`, `test_max_cost_budget_rejects_pricier_models`) in files that never import `setup_verification`, and they fail in isolation on this branch as well.
- [ ] CI matrix green on this PR.
