### PR TITLE
absorb #195: generated swarm adapter lock is a launch lane

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Unreleased
 
+**Generated auto-routed swarms can leave a spent launch adapter (#195).**
+
+- `build_analysis_swarm_specs` still pins `allowed_adapters` to the launch
+  adapter so the first route cannot silently hop (v1.20.6). That pin is now a
+  launch lane (`adapter_lock=lane`), not a hard platform prohibition.
+- After a classified recoverable failure, fallback may select a funded
+  identity such as `agentic/openai/gpt-5-6-sol` and emit `router-fallback`
+  with API billing provenance. Explicit model pins and `adapter_lock=hard`
+  stay locked. Credit @kbentonferguson.
+
 ## v1.27.17 — 2026-09-12
 
 **Read-only workers never claim another process's repository edits.**

--- a/puppetmaster/orchestrator.py
+++ b/puppetmaster/orchestrator.py
@@ -224,6 +224,26 @@ def _payload_has_explicit_model_pin(payload: dict) -> bool:
     )
 
 
+def _is_lane_adapter_lock(payload: dict) -> bool:
+    """True when allowed_adapters is a generated launch lane, not a hard pin."""
+    return str((payload or {}).get("adapter_lock") or "") == "lane"
+
+
+def _fallback_route_signals(task):
+    """Signals for recoverable fallback.
+
+    Generated swarms stamp allowed_adapters to the launch adapter so the
+    first route cannot silently hop. That lane must not also reject a
+    funded cross-adapter recovery after billing_or_quota.
+    """
+    from puppetmaster.router import signals_from_worker_spec
+
+    signals = signals_from_worker_spec(task)
+    if _is_lane_adapter_lock(getattr(task, "payload", None) or {}):
+        return replace(signals, allowed_adapters=None)
+    return signals
+
+
 _MODEL_BACKED_ADAPTERS = frozenset(
     {"agentic", "openai", "cursor", "codex", "claude-code", "hermes", "antigravity"}
 )
@@ -827,7 +847,6 @@ class Orchestrator:
         from puppetmaster.router import (
             NoEligibleModelError,
             route_task,
-            signals_from_worker_spec,
         )
 
         failed = [
@@ -933,7 +952,7 @@ class Orchestrator:
             policy = payload.get("router_policy") or "balanced"
             try:
                 decision = route_task(
-                    signals_from_worker_spec(task),
+                    _fallback_route_signals(task),
                     candidates,
                     policy=policy,
                     local_receipts=self._host_local_receipts(),
@@ -952,6 +971,8 @@ class Orchestrator:
                 "fallback_from_model": current_model_id or None,
                 "tried_models": tried_out,
             }
+            if _is_lane_adapter_lock(payload):
+                fallback_extra["allowed_adapters"] = [decision.model.adapter]
             if (
                 reason == RUN_STATUS_ERROR
                 and decision.model.adapter == failed_adapter

--- a/puppetmaster/swarm_launch.py
+++ b/puppetmaster/swarm_launch.py
@@ -156,11 +156,10 @@ def build_analysis_swarm_specs(
             payload["model"] = str(explicit_model)
         if auto_route_enabled:
             payload["auto_route"] = True
-            # Pin every launch adapter — including cursor. Without this,
-            # start_cursor_swarm could hop onto agentic/minimax when vision
-            # tags or cursor-cli keys fail, yielding empty unstructured
-            # findings while the user asked for a Cursor SDK swarm.
+            # Launch-lane pin: first route stays on this adapter (v1.20.6).
+            # Classified billing/auth recovery may cross it (adapter_lock=lane).
             payload["allowed_adapters"] = [adapter]
+            payload["adapter_lock"] = "lane"
             if isinstance(routing_policy, str) and routing_policy:
                 payload["routing_policy"] = routing_policy
             else:

--- a/tests/test_generated_swarm_fallback.py
+++ b/tests/test_generated_swarm_fallback.py
@@ -1,0 +1,221 @@
+"""Generated auto-routed swarms must recover across a launch-lane adapter lock.
+
+Issue #195: swarm_launch pins allowed_adapters to the launch adapter so the
+initial route cannot silently hop (v1.20.6). Orchestrator fallback then
+rebuilds signals from that same pin and rejects a funded agentic/openai
+identity after billing_or_quota. The public path is a generated Codex swarm
+task, not a hand-built payload that omits allowed_adapters.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import patch
+
+_HERMETIC_DIR = os.path.dirname(os.path.abspath(__file__))
+if _HERMETIC_DIR not in sys.path:
+    sys.path.insert(0, _HERMETIC_DIR)
+import hermetic_env  # noqa: F401
+
+from puppetmaster.model_registry import ModelSpec, registry_digest, save_registry
+from puppetmaster.models import Artifact, ArtifactType, Task, TaskStatus
+from puppetmaster.orchestrator import Orchestrator
+from puppetmaster.platform_billing import BillingStatus, _BILLING_CACHE
+from puppetmaster.store import SwarmStore
+from puppetmaster.swarm_launch import build_analysis_swarm_specs
+
+
+def _persist_registry(root, models):
+    path = Path(root) / "models.json"
+    save_registry(models, path)
+    return {
+        "registry_path": str(path),
+        "registry_digest": registry_digest(models),
+    }
+
+
+def _codex_openai_registry():
+    return [
+        ModelSpec(
+            id="codex/gpt-5-5",
+            adapter="codex",
+            adapter_model_name="gpt-5.5",
+            capability_score=90,
+            billing="plan",
+            tags=["codex"],
+        ),
+        ModelSpec(
+            id="agentic/openai/gpt-5-6-sol",
+            adapter="agentic",
+            adapter_model_name="gpt-5.6-sol",
+            capability_score=92,
+            billing="api",
+            tags=["agentic"],
+            payload_defaults={"provider": "openai"},
+        ),
+    ]
+
+
+def _billing(adapter, **_kwargs):
+    if adapter == "agentic":
+        return BillingStatus(
+            adapter="agentic",
+            billing="api",
+            healthy=True,
+            detail="openai ready",
+            evidence=["openai"],
+        )
+    return BillingStatus(
+        adapter=adapter,
+        billing="unknown",
+        healthy=False,
+        detail="no",
+        evidence=[],
+    )
+
+
+class GeneratedSwarmFallbackTests(TestCase):
+    def setUp(self) -> None:
+        _BILLING_CACHE.clear()
+
+    def tearDown(self) -> None:
+        _BILLING_CACHE.clear()
+
+    def _failed_generated_task(self, tmp, *, adapter="codex", extra_payload=None):
+        registry = _codex_openai_registry()
+        if adapter == "cursor":
+            registry = [
+                ModelSpec(
+                    id="cursor/grok-4-6",
+                    adapter="cursor",
+                    adapter_model_name="grok-4.6",
+                    capability_score=90,
+                    billing="plan",
+                    tags=["cursor"],
+                ),
+                registry[1],
+            ]
+        specs = build_analysis_swarm_specs(
+            "audit the repo",
+            ["explore"],
+            adapter=adapter,
+            cwd=str(tmp),
+            allowed_model_ids=[spec.id for spec in registry],
+        )
+        spec = specs[0]
+        payload = dict(spec.payload)
+        payload.update(_persist_registry(tmp, registry))
+        if extra_payload:
+            payload.update(extra_payload)
+        store = SwarmStore(Path(tmp) / ".puppetmaster")
+        job = store.create_job("generated swarm fallback")
+        task = Task(
+            job_id=job.id,
+            role=spec.role,
+            instruction=spec.instruction,
+            adapter=spec.adapter,
+            status=TaskStatus.FAILED,
+            payload=payload,
+        )
+        store.save_task(task)
+        store.save_artifact(
+            Artifact(
+                job_id=job.id,
+                task_id=task.id,
+                type=ArtifactType.VERIFICATION,
+                created_by="w",
+                payload={
+                    "check": "x",
+                    "result": "blocked",
+                    "failure": "billing_or_quota",
+                    "adapter": adapter,
+                },
+                confidence=0.5,
+                evidence=["adapter:%s" % adapter],
+            )
+        )
+        return store, job, task, spec
+
+    def _reroute(self, store, job):
+        orch = Orchestrator(store)
+        with patch(
+            "puppetmaster.platform_billing.detect_adapter_billing",
+            side_effect=_billing,
+        ), patch(
+            "puppetmaster.platform_lock.is_adapter_enabled",
+            return_value=True,
+        ), patch(
+            "puppetmaster.preflight.adapter_cli_present",
+            return_value=True,
+        ), patch(
+            "puppetmaster.providers.available_providers",
+            return_value={"openai"},
+        ):
+            return orch._reroute_recoverable_failures(job)
+
+    def test_generated_codex_swarm_falls_back_to_funded_openai(self) -> None:
+        with TemporaryDirectory() as tmp:
+            store, job, task, spec = self._failed_generated_task(tmp)
+            self.assertEqual(spec.payload.get("allowed_adapters"), ["codex"])
+            self.assertEqual(spec.payload.get("adapter_lock"), "lane")
+            self.assertTrue(spec.payload.get("auto_route"))
+            rerouted = self._reroute(store, job)
+            self.assertEqual(rerouted, 1)
+            updated = store.get_task_by_id(task.id)
+            self.assertEqual(updated.status, TaskStatus.QUEUED)
+            self.assertEqual(updated.adapter, "agentic")
+            self.assertEqual(
+                updated.payload.get("router_model_id"),
+                "agentic/openai/gpt-5-6-sol",
+            )
+            self.assertEqual(updated.payload.get("billing"), "api")
+            self.assertEqual(updated.payload.get("allowed_adapters"), ["agentic"])
+            self.assertEqual(updated.payload.get("adapter_lock"), "lane")
+            fallbacks = [
+                artifact
+                for artifact in store.list_artifacts(job.id)
+                if artifact.created_by == "router-fallback"
+                and artifact.type == ArtifactType.ROUTING
+            ]
+            self.assertEqual(len(fallbacks), 1)
+            body = fallbacks[0].payload
+            self.assertEqual(body.get("model_id"), "agentic/openai/gpt-5-6-sol")
+            self.assertEqual(body.get("adapter"), "agentic")
+            self.assertEqual(body.get("billing"), "api")
+            self.assertEqual(body.get("fallback_reason"), "billing_or_quota")
+            self.assertEqual(body.get("fallback_from_adapter"), "codex")
+
+    def test_hard_adapter_pin_still_blocks_fallback(self) -> None:
+        with TemporaryDirectory() as tmp:
+            store, job, task, spec = self._failed_generated_task(
+                tmp,
+                extra_payload={"adapter_lock": "hard"},
+            )
+            self.assertEqual(spec.payload.get("allowed_adapters"), ["codex"])
+            rerouted = self._reroute(store, job)
+            self.assertEqual(rerouted, 0)
+            updated = store.get_task_by_id(task.id)
+            self.assertEqual(updated.status, TaskStatus.FAILED)
+            self.assertEqual(updated.adapter, "codex")
+            self.assertFalse(
+                any(
+                    artifact.created_by == "router-fallback"
+                    for artifact in store.list_artifacts(job.id)
+                )
+            )
+
+    def test_generated_cursor_lane_also_recovers_to_openai(self) -> None:
+        with TemporaryDirectory() as tmp:
+            store, job, task, spec = self._failed_generated_task(tmp, adapter="cursor")
+            self.assertEqual(spec.payload.get("allowed_adapters"), ["cursor"])
+            rerouted = self._reroute(store, job)
+            self.assertEqual(rerouted, 1)
+            updated = store.get_task_by_id(task.id)
+            self.assertEqual(updated.adapter, "agentic")
+            self.assertEqual(
+                updated.payload.get("router_model_id"),
+                "agentic/openai/gpt-5-6-sol",
+            )

--- a/tests/test_swarm_launch.py
+++ b/tests/test_swarm_launch.py
@@ -74,6 +74,7 @@ class BuildAnalysisSwarmSpecsTests(unittest.TestCase):
             cwd="/tmp/x",
         )
         self.assertEqual(specs[0].payload.get("allowed_adapters"), ["agentic"])
+        self.assertEqual(specs[0].payload.get("adapter_lock"), "lane")
 
     def test_cursor_adapter_pins_allowed_adapters(self) -> None:
         specs = build_analysis_swarm_specs(
@@ -83,6 +84,7 @@ class BuildAnalysisSwarmSpecsTests(unittest.TestCase):
             cwd="/tmp/x",
         )
         self.assertEqual(specs[0].payload.get("allowed_adapters"), ["cursor"])
+        self.assertEqual(specs[0].payload.get("adapter_lock"), "lane")
 
     def test_rejects_unknown_adapter(self) -> None:
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Why

Benton reported that a generated auto-routed Codex swarm still dies after a classified `billing_or_quota` failure even when a funded `agentic/openai/gpt-5-6-sol` row is enabled. #161 made the spend-cap recoverable. #188 kept the exact OpenAI identity. The composed public path stayed dead.

`build_analysis_swarm_specs` pins `allowed_adapters` to the launch adapter so the first route cannot silently hop (v1.20.6). `_reroute_recoverable_failures` then rebuilt signals from that same pin, so `route_task` rejected every other adapter. The old fallback test omitted `allowed_adapters`, so it never mounted the generated swarm shape.

## Scope

- Stamp `adapter_lock=lane` on generated auto-routed swarm specs.
- Recoverable fallback ignores that lane lock, then restamps `allowed_adapters` to the funded adapter.
- `adapter_lock=hard` and explicit model pins stay locked.
- Acceptance test mounts `build_analysis_swarm_specs` for Codex and Cursor, plus a hard-pin control.
- Cached-catalog preflight for provider-qualified custom rows is out of scope, as Benton asked.

## Tradeoffs

A heuristic that unlocked any `auto_route` plus single-adapter allowlist would also unlock callers who set `allowed_adapters` themselves. The lane marker keeps those hard unless they opt into `adapter_lock=lane`.

## Blast radius

Fallback only clears `allowed_adapters` when `adapter_lock` is `lane`. Existing `AutoFallbackTests` and `test_fallback_skips_explicit_model_pin` still pass. Escalation still uses the original lock.

## Verification

Failing before the fix:

`python3 -m unittest tests.test_generated_swarm_fallback.GeneratedSwarmFallbackTests.test_generated_codex_swarm_falls_back_to_funded_openai`

`AssertionError: 0 != 1`

Passing after:

`python3 -m unittest tests.test_generated_swarm_fallback tests.test_swarm_launch tests.test_puppetmaster.AutoFallbackTests tests.test_recovery_pin_governance -q`

35 tests OK.

Live stock repro on v1.27.17: generated Codex lock stayed on `codex` with no `router-fallback` artifact. Dropping `allowed_adapters` selected `agentic/openai/gpt-5-6-sol` with `billing=api`.

Cursor review `job_901e082b5355` was degraded (`sdk_not_installed` in the isolated worktree). Parent review stands.

Credit @kbentonferguson. Closes #195 after this lands on `dev`.